### PR TITLE
Support pre-migration scripts that alter .copier-answers.yml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ _tasks:
 # - After being rendered with Jinja, with the same context as the rest of the template
 # - With $VERSION_FROM, $VERSION_TO, $VERSION_CURRENT and $STAGE (before/after)
 #   environment variables
+# - The answers file is reloaded after running migrations in the "before" stage.
 _migrations:
   - version: v1.0.0
     before:

--- a/copier/main.py
+++ b/copier/main.py
@@ -245,6 +245,14 @@ def update_diff(conf: ConfigData):
     # Run pre-migration tasks
     renderer = Renderer(conf)
     run_tasks(conf, renderer, get_migration_tasks(conf, "before"))
+    # Import possible answers migration
+    conf = conf.copy(
+        update={
+            "data_from_answers_file": load_answersfile_data(
+                conf.dst_path, conf.answers_file
+            )
+        }
+    )
     # Do a normal update in final destination
     copy_local(conf)
     # Try to apply cached diff into final destination

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -9,7 +9,7 @@ from plumbum.cmd import git
 
 from copier import copy
 
-from .helpers import PROJECT_TEMPLATE
+from .helpers import PROJECT_TEMPLATE, build_file_tree
 
 SRC = Path(f"{PROJECT_TEMPLATE}_migrations").absolute()
 
@@ -58,3 +58,70 @@ def test_migrations_and_tasks(tmpdir: py.path.local):
     assert (dst / "v1.0.0-v2-v2.0-after.json").isfile()
     answers = yaml.safe_load((dst / ".copier-answers.yml").read())
     assert answers == {"_commit": "v2.0", "_src_path": str(git_src)}
+
+
+def test_pre_migration_modifies_answers(tmp_path_factory):
+    """Test support for answers modifications in pre-migrations."""
+    template = tmp_path_factory.mktemp("template")
+    subproject = tmp_path_factory.mktemp("subproject")
+    # v1 of template asks for a favourite song and writes it to songs.yaml
+    with local.cwd(template):
+        build_file_tree(
+            {
+                "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+                "copier.yml": """\
+                    best_song: la vie en rose
+                    """,
+                "songs.yaml.tmpl": "- [[ best_song ]]",
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
+    # User copies v1 template into subproject
+    with local.cwd(subproject):
+        copy(src_path=str(template), force=True)
+        answers = yaml.safe_load(Path(".copier-answers.yml").read_text())
+        assert answers["_commit"] == "v1"
+        assert answers["best_song"] == "la vie en rose"
+        assert yaml.safe_load(Path("songs.yaml").read_text()) == ["la vie en rose"]
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+    with local.cwd(template):
+        build_file_tree(
+            {
+                # v2 of template supports multiple songs, has a different default
+                # and includes a data format migration script
+                "copier.yml": """\
+                    best_song_list:
+                      default: [paranoid android]
+                    _migrations:
+                      - version: v2
+                        before:
+                          - - python3
+                            - -c
+                            - |
+                                import sys, yaml, pathlib
+                                answers_path = pathlib.Path(*sys.argv[1:])
+                                answers = yaml.safe_load(answers_path.read_text())
+                                answers["best_song_list"] = [answers.pop("best_song")]
+                                answers_path.write_text(yaml.safe_dump(answers))
+                            - "[[ _copier_conf.dst_path ]]"
+                            - "[[ _copier_conf.answers_file ]]"
+                    """,
+                "songs.yaml.tmpl": "[[ best_song_list|to_nice_yaml ]]",
+            }
+        )
+        git("add", ".")
+        git("commit", "-m2")
+        git("tag", "v2")
+    # User updates subproject to v2 template
+    with local.cwd(subproject):
+        copy(force=True)
+        answers = yaml.safe_load(Path(".copier-answers.yml").read_text())
+        assert answers["_commit"] == "v2"
+        assert "best_song" not in answers
+        assert answers["best_song_list"] == ["la vie en rose"]
+        assert yaml.safe_load(Path("songs.yaml").read_text()) == ["la vie en rose"]


### PR DESCRIPTION
When migrating a template, it can happen that the answers spec is modified.

When that happens, the migration script should modify the answers file. Thus, the update process should reload answers after running pre-migrations.

That's what it is doing now with this patch.

@Tecnativa TT23705