### PR TITLE
Remember answer procedence

### DIFF
--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -1,3 +1,4 @@
+from collections import ChainMap
 from typing import Tuple
 
 from packaging import version
@@ -6,7 +7,7 @@ from plumbum.cmd import git
 
 from .. import vcs
 from ..types import AnyByStrDict, OptAnyByStrDict, OptBool, OptStr, OptStrSeq
-from .objects import DEFAULT_DATA, ConfigData, EnvOps, NoSrcPathError, UserMessageError
+from .objects import ConfigData, EnvOps, NoSrcPathError, UserMessageError
 from .user_data import load_answersfile_data, load_config_data, query_user_data
 
 __all__ = ("make_config",)
@@ -50,7 +51,6 @@ def make_config(
     dst_path: str = ".",
     *,
     answers_file: OptStr = None,
-    data: OptAnyByStrDict = None,
     exclude: OptStrSeq = None,
     skip_if_exists: OptStrSeq = None,
     tasks: OptStrSeq = None,
@@ -70,32 +70,31 @@ def make_config(
     The order of precedence for the merger of configuration objects is:
     function_args > user_data > defaults.
     """
-    # Merge answer sources in the order of precedence
-    answers_data = DEFAULT_DATA.copy()
-    answers_data.update(load_answersfile_data(dst_path, answers_file))
-    answers_data.update(data or {})
-
-    _metadata = {}
-    if "_commit" in answers_data:
-        _metadata["old_commit"] = answers_data["_commit"]
+    # These args are provided by API or CLI call
+    init_args = {k: v for k, v in locals().items() if v is not None and v != []}
+    # Store different answer sources
+    init_args["data_from_answers_file"] = load_answersfile_data(dst_path, answers_file)
+    if "_commit" in init_args["data_from_answers_file"]:
+        init_args["old_commit"] = init_args["data_from_answers_file"]["_commit"]
     # Detect original source if running in update mode
     if src_path is None:
         try:
-            src_path = answers_data["_src_path"]
+            src_path = init_args["data_from_answers_file"]["_src_path"]
         except KeyError:
             raise NoSrcPathError(
                 "No copier answers file found, or it didn't include "
                 "original template information (_src_path). "
                 "Run `copier copy` instead."
             )
-    _metadata["original_src_path"] = src_path
+    init_args["original_src_path"] = src_path
     if src_path:
         repo = vcs.get_repo(src_path)
         if repo:
             src_path = vcs.clone(repo, vcs_ref or "HEAD")
             vcs_ref = vcs_ref or vcs.checkout_latest_tag(src_path)
             with local.cwd(src_path):
-                _metadata["commit"] = git("describe", "--tags", "--always").strip()
+                init_args["commit"] = git("describe", "--tags", "--always").strip()
+        init_args["src_path"] = src_path
     # Obtain config and query data, asking the user if needed
     file_data = load_config_data(src_path, quiet=True)
 
@@ -104,15 +103,22 @@ def make_config(
     except KeyError:
         pass
 
-    config_data, questions_data = filter_config(file_data)
-    config_data.update(_metadata)
-    del _metadata
-    args = {k: v for k, v in locals().items() if v is not None and v != []}
-    env_ops = EnvOps(**config_data.get("envops", {}))
-    config_data["data"] = query_user_data(
-        questions_data, answers_data, not force, env_ops
+    template_config_data, questions_data = filter_config(file_data)
+    init_args["data_from_template_defaults"] = {
+        k: v.get("default") for k, v in questions_data.items()
+    }
+    init_args["envops"] = EnvOps(**template_config_data.get("envops", {}))
+    init_args["data_from_init"] = ChainMap(
+        query_user_data(
+            questions_data, {}, kwargs.get("data") or {}, False, init_args["envops"]
+        ),
+        kwargs.get("data") or {},
     )
-    args = {**config_data, **args}
-    args["envops"] = env_ops
-    args["data"].update(config_data["data"])
-    return ConfigData(**args)
+    init_args["data_from_asking_user"] = query_user_data(
+        questions_data,
+        init_args["data_from_answers_file"],
+        init_args["data_from_init"],
+        not force,
+        init_args["envops"],
+    )
+    return ConfigData(**ChainMap(init_args, template_config_data))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,7 @@ use_parentheses = true
 
 [flake8]
 max-complexity = 20
-max-line-length = 88
-ignore = ",W503,E203,D100,D101,D102,D103,D104,D105,D107,"
+ignore = ",W503,E203,E501,D100,D101,D102,D103,D104,D105,D107,"
 
 [build-system]
 requires = ["poetry>=1.0.3"]

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -43,14 +43,14 @@ def test_api(dst):
     )
 
 
-def test_cli(dst):
+def test_cli(tmp_path):
     """Test copier correctly processes advanced questions and answers through CLI."""
     (
-        copier_cmd["copy", SRC, dst]
+        copier_cmd["copy", SRC, tmp_path]
         << dedent(
             # These are the answers; those marked as "wrong" will fail and
             # make the prompt function ask again
-            """
+            """\
                 y
                 Guybrush Threpwood
                 wrong your_age
@@ -68,8 +68,8 @@ def test_cli(dst):
 
             """
         )
-    )()
-    results_file = dst / "results.txt"
+    )(timeout=5)
+    results_file = tmp_path / "results.txt"
     assert results_file.read_text() == dedent(
         r"""
             love_me: true
@@ -139,7 +139,7 @@ def test_cli_with_flag_data_and_type_casts(tmp_path: Path):
         << dedent(
             # These are the answers; those marked as "wrong" will fail and
             # make the prompt function ask again
-            """
+            """\
                 y
                 Guybrush Threpwood
                 wrong your_age
@@ -150,14 +150,9 @@ def test_cli_with_flag_data_and_type_casts(tmp_path: Path):
                 {"objective": "be a pirate"}
                 {wrong anything_else
                 ['Want some grog?', I'd love it]
-
-
-
-
-
             """
         )
