### PR TITLE
Make Copier work with Git 2.28

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -243,7 +243,7 @@ def update_diff(conf: ConfigData) -> None:
             git("config", "--unset", "user.email")
             git("remote", "add", "real_dst", conf.dst_path)
             git("fetch", "real_dst", "HEAD")
-            diff_cmd = git["diff", "--unified=1", "HEAD...FETCH_HEAD"]
+            diff_cmd = git["diff-tree", "--unified=1", "HEAD...FETCH_HEAD"]
             try:
                 diff = diff_cmd("--inter-hunk-context=-1")
             except ProcessExecutionError:


### PR DESCRIPTION
It seems that the proper command was `git diff-tree` and not `git diff`, which was accidentally working until today, where some things got fixed on Git 2.28 and GH actions updated their images to use that version of Git and broke everything for us.

FTR here's a broken CI: https://github.com/copier-org/copier/runs/945692746