### PR TITLE
 Avoid templated defaults counting as init data

### DIFF
--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -108,11 +108,16 @@ def make_config(
         k: v.get("default") for k, v in questions_data.items()
     }
     init_args["envops"] = EnvOps(**template_config_data.get("envops", {}))
+    data = kwargs.get("data") or {}
     init_args["data_from_init"] = ChainMap(
         query_user_data(
-            questions_data, {}, kwargs.get("data") or {}, False, init_args["envops"]
+            {k: v for k, v in questions_data.items() if k in data},
+            {},
+            data,
+            False,
+            init_args["envops"],
         ),
-        kwargs.get("data") or {},
+        data,
     )
     init_args["data_from_asking_user"] = query_user_data(
         questions_data,

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -52,8 +52,14 @@ def test_copy(tmp_path):
 
 
 def test_copy_repo(tmp_path):
-    copier.copy("gh:jpscaletti/siht.git", tmp_path, vcs_ref="HEAD", quiet=True)
-    assert (tmp_path / "setup.py").exists()
+    copier.copy(
+        "gh:copier-org/copier.git",
+        tmp_path,
+        vcs_ref="HEAD",
+        quiet=True,
+        exclude=["*", "!README.*"],
+    )
+    assert (tmp_path / "README.md").exists()
 
 
 def test_default_exclude(tmp_path):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -9,6 +9,7 @@ from copier import copy
 
 from .helpers import build_file_tree
 
+DEFAULT = object()
 MARIO_TREE = {
     "copier.yml": """\
         in_love:
@@ -23,13 +24,16 @@ MARIO_TREE = {
             default: Bowser
             secret: yes
             help: Secret enemy name
+        what_enemy_does:
+            type: str
+            default: "[[ your_enemy ]] hates [[ your_name ]]"
         """,
     "[[ _copier_conf.answers_file ]].tmpl": "[[_copier_answers|to_nice_yaml]]",
 }
 
 
-@pytest.mark.timeout(5)
-@pytest.mark.parametrize("name", [None, "Luigi"])
+# @pytest.mark.timeout(5)
+@pytest.mark.parametrize("name", [DEFAULT, None, "Luigi"])
 def test_copy_default_advertised(tmp_path_factory, monkeypatch, capsys, name):
     """Test that the questions for the user are OK"""
     monkeypatch.setattr("sys.stdin", StringIO("\n" * 3))
@@ -47,15 +51,23 @@ def test_copy_default_advertised(tmp_path_factory, monkeypatch, capsys, name):
         git("tag", "v2")
     with local.cwd(subproject):
         # Copy the v1 template
-        copy(str(template), ".", vcs_ref="v1", data={"your_name": name})
+        kwargs = {}
+        if name is not DEFAULT:
+            kwargs["data"] = {"your_name": name}
+        else:
+            name = "Mario"  # Default in the template
+        copy(str(template), ".", vcs_ref="v1", **kwargs)
         # Check what was captured
         captured = capsys.readouterr()
         assert "in_love? Format: bool\n🎤? [Y/n] " in captured.out
         assert (
             "Secret enemy name\nyour_enemy? Format: str\n🕵️ [Bowser]: " in captured.out
         )
+        assert (
+            f"what_enemy_does? Format: str\n🎤 [Bowser hates {name}]: " in captured.out
+        )
         # We already sent the name through 'data', so it shouldn't be prompted
-        assert "your_name" not in captured.out
+        assert name == "Mario" or "your_name" not in captured.out
         assert "_commit: v1" in Path(".copier-answers.yml").read_text()
         # Update subproject
         git("init")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -42,7 +42,7 @@ def test_get_repo():
 
 
 def test_clone():
-    tmp = vcs.clone("https://github.com/jpscaletti/siht.git")
+    tmp = vcs.clone("https://github.com/copier-org/copier.git")
     assert tmp
-    assert exists(join(tmp, "setup.py"))
+    assert exists(join(tmp, "README.md"))
     shutil.rmtree(tmp)


### PR DESCRIPTION
Before this patch, a templated default was counting as init data because it was different from the original default after rendereing, making copier believe the user provided an answer.

This patch fixes #230 by avoiding to parse questions that have no init data answer in the step of filling `data_from_init`. Those defaults will be used later as `data_from_asking_user` if needed.

---

Fix failing tests.

https://github.com/jpscaletti/siht disappeared, so these tests were failing now. Fixed by using own copier repo to test.