-    )()
+    )(timeout=5)
     results_file = tmp_path / "results.txt"
     assert results_file.read_text() == dedent(
         r"""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 
 import copier
 from copier.config.factory import make_config
-from copier.config.objects import DEFAULT_DATA, DEFAULT_EXCLUDE, ConfigData, EnvOps
+from copier.config.objects import DEFAULT_EXCLUDE, ConfigData, EnvOps
 from copier.config.user_data import (
     InvalidConfigFileError,
     MultipleConfigFilesError,
@@ -168,7 +168,6 @@ def test_config_data_good_data(dst):
         "commit": None,
         "old_commit": None,
         "dst_path": dst,
-        "data": DEFAULT_DATA,
         "extra_paths": [dst],
         "exclude": DEFAULT_EXCLUDE,
         "original_src_path": None,
@@ -188,9 +187,11 @@ def test_config_data_good_data(dst):
         "subdirectory": None,
     }
     conf = ConfigData(**expected)
-    expected["data"]["_folder_name"] = dst.name
+    conf.data["_folder_name"] = dst.name
     expected["answers_file"] = Path(".copier-answers.yml")
-    assert conf.dict() == expected
+    conf_dict = conf.dict()
+    for key, value in expected.items():
+        assert conf_dict[key] == value
 
 
 def test_make_config_bad_data(dst):

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -11,7 +11,9 @@ from .helpers import DATA, PROJECT_TEMPLATE
 def test_render(dst):
     envops = EnvOps().dict()
     render = tools.Renderer(
-        ConfigData(src_path=PROJECT_TEMPLATE, dst_path=dst, data=DATA, envops=envops)
+        ConfigData(
+            src_path=PROJECT_TEMPLATE, dst_path=dst, data_from_init=DATA, envops=envops
+        )
     )
 
     assert render.string("/hello/[[ what ]]/") == "/hello/world/"


### PR DESCRIPTION
- `ConfigData` objects now know where do answers come from.
- Their `.data` attribute is now a computed property that merges all those answer sources in priority order.
- To merge dicts, `ChainMap` is used extensively.
- `query_user_data` gets both `last_answer_data` and `forced_answers_data` instead of the single `answers_data` argument it got before.
- By knowing where does an answer come from, now Copier avoids asking something if the user already answered that from other source. For example, if you use `copier -d some_question=some_answer copy $src $dst`, then Copier will not ask you about `some_question` again, because you already answered that. 🎉
- All answer sources are deep-copied to avoid modifying mutable dicts and affecting further copier executions.
- A minimal amount of tests got updated as they were now supposed to fail with new behavior.