### PR TITLE
Remove `dst` fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,4 @@
-import shutil
 from os import SEEK_END
-from pathlib import Path
-from tempfile import mkdtemp
 from unittest import mock
 
 import pytest
@@ -10,16 +7,6 @@ from plumbum import local
 
 # Workaround to let plumbum.local and plumbum.cmd run in virtualenv
 local.env.path.insert(0, local.cwd / ".venv" / "bin")
-
-
-@pytest.fixture()
-def dst(request):
-    """Return a real temporary folder path which is unique to each test
-    function invocation. This folder is deleted after the test has finished.
-    """
-    dst = mkdtemp(prefix=f"{__name__}.dst.")
-    request.addfinalizer(lambda: shutil.rmtree(dst, ignore_errors=True))
-    return Path(dst)
 
 
 class AppendableStringIO(six.StringIO):

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,13 +21,13 @@ DATA = {
 }
 
 
-def render(dst, **kwargs):
+def render(tmp_path, **kwargs):
     kwargs.setdefault("quiet", True)
-    copier.copy(str(PROJECT_TEMPLATE), dst, data=DATA, **kwargs)
+    copier.copy(str(PROJECT_TEMPLATE), tmp_path, data=DATA, **kwargs)
 
 
-def assert_file(dst, *path):
-    p1 = os.path.join(str(dst), *path)
+def assert_file(tmp_path, *path):
+    p1 = os.path.join(str(tmp_path), *path)
     p2 = os.path.join(str(PROJECT_TEMPLATE), *path)
     assert filecmp.cmp(p1, p2)
 

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -11,12 +11,12 @@ SRC = f"{PROJECT_TEMPLATE}_answersfile"
 
 
 @pytest.mark.parametrize("answers_file", [None, ".changed-by-user.yaml"])
-def test_answersfile(dst, answers_file):
+def test_answersfile(tmp_path, answers_file):
     """Test copier behaves properly when using an answersfile."""
-    round_file = dst / "round.txt"
+    round_file = tmp_path / "round.txt"
 
     # Check 1st round is properly executed and remembered
-    copier.copy(SRC, dst, answers_file=answers_file, force=True)
+    copier.copy(SRC, tmp_path, answers_file=answers_file, force=True)
     answers_file = answers_file or ".answers-file-changed-in-template.yml"
     assert (
         round_file.read_text()
@@ -28,14 +28,14 @@ def test_answersfile(dst, answers_file):
             """
         ).lstrip()
     )
-    log = load_answersfile_data(dst, answers_file)
+    log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "1st"
     assert log["str_question_without_default"] is None
     assert "password_1" not in log
     assert "password_2" not in log
 
     # Check 2nd round is properly executed and remembered
-    copier.copy(SRC, dst, {"round": "2nd"}, answers_file=answers_file, force=True)
+    copier.copy(SRC, tmp_path, {"round": "2nd"}, answers_file=answers_file, force=True)
     assert (
         round_file.read_text()
         == dedent(
@@ -46,14 +46,14 @@ def test_answersfile(dst, answers_file):
             """
         ).lstrip()
     )
-    log = load_answersfile_data(dst, answers_file)
+    log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "2nd"
     assert log["str_question_without_default"] is None
     assert "password_1" not in log
     assert "password_2" not in log
 
     # Check repeating 2nd is properly executed and remembered
-    copier.copy(SRC, dst, answers_file=answers_file, force=True)
+    copier.copy(SRC, tmp_path, answers_file=answers_file, force=True)
     assert (
         round_file.read_text()
         == dedent(
@@ -64,7 +64,7 @@ def test_answersfile(dst, answers_file):
             """
         ).lstrip()
     )
-    log = load_answersfile_data(dst, answers_file)
+    log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "2nd"
     assert log["str_question_without_default"] is None
     assert "password_1" not in log

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -5,13 +5,15 @@ import pytest
 import copier
 
 
-def test_cleanup(dst):
+def test_cleanup(tmp_path):
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", dst, quiet=True)
-    assert not (dst).exists()
+        copier.copy("./tests/demo_cleanup", tmp_path, quiet=True)
+    assert not (tmp_path).exists()
 
 
-def test_do_not_cleanup(dst):
+def test_do_not_cleanup(tmp_path):
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False)
-    assert (dst).exists()
+        copier.copy(
+            "./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=False
+        )
+    assert (tmp_path).exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,17 +8,17 @@ from copier.cli import CopierApp
 SIMPLE_DEMO_PATH = Path(__file__).parent / "demo_simple"
 
 
-def test_good_cli_run(dst):
+def test_good_cli_run(tmp_path):
     run_result = CopierApp.run(
-        ["--quiet", "-a", "altered-answers.yml", str(SIMPLE_DEMO_PATH), str(dst)],
+        ["--quiet", "-a", "altered-answers.yml", str(SIMPLE_DEMO_PATH), str(tmp_path)],
         exit=False,
     )
-    a_txt = dst / "a.txt"
+    a_txt = tmp_path / "a.txt"
     assert run_result[1] == 0
     assert a_txt.exists()
     assert a_txt.is_file()
     assert a_txt.read_text().strip() == "EXAMPLE_CONTENT"
-    answers = yaml.safe_load((dst / "altered-answers.yml").read_text())
+    answers = yaml.safe_load((tmp_path / "altered-answers.yml").read_text())
     assert answers["_src_path"] == str(SIMPLE_DEMO_PATH)
 
 

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -10,11 +10,11 @@ from .helpers import PROJECT_TEMPLATE
 SRC = f"{PROJECT_TEMPLATE}_complex_questions"
 
 
-def test_api(dst):
+def test_api(tmp_path):
     """Test copier correctly processes advanced questions and answers through API."""
     copy(
         SRC,
-        dst,
+        tmp_path,
         {
             "love_me": False,
             "your_name": "LeChuck",
@@ -25,7 +25,7 @@ def test_api(dst):
         },
         force=True,
     )
-    results_file = dst / "results.txt"
+    results_file = tmp_path / "results.txt"
     assert results_file.read_text() == dedent(
         """
             love_me: false
@@ -87,14 +87,14 @@ def test_cli(tmp_path):
     )
 
 
-def test_api_str_data(dst):
+def test_api_str_data(tmp_path):
     """Test copier when all data comes as a string.
 
     This happens i.e. when using the --data CLI argument.
     """
     copy(
         SRC,
-        dst,
+        tmp_path,
         data={
             "love_me": "false",
             "your_name": "LeChuck",
@@ -106,7 +106,7 @@ def test_api_str_data(dst):
         },
         force=True,
     )
-    results_file = dst / "results.txt"
+    results_file = tmp_path / "results.txt"
     assert results_file.read_text() == dedent(
         r"""
             love_me: false

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -8,151 +8,153 @@ import copier
 from .helpers import DATA, PROJECT_TEMPLATE, assert_file, filecmp, render
 
 
-def test_project_not_found(dst):
+def test_project_not_found(tmp_path):
     with pytest.raises(ValueError):
-        copier.copy("foobar", dst)
+        copier.copy("foobar", tmp_path)
 
     with pytest.raises(ValueError):
-        copier.copy(__file__, dst)
+        copier.copy(__file__, tmp_path)
 
 
-def test_copy(dst):
-    render(dst)
+def test_copy(tmp_path):
+    render(tmp_path)
 
-    generated = (dst / "pyproject.toml").read_text()
+    generated = (tmp_path / "pyproject.toml").read_text()
     control = (Path(__file__).parent / "reference_files/pyproject.toml").read_text()
     assert generated == control
 
-    assert_file(dst, "doc", "mañana.txt")
-    assert_file(dst, "doc", "images", "nslogo.gif")
+    assert_file(tmp_path, "doc", "mañana.txt")
+    assert_file(tmp_path, "doc", "images", "nslogo.gif")
 
-    p1 = str(dst / "awesome" / "hello.txt")
+    p1 = str(tmp_path / "awesome" / "hello.txt")
     p2 = str(PROJECT_TEMPLATE / "[[ myvar ]]" / "hello.txt")
     assert filecmp.cmp(p1, p2)
 
-    with open(dst / "README.txt") as readme:
+    with open(tmp_path / "README.txt") as readme:
         assert readme.read() == "This is the README for Copier.\n"
 
-    p1 = str(dst / "awesome.txt")
+    p1 = str(tmp_path / "awesome.txt")
     p2 = str(PROJECT_TEMPLATE / "[[ myvar ]].txt")
     assert filecmp.cmp(p1, p2)
 
-    assert not os.path.exists(dst / "[% if not py3 %]py2_only.py[% endif %]")
-    assert not os.path.exists(dst / "[% if py3 %]py3_only.py[% endif %]")
-    assert not os.path.exists(dst / "py2_only.py")
-    assert os.path.exists(dst / "py3_only.py")
+    assert not os.path.exists(tmp_path / "[% if not py3 %]py2_only.py[% endif %]")
+    assert not os.path.exists(tmp_path / "[% if py3 %]py3_only.py[% endif %]")
+    assert not os.path.exists(tmp_path / "py2_only.py")
+    assert os.path.exists(tmp_path / "py3_only.py")
     assert not os.path.exists(
-        dst / "[% if not py3 %]py2_folder[% endif %]" / "thing.py"
+        tmp_path / "[% if not py3 %]py2_folder[% endif %]" / "thing.py"
     )
-    assert not os.path.exists(dst / "[% if py3 %]py3_folder[% endif %]" / "thing.py")
-    assert not os.path.exists(dst / "py2_folder" / "thing.py")
-    assert os.path.exists(dst / "py3_folder" / "thing.py")
+    assert not os.path.exists(
+        tmp_path / "[% if py3 %]py3_folder[% endif %]" / "thing.py"
+    )
+    assert not os.path.exists(tmp_path / "py2_folder" / "thing.py")
+    assert os.path.exists(tmp_path / "py3_folder" / "thing.py")
 
 
-def test_copy_repo(dst):
-    copier.copy("gh:jpscaletti/siht.git", dst, vcs_ref="HEAD", quiet=True)
-    assert (dst / "setup.py").exists()
+def test_copy_repo(tmp_path):
+    copier.copy("gh:jpscaletti/siht.git", tmp_path, vcs_ref="HEAD", quiet=True)
+    assert (tmp_path / "setup.py").exists()
 
 
-def test_default_exclude(dst):
-    render(dst)
-    assert not (dst / ".svn").exists()
+def test_default_exclude(tmp_path):
+    render(tmp_path)
+    assert not (tmp_path / ".svn").exists()
 
 
-def test_include_file(dst):
-    render(dst, exclude=["!.svn"])
-    assert_file(dst, ".svn")
+def test_include_file(tmp_path):
+    render(tmp_path, exclude=["!.svn"])
+    assert_file(tmp_path, ".svn")
 
 
-def test_include_pattern(dst):
-    render(dst, exclude=["!.*"])
-    assert (dst / ".svn").exists()
+def test_include_pattern(tmp_path):
+    render(tmp_path, exclude=["!.*"])
+    assert (tmp_path / ".svn").exists()
 
 
-def test_exclude_file(dst):
-    render(dst, exclude=["mañana.txt"])
-    assert not (dst / "doc" / "mañana.txt").exists()
-    assert (dst / "doc" / "mañana.txt").exists()
-    assert (dst / "doc" / "manana.txt").exists()
+def test_exclude_file(tmp_path):
+    render(tmp_path, exclude=["mañana.txt"])
+    assert not (tmp_path / "doc" / "mañana.txt").exists()
+    assert (tmp_path / "doc" / "mañana.txt").exists()
+    assert (tmp_path / "doc" / "manana.txt").exists()
 
 
-def test_skip_if_exists(dst):
-    copier.copy("tests/demo_skip_dst", dst)
+def test_skip_if_exists(tmp_path):
+    copier.copy("tests/demo_skip_dst", tmp_path)
     copier.copy(
         "tests/demo_skip_src",
-        dst,
+        tmp_path,
         skip_if_exists=["b.noeof.txt", "meh/c.noeof.txt"],
         force=True,
     )
 
-    assert (dst / "a.noeof.txt").read_text() == "OVERWRITTEN"
-    assert (dst / "b.noeof.txt").read_text() == "SKIPPED"
-    assert (dst / "meh" / "c.noeof.txt").read_text() == "SKIPPED"
+    assert (tmp_path / "a.noeof.txt").read_text() == "OVERWRITTEN"
+    assert (tmp_path / "b.noeof.txt").read_text() == "SKIPPED"
+    assert (tmp_path / "meh" / "c.noeof.txt").read_text() == "SKIPPED"
 
 
-def test_skip_if_exists_rendered_patterns(dst):
-    copier.copy("tests/demo_skip_dst", dst)
+def test_skip_if_exists_rendered_patterns(tmp_path):
+    copier.copy("tests/demo_skip_dst", tmp_path)
     copier.copy(
         "tests/demo_skip_src",
-        dst,
+        tmp_path,
         data={"name": "meh"},
         skip_if_exists=["[[ name ]]/c.noeof.txt"],
         force=True,
     )
-    assert (dst / "a.noeof.txt").read_text() == "OVERWRITTEN"
-    assert (dst / "b.noeof.txt").read_text() == "OVERWRITTEN"
-    assert (dst / "meh" / "c.noeof.txt").read_text() == "SKIPPED"
+    assert (tmp_path / "a.noeof.txt").read_text() == "OVERWRITTEN"
+    assert (tmp_path / "b.noeof.txt").read_text() == "OVERWRITTEN"
+    assert (tmp_path / "meh" / "c.noeof.txt").read_text() == "SKIPPED"
 
 
-def test_config_exclude(dst, monkeypatch):
+def test_config_exclude(tmp_path, monkeypatch):
     def fake_data(*_args, **_kwargs):
         return {"_exclude": ["*.txt"]}
 
     monkeypatch.setattr(copier.config.factory, "load_config_data", fake_data)
-    copier.copy(str(PROJECT_TEMPLATE), dst, data=DATA, quiet=True)
-    assert not (dst / "aaaa.txt").exists()
+    copier.copy(str(PROJECT_TEMPLATE), tmp_path, data=DATA, quiet=True)
+    assert not (tmp_path / "aaaa.txt").exists()
 
 
-def test_config_exclude_overridden(dst):
+def test_config_exclude_overridden(tmp_path):
     def fake_data(*_args, **_kwargs):
         return {"_exclude": ["*.txt"]}
 
-    copier.copy(str(PROJECT_TEMPLATE), dst, data=DATA, quiet=True, exclude=[])
-    assert (dst / "aaaa.txt").exists()
+    copier.copy(str(PROJECT_TEMPLATE), tmp_path, data=DATA, quiet=True, exclude=[])
+    assert (tmp_path / "aaaa.txt").exists()
 
 
-def test_config_include(dst, monkeypatch):
+def test_config_include(tmp_path, monkeypatch):
     def fake_data(*_args, **_kwargs):
         return {"_exclude": ["!.svn"]}
 
     monkeypatch.setattr(copier.config.factory, "load_config_data", fake_data)
-    copier.copy(str(PROJECT_TEMPLATE), dst, data=DATA, quiet=True)
-    assert (dst / ".svn").exists()
+    copier.copy(str(PROJECT_TEMPLATE), tmp_path, data=DATA, quiet=True)
+    assert (tmp_path / ".svn").exists()
 
 
-def test_skip_option(dst):
-    render(dst)
-    path = dst / "pyproject.toml"
+def test_skip_option(tmp_path):
+    render(tmp_path)
+    path = tmp_path / "pyproject.toml"
     content = "lorem ipsum"
     path.write_text(content)
-    render(dst, skip=True)
+    render(tmp_path, skip=True)
     assert path.read_text() == content
 
 
-def test_force_option(dst):
-    render(dst)
-    path = dst / "pyproject.toml"
+def test_force_option(tmp_path):
+    render(tmp_path)
+    path = tmp_path / "pyproject.toml"
     content = "lorem ipsum"
     path.write_text(content)
-    render(dst, force=True)
+    render(tmp_path, force=True)
     assert path.read_text() != content
 
 
-def test_pretend_option(dst):
-    render(dst, pretend=True)
-    assert not (dst / "doc").exists()
-    assert not (dst / "config.py").exists()
-    assert not (dst / "pyproject.toml").exists()
+def test_pretend_option(tmp_path):
+    render(tmp_path, pretend=True)
+    assert not (tmp_path / "doc").exists()
+    assert not (tmp_path / "config.py").exists()
+    assert not (tmp_path / "pyproject.toml").exists()
 
 
 def test_subdirectory(tmp_path: Path):

--- a/tests/test_demo_update_tasks.py
+++ b/tests/test_demo_update_tasks.py
@@ -12,13 +12,13 @@ REPO_BUNDLE_PATH = Path(f"{PROJECT_TEMPLATE}_update_tasks.bundle").absolute()
 
 def test_update_tasks(tmpdir):
     """Test that updating a template runs tasks from the expected version."""
-    dst = tmpdir / "dst"
+    tmp_path = tmpdir / "tmp_path"
     # Copy the 1st version
     copy(
-        str(REPO_BUNDLE_PATH), dst, force=True, vcs_ref="v1",
+        str(REPO_BUNDLE_PATH), tmp_path, force=True, vcs_ref="v1",
     )
     # Init destination as a new independent git repo
-    with local.cwd(dst):
+    with local.cwd(tmp_path):
         git("init")
         # Configure git in case you're running in CI
         git("config", "user.name", "Copier Test")
@@ -27,4 +27,4 @@ def test_update_tasks(tmpdir):
         git("add", ".")
         git("commit", "-m", "hello world")
     # Update target to v2
-    copy(dst_path=str(dst), force=True)
+    copy(dst_path=str(tmp_path), force=True)

--- a/tests/test_extra_paths.py
+++ b/tests/test_extra_paths.py
@@ -10,29 +10,29 @@ CHILD_DIR_CONFIG = "./tests/demo_extra_paths/children_config"
 PARENT_DIR = "./tests/demo_extra_paths/parent"
 
 
-def test_template_not_found(dst):
+def test_template_not_found(tmp_path):
     with pytest.raises(TemplateNotFound):
-        copier.copy(CHILD_DIR, dst)
+        copier.copy(CHILD_DIR, tmp_path)
 
 
-def test_parent_dir_not_found(dst):
+def test_parent_dir_not_found(tmp_path):
     with pytest.raises(ValueError):
-        copier.copy(CHILD_DIR, dst, extra_paths="foobar")
+        copier.copy(CHILD_DIR, tmp_path, extra_paths="foobar")
 
 
-def test_copy_with_extra_paths(dst):
-    copier.copy(CHILD_DIR, dst, extra_paths=[PARENT_DIR])
+def test_copy_with_extra_paths(tmp_path):
+    copier.copy(CHILD_DIR, tmp_path, extra_paths=[PARENT_DIR])
 
-    gen_file = dst / "child.txt"
+    gen_file = tmp_path / "child.txt"
     result = gen_file.read_text()
     expected = Path(PARENT_DIR + "/parent.txt").read_text()
     assert result == expected
 
 
-def test_copy_with_extra_paths_from_config(dst):
-    copier.copy(CHILD_DIR_CONFIG, dst)
+def test_copy_with_extra_paths_from_config(tmp_path):
+    copier.copy(CHILD_DIR_CONFIG, tmp_path)
 
-    gen_file = dst / "child.txt"
+    gen_file = tmp_path / "child.txt"
     result = gen_file.read_text()
     expected = Path(PARENT_DIR + "/parent.txt").read_text()
     assert result == expected

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -17,7 +17,7 @@ SRC = Path(f"{PROJECT_TEMPLATE}_migrations").absolute()
 def test_migrations_and_tasks(tmpdir: py.path.local):
     """Check migrations and tasks are run properly."""
     # Convert demo_migrations in a git repository with 2 versions
-    git_src, dst = tmpdir / "src", tmpdir / "dst"
+    git_src, tmp_path = tmpdir / "src", tmpdir / "tmp_path"
     copytree(SRC, git_src)
     with local.cwd(git_src):
         git("init")
@@ -29,34 +29,34 @@ def test_migrations_and_tasks(tmpdir: py.path.local):
         git("commit", "--allow-empty", "-m2")
         git("tag", "v2.0")
     # Copy it in v1
-    copy(src_path=str(git_src), dst_path=str(dst), vcs_ref="v1.0.0")
+    copy(src_path=str(git_src), dst_path=str(tmp_path), vcs_ref="v1.0.0")
     # Check copy was OK
-    assert (dst / "created-with-tasks.txt").read() == "task 1\ntask 2\n"
-    assert not (dst / "delete-in-tasks.txt").exists()
-    assert (dst / "delete-in-migration-v2.txt").isfile()
-    assert not (dst / "migrations.py").exists()
-    assert not (dst / "tasks.sh").exists()
-    assert not glob(str(dst / "*-before.txt"))
-    assert not glob(str(dst / "*-after.txt"))
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read())
+    assert (tmp_path / "created-with-tasks.txt").read() == "task 1\ntask 2\n"
+    assert not (tmp_path / "delete-in-tasks.txt").exists()
+    assert (tmp_path / "delete-in-migration-v2.txt").isfile()
+    assert not (tmp_path / "migrations.py").exists()
+    assert not (tmp_path / "tasks.sh").exists()
+    assert not glob(str(tmp_path / "*-before.txt"))
+    assert not glob(str(tmp_path / "*-after.txt"))
+    answers = yaml.safe_load((tmp_path / ".copier-answers.yml").read())
     assert answers == {"_commit": "v1.0.0", "_src_path": str(git_src)}
     # Save changes in downstream repo
-    with local.cwd(dst):
+    with local.cwd(tmp_path):
         git("add", ".")
         git("config", "user.name", "Copier Test")
         git("config", "user.email", "test@copier")
         git("commit", "-m1")
     # Update it to v2
-    copy(dst_path=str(dst), force=True)
+    copy(dst_path=str(tmp_path), force=True)
     # Check update was OK
-    assert (dst / "created-with-tasks.txt").read() == "task 1\ntask 2\n" * 2
-    assert not (dst / "delete-in-tasks.txt").exists()
-    assert not (dst / "delete-in-migration-v2.txt").exists()
-    assert not (dst / "migrations.py").exists()
-    assert not (dst / "tasks.sh").exists()
-    assert (dst / "v1.0.0-v2-v2.0-before.json").isfile()
-    assert (dst / "v1.0.0-v2-v2.0-after.json").isfile()
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read())
+    assert (tmp_path / "created-with-tasks.txt").read() == "task 1\ntask 2\n" * 2
+    assert not (tmp_path / "delete-in-tasks.txt").exists()
+    assert not (tmp_path / "delete-in-migration-v2.txt").exists()
+    assert not (tmp_path / "migrations.py").exists()
+    assert not (tmp_path / "tasks.sh").exists()
+    assert (tmp_path / "v1.0.0-v2-v2.0-before.json").isfile()
+    assert (tmp_path / "v1.0.0-v2-v2.0-after.json").isfile()
+    answers = yaml.safe_load((tmp_path / ".copier-answers.yml").read())
     assert answers == {"_commit": "v2.0", "_src_path": str(git_src)}
 
 

--- a/tests/test_normal_jinja2.py
+++ b/tests/test_normal_jinja2.py
@@ -3,8 +3,8 @@ import copier
 from .helpers import PROJECT_TEMPLATE
 
 
-def test_normal_jinja2(dst):
-    copier.copy(f"{PROJECT_TEMPLATE}_normal_jinja2", dst, force=True)
-    todo = (dst / "TODO.txt").read_text()
+def test_normal_jinja2(tmp_path):
+    copier.copy(f"{PROJECT_TEMPLATE}_normal_jinja2", tmp_path, force=True)
+    todo = (tmp_path / "TODO.txt").read_text()
     expected = "[[ Guybrush TODO LIST]]\n[# GROG #]\n    - Become a pirate\n"
     assert todo == expected

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3,26 +3,26 @@ import re
 from .helpers import render
 
 
-def test_output(capsys, dst):
-    render(dst, quiet=False)
+def test_output(capsys, tmp_path):
+    render(tmp_path, quiet=False)
     out, _ = capsys.readouterr()
     assert re.search(r"create[^\s]*  config\.py", out)
     assert re.search(r"create[^\s]*  pyproject\.toml", out)
     assert re.search(r"create[^\s]*  doc/images/nslogo\.gif", out)
 
 
-def test_output_pretend(capsys, dst):
-    render(dst, quiet=False, pretend=True)
+def test_output_pretend(capsys, tmp_path):
+    render(tmp_path, quiet=False, pretend=True)
     out, _ = capsys.readouterr()
     assert re.search(r"create[^\s]*  config\.py", out)
     assert re.search(r"create[^\s]*  pyproject\.toml", out)
     assert re.search(r"create[^\s]*  doc/images/nslogo\.gif", out)
 
 
-def test_output_force(capsys, dst):
-    render(dst)
+def test_output_force(capsys, tmp_path):
+    render(tmp_path)
     out, _ = capsys.readouterr()
-    render(dst, quiet=False, force=True)
+    render(tmp_path, quiet=False, force=True)
     out, _ = capsys.readouterr()
     assert re.search(r"conflict[^\s]*  config\.py", out)
     assert re.search(r"force[^\s]*  config\.py", out)
@@ -30,10 +30,10 @@ def test_output_force(capsys, dst):
     assert re.search(r"identical[^\s]*  doc/images/nslogo\.gif", out)
 
 
-def test_output_skip(capsys, dst):
-    render(dst)
+def test_output_skip(capsys, tmp_path):
+    render(tmp_path)
     out, _ = capsys.readouterr()
-    render(dst, quiet=False, skip=True)
+    render(tmp_path, quiet=False, skip=True)
     out, _ = capsys.readouterr()
     assert re.search(r"conflict[^\s]*  config\.py", out)
     assert re.search(r"skip[^\s]*  config\.py", out)
@@ -41,7 +41,7 @@ def test_output_skip(capsys, dst):
     assert re.search(r"identical[^\s]*  doc/images/nslogo\.gif", out)
 
 
-def test_output_quiet(capsys, dst):
-    render(dst, quiet=True)
+def test_output_quiet(capsys, tmp_path):
+    render(tmp_path, quiet=True)
     out, _ = capsys.readouterr()
     assert out == ""

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -3,15 +3,15 @@ import copier
 from .helpers import DATA, render
 
 
-def test_render_tasks(dst):
+def test_render_tasks(tmp_path):
     tasks = ["touch [[ myvar ]]/1.txt", "touch [[ myvar ]]/2.txt"]
-    render(dst, tasks=tasks)
-    assert (dst / DATA["myvar"] / "1.txt").exists()
-    assert (dst / DATA["myvar"] / "2.txt").exists()
+    render(tmp_path, tasks=tasks)
+    assert (tmp_path / DATA["myvar"] / "1.txt").exists()
+    assert (tmp_path / DATA["myvar"] / "2.txt").exists()
 
 
-def test_copy_tasks(dst):
-    copier.copy("tests/demo_tasks", dst, quiet=True)
-    assert (dst / "hello").exists()
-    assert (dst / "hello").is_dir()
-    assert (dst / "hello" / "world").exists()
+def test_copy_tasks(tmp_path):
+    copier.copy("tests/demo_tasks", tmp_path, quiet=True)
+    assert (tmp_path / "hello").exists()
+    assert (tmp_path / "hello").is_dir()
+    assert (tmp_path / "hello" / "world").exists()

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -134,12 +134,12 @@ def test_templated_prompt(
         assert output in captured.out
 
 
-def test_templated_prompt_custom_envops(dst):
-    conf = make_config("./tests/demo_templated_prompt", dst, force=True)
+def test_templated_prompt_custom_envops(tmp_path):
+    conf = make_config("./tests/demo_templated_prompt", tmp_path, force=True)
     assert conf.data["sentence"] == "It's over 9000!"
 
     conf = make_config(
-        "./tests/demo_templated_prompt", dst, data={"powerlevel": 1}, force=True
+        "./tests/demo_templated_prompt", tmp_path, data={"powerlevel": 1}, force=True
     )
     assert conf.data["sentence"] == "It's only 1..."
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -8,11 +8,14 @@ from copier.config.factory import ConfigData, EnvOps
 from .helpers import DATA, PROJECT_TEMPLATE
 
 
-def test_render(dst):
+def test_render(tmp_path):
     envops = EnvOps().dict()
     render = tools.Renderer(
         ConfigData(
-            src_path=PROJECT_TEMPLATE, dst_path=dst, data_from_init=DATA, envops=envops
+            src_path=PROJECT_TEMPLATE,
+            dst_path=tmp_path,
+            data_from_init=DATA,
+            envops=envops,
         )
     )
 

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -13,8 +13,8 @@ REPO_BUNDLE_PATH = Path(f"{PROJECT_TEMPLATE}_updatediff_repo.bundle").absolute()
 
 
 def test_updatediff(tmpdir):
-    dst = Path(tmpdir)
-    target = dst / "target"
+    tmp_path = Path(tmpdir)
+    target = tmp_path / "target"
     readme = target / "README.txt"
     answers = target / ".copier-answers.yml"
     commit = git["commit", "--all"]
@@ -142,7 +142,7 @@ def test_updatediff(tmpdir):
 def test_commit_hooks_respected(tmp_path: Path):
     """Commit hooks are taken into account when producing the update diff."""
     # Prepare source template v1
-    src, dst = tmp_path / "src", tmp_path / "dst"
+    src, tmp_path = tmp_path / "src", tmp_path / "tmp_path"
     src.mkdir()
     with local.cwd(src):
         build_file_tree(
@@ -184,8 +184,8 @@ def test_commit_hooks_respected(tmp_path: Path):
         git("commit", "-m", "commit 1")
         git("tag", "v1")
     # Copy source template
-    copy(src_path=str(src), dst_path=dst, force=True)
-    with local.cwd(dst):
+    copy(src_path=str(src), dst_path=tmp_path, force=True)
+    with local.cwd(tmp_path):
         life = Path("life.yml")
         git("add", ".")
         # 1st commit fails because pre-commit reformats life.yml
@@ -219,8 +219,8 @@ def test_commit_hooks_respected(tmp_path: Path):
         git("commit", "-m", "commit 2")
         git("tag", "v2")
     # Update subproject to v2
-    copy(dst_path=dst, force=True)
-    with local.cwd(dst):
+    copy(dst_path=tmp_path, force=True)
+    with local.cwd(tmp_path):
         git("commit", "-am", "copied v2")
         assert life.read_text() == dedent(
             """\


### PR DESCRIPTION
This is redundant with pytest's native `tmp_path` fixture, so we use that one instead now.