### PR TITLE
Add 4-space indentation to .md files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # Specific language overrides
-[*.{yml,yaml,json,md}]
+[*.{yml,yaml,json}]
 indent_size = 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,48 +7,49 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 [All changes here](https://github.com/copier-org/copier/milestone/12?closed=1). Summary:
 
-- Make copier work fine with Git 2.28.
-- We have [docs](https://copier.readthedocs.io/)!
-- Polish docs a little bit.
-- We now run tests on macOS and Windows!
+-   Make copier work fine with Git 2.28.
+-   We have [docs](https://copier.readthedocs.io/)!
+-   Polish docs a little bit.
+-   We now run tests on macOS and Windows!
 
 ### Version 4.0.2 (2020-07-21)
 
 [All changes here](https://github.com/copier-org/copier/milestone/11?closed=1). Summary:
 
-- Fix wrong templated default answers classification, which produced some questions
-  being ignored.
+-   Fix wrong templated default answers classification, which produced some questions
+    being ignored.
 
 ### Version 4.0.1 (2020-06-23)
 
 [All changes here](https://github.com/copier-org/copier/milestone/10?closed=1). Summary:
 
-- Fix wrong prompt regression when updating.
-- Remove redundant `dst` fixture in tests.
+-   Fix wrong prompt regression when updating.
+-   Remove redundant `dst` fixture in tests.
 
 ### Version 4.0.0 (2020-06)
 
 [All changes here](https://github.com/copier-org/copier/milestone/9?closed=1). Summary:
 
-- Remove semver to avoid having 2 different versioning systems. We stick to PEP 440 now.
-- Remember where an answer comes from.
-- Do not re-ask to the user if already answer via `--data`.
-- Support pre-migration scripts that modify the answers file.
+-   Remove semver to avoid having 2 different versioning systems. We stick to PEP 440
+    now.
+-   Remember where an answer comes from.
+-   Do not re-ask to the user if already answer via `--data`.
+-   Support pre-migration scripts that modify the answers file.
 
 ### Version 3.2.0 (2020-06)
 
 [All changes here](https://github.com/copier-org/copier/milestone/8?closed=1). Summary:
 
-- Templates can now use a subdirectory instead of always the template root.
+-   Templates can now use a subdirectory instead of always the template root.
 
 ### Version 3.1.0 (2020-05)
 
 [All changes here](https://github.com/pykong/copier/milestone/7?closed=1). Summary:
 
-- Assert minimum copier version.
-- Prettier prompts.
-- Prompt self-templating.
-- Better README.
+-   Assert minimum copier version.
+-   Prettier prompts.
+-   Prompt self-templating.
+-   Better README.
 
 ### Version 3.0.0 (2020-03)
 
@@ -57,84 +58,85 @@ received a lot of love and hardening.
 
 #### Features
 
-- Minimal supported Python version is now 3.6.
-- Dropped support for deprecated `voodoo.json`.
-- Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
-- Dropped support for `include` option.
-- Added support for extending content of config files via content of other files via
-  `pyaml-include`.
-- Customizable template extension.
-- Ability to remember last answers.
-- Ability to choose where to remember them.
-- Template upgrades support, (based on the previous points) with migration tasks
-  specification.
-- Extended questions format, supporting help, format, choices and secrets.
-- More beautiful prompts.
-- New CLI experience.
+-   Minimal supported Python version is now 3.6.
+-   Dropped support for deprecated `voodoo.json`.
+-   Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
+-   Dropped support for `include` option.
+-   Added support for extending content of config files via content of other files via
+    `pyaml-include`.
+-   Customizable template extension.
+-   Ability to remember last answers.
+-   Ability to choose where to remember them.
+-   Template upgrades support, (based on the previous points) with migration tasks
+    specification.
+-   Extended questions format, supporting help, format, choices and secrets.
+-   More beautiful prompts.
+-   New CLI experience.
 
 #### Other
 
-- Moved to `poetry` for package management.
-- Type annotated entire code base.
-- Increased test coverage.
-- Ditched `ruamel.yaml` for `PyYaml`.
-- Ditched Travis CI for GitHub Actions.
-- Added `pre-commit` for enforced linting.
-- Added `prettier`, `black` and `isort` for code formatting.
-- Added `pytest` for running tests.
-- Use `plumbum` as CLI and subprocess engine.
+-   Moved to `poetry` for package management.
+-   Type annotated entire code base.
+-   Increased test coverage.
+-   Ditched `ruamel.yaml` for `PyYaml`.
+-   Ditched Travis CI for GitHub Actions.
+-   Added `pre-commit` for enforced linting.
+-   Added `prettier`, `black` and `isort` for code formatting.
+-   Added `pytest` for running tests.
+-   Use `plumbum` as CLI and subprocess engine.
 
 ### Version 2.5 (2019-06)
 
-- Expanduser on all paths (so "~/foo/bar" is expanded to "<YOUR_HOME_FOLDER>/foo/bar").
-- Improve the output when running tasks.
-- Remove the destination folder if the copy process or one of the tasks fail.
-- Add a `cleanup_on_error` flag to optionally disable the cleanup feature.
-- Add the `skip_if_exists` option to skip files, without asking, if they already exists
-  in the destination folder.
+-   Expanduser on all paths (so "~/foo/bar" is expanded to
+    "<YOUR_HOME_FOLDER>/foo/bar").
+-   Improve the output when running tasks.
+-   Remove the destination folder if the copy process or one of the tasks fail.
+-   Add a `cleanup_on_error` flag to optionally disable the cleanup feature.
+-   Add the `skip_if_exists` option to skip files, without asking, if they already
+    exists in the destination folder.
 
 ### Version 2.4.2 (2019-06)
 
-- Fix MAJOR bug that was preventing the `_exclude`, `_include` and `_tasks` keys from
-  `copier.yml` (or alternatives) to be used at all. It also interpreted `_tasks` as a
-  user-provided variable.
+-   Fix MAJOR bug that was preventing the `_exclude`, `_include` and `_tasks` keys from
+    `copier.yml` (or alternatives) to be used at all. It also interpreted `_tasks` as a
+    user-provided variable.
 
 ### Version 2.4 (2019-06)
 
-- Empty folders are now copied. The folders are also displayed in the console output
-  instead of just the files.
-- `prompt_bool` can now have an undefined default (ans answer is mandatory in that
-  case).
-- Reactivates the `copier.yml` and `copier.yaml` as configuration files.
-- The new `extra_paths` argument specifies additional paths to find templates to inherit
-  from.
+-   Empty folders are now copied. The folders are also displayed in the console output
+    instead of just the files.
+-   `prompt_bool` can now have an undefined default (ans answer is mandatory in that
+    case).
+-   Reactivates the `copier.yml` and `copier.yaml` as configuration files.
+-   The new `extra_paths` argument specifies additional paths to find templates to
+    inherit from.
 
 ### Version 2.3 (2019-04)
 
-- Back to using a setup.py intead of a pyproject.toml.
-- The recommended configuration file is now `copier.toml`.
+-   Back to using a setup.py intead of a pyproject.toml.
+-   The recommended configuration file is now `copier.toml`.
 
 ### Version 2.2 (2019-04)
 
-- The `copier` command-line script now accepts "help" and "version" as commands.
+-   The `copier` command-line script now accepts "help" and "version" as commands.
 
 ### Version 2.1 (2019-02)
 
-- Task runner 🎉.
-- Use `_exclude`, `_include`, and `_tasks` keys in `copier.yml` as the default values
-  for the `.copy()` arguments `exclude`, `include`, and `tasks`.
+-   Task runner 🎉.
+-   Use `_exclude`, `_include`, and `_tasks` keys in `copier.yml` as the default values
+    for the `.copy()` arguments `exclude`, `include`, and `tasks`.
 
 ### Version 2.0 (2019-02)
 
-- Rebranded from `Voodoo` to `Copier`!
-- Dropped support for Python 2.x, the minimal version is now Python 3.5.
-- Cleanup and 100% test coverage.
-- The recommended configuration file is now `copier.yaml`, but a `copier.json` can be
-  used as well. The old `voodoo.json` is also supported _for now_ but is deprecated and
-  will be removed in version 2.2.
-- Python package format updated to the latest standard (no `setup.py` 😵).
-- Renamed the `render_skeleton()` function to `copy()`. The function signature remains
-  almost the same, the only changes are:
-  - `filter_this` parameter is now called `exclude`.
-  - `ignore_this` parameter is now called just `ignore`.
-- Dropped the idea of storing the templates in a hidden `$HOME` folder.
+-   Rebranded from `Voodoo` to `Copier`!
+-   Dropped support for Python 2.x, the minimal version is now Python 3.5.
+-   Cleanup and 100% test coverage.
+-   The recommended configuration file is now `copier.yaml`, but a `copier.json` can be
+    used as well. The old `voodoo.json` is also supported _for now_ but is deprecated
+    and will be removed in version 2.2.
+-   Python package format updated to the latest standard (no `setup.py` 😵).
+-   Renamed the `render_skeleton()` function to `copy()`. The function signature remains
+    almost the same, the only changes are:
+    -   `filter_this` parameter is now called `exclude`.
+    -   `ignore_this` parameter is now called just `ignore`.
+-   Dropped the idea of storing the templates in a hidden `$HOME` folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Report bugs at <https://github.com/copier-org/copier/issues>.
 
 If you are reporting a bug, please include:
 
-- Your operating system name and version.
-- Any details about your local setup that might be helpful in troubleshooting.
-- Detailed steps to reproduce the bug.
+-   Your operating system name and version.
+-   Any details about your local setup that might be helpful in troubleshooting.
+-   Detailed steps to reproduce the bug.
 
 ## Fix Bugs
 
@@ -35,10 +35,10 @@ The best way to send feedback is to file an issue at
 
 If you are proposing a feature:
 
-- Explain in detail how it would work.
-- Keep the scope as narrow as possible, to make it easier to implement.
-- Remember that this is a volunteer-driven project, and that contributions are welcome
-  :)
+-   Explain in detail how it would work.
+-   Keep the scope as narrow as possible, to make it easier to implement.
+-   Remember that this is a volunteer-driven project, and that contributions are welcome
+    :)
 
 ## Get Started!
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 A library for rendering project templates.
 
-- Works with **local** paths and **git URLs**.
-- Your project can include any file and `Copier` can dynamically replace values in any
-  kind of text file.
-- It generates a beautiful output and takes care of not overwrite existing files unless
-  instructed to do so.
+-   Works with **local** paths and **git URLs**.
+-   Your project can include any file and `Copier` can dynamically replace values in any
+    kind of text file.
+-   It generates a beautiful output and takes care of not overwrite existing files
+    unless instructed to do so.
 
 ![Sample output](https://github.com/copier-org/copier/raw/master/img/copier-output.png)
 
@@ -27,29 +27,29 @@ A library for rendering project templates.
 
 ## Quick usage
 
-- Use it in your Python code:
+-   Use it in your Python code:
 
-```python
-from copier import copy
+    ```python
+    from copier import copy
 
-# Create a project from a local path
-copy("path/to/project/template", "path/to/destination")
+    # Create a project from a local path
+    copy("path/to/project/template", "path/to/destination")
 
-# Or from a git URL.
-copy("https://github.com/copier-org/copier.git", "path/to/destination")
+    # Or from a git URL.
+    copy("https://github.com/copier-org/copier.git", "path/to/destination")
 
-# You can also use "gh:" as a shortcut of "https://github.com/"
-copy("gh:copier-org/copier.git", "path/to/destination")
+    # You can also use "gh:" as a shortcut of "https://github.com/"
+    copy("gh:copier-org/copier.git", "path/to/destination")
 
-# Or "gl:" as a shortcut of "https://gitlab.com/"
-copy("gl:copier-org/copier.git", "path/to/destination")
-```
+    # Or "gl:" as a shortcut of "https://gitlab.com/"
+    copy("gl:copier-org/copier.git", "path/to/destination")
+    ```
 
-- Or as a command-line tool:
+-   Or as a command-line tool:
 
-```bash
-copier path/to/project/template path/to/destination
-```
+    ```bash
+    copier path/to/project/template path/to/destination
+    ```
 
 ## Browse or tag public templates
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -29,73 +29,74 @@ Uses the template in _src_path_ to generate a new project at _dst_path_.
 
 **Arguments**:
 
-- **src_path** (str):<br> Absolute path to the project skeleton, which can also be a
-  version control system URL.
+-   **src_path** (str):<br> Absolute path to the project skeleton, which can also be a
+    version control system URL.
 
-- **dst_path** (str):<br> Absolute path to where to render the skeleton.
+-   **dst_path** (str):<br> Absolute path to where to render the skeleton.
 
-- **data** (dict):<br> Data to be passed to the templates in addition to the user data
-  from a `copier.yml`.
+-   **data** (dict):<br> Data to be passed to the templates in addition to the user data
+    from a `copier.yml`.
 
-- **exclude** (list):<br> A list of names or gitignore-style patterns matching files or
-  folders that must not be copied.
+-   **exclude** (list):<br> A list of names or gitignore-style patterns matching files
+    or folders that must not be copied.
 
-- **skip_if_exists** (list):<br> A list of names or gitignore-style patterns matching
-  files or folders, that are skipped if another with the same name already exists in the
-  destination folder. (It only makes sense if you are copying to a folder that already
-  exists).
+-   **skip_if_exists** (list):<br> A list of names or gitignore-style patterns matching
+    files or folders, that are skipped if another with the same name already exists in
+    the destination folder. (It only makes sense if you are copying to a folder that
+    already exists).
 
-- **tasks** (list):<br> Optional lists of commands to run in order after finishing the
-  copy. Like in the templates files, you can use variables on the commands that will be
-  replaced by the real values before running the command. If one of the commands fails,
-  the rest of them will not run.
+-   **tasks** (list):<br> Optional lists of commands to run in order after finishing the
+    copy. Like in the templates files, you can use variables on the commands that will
+    be replaced by the real values before running the command. If one of the commands
+    fails, the rest of them will not run.
 
-- **envops** (dict):<br> Extra options for the Jinja template environment. See available
-  options in
-  [Jinja's docs](https://jinja.palletsprojects.com/en/2.10.x/api/#jinja2.Environment).
+-   **envops** (dict):<br> Extra options for the Jinja template environment. See
+    available options in
+    [Jinja's docs](https://jinja.palletsprojects.com/en/2.10.x/api/#jinja2.Environment).
 
-  Copier uses these defaults that are different from Jinja's:
+    Copier uses these defaults that are different from Jinja's:
 
-  ```yml
-  # copier.yml
-  _envops:
-    block_start_string: "[%"
-    block_end_string: "%]"
-    comment_start_string: "[#"
-    comment_end_string: "#]"
-    variable_start_string: "[["
-    variable_end_string: "]]"
-    keep_trailing_newline: true
-  ```
+    ```yml
+    # copier.yml
+    _envops:
+        block_start_string: "[%"
+        block_end_string: "%]"
+        comment_start_string: "[#"
+        comment_end_string: "#]"
+        variable_start_string: "[["
+        variable_end_string: "]]"
+        keep_trailing_newline: true
+    ```
 
-  You can use default Jinja syntax with:
+    You can use default Jinja syntax with:
 
-  ```yml
-  # copier.yml
-  _envops:
-    block_start_string: "{%"
-    block_end_string: "%}"
-    comment_start_string: "{#"
-    comment_end_string: "#}"
-    variable_start_string: "{{"
-    variable_end_string: "}}"
-    keep_trailing_newline: false
-  ```
+    ```yml
+    # copier.yml
+    _envops:
+        block_start_string: "{%"
+        block_end_string: "%}"
+        comment_start_string: "{#"
+        comment_end_string: "#}"
+        variable_start_string: "{{"
+        variable_end_string: "}}"
+        keep_trailing_newline: false
+    ```
 
-- **extra_paths** (list):<br> Additional paths, from where to search for templates. This
-  is intended to be used with shared parent templates, files with macros, etc. outside
-  the copied project skeleton.
+-   **extra_paths** (list):<br> Additional paths, from where to search for templates.
+    This is intended to be used with shared parent templates, files with macros, etc.
+    outside the copied project skeleton.
 
-- **pretend** (bool):<br> Run but do not make any changes.
+-   **pretend** (bool):<br> Run but do not make any changes.
 
-- **force** (bool):<br> Overwrite files that already exist, without asking.
+-   **force** (bool):<br> Overwrite files that already exist, without asking.
 
-- **skip** (bool):<br> Skip files that already exist, without asking.
+-   **skip** (bool):<br> Skip files that already exist, without asking.
 
-- **quiet** (bool):<br> Suppress the status output.
+-   **quiet** (bool):<br> Suppress the status output.
 
-- **cleanup_on_error** (bool):<br> Remove the destination folder if the copy process or
-  one of the tasks fails. True by default.
+-   **cleanup_on_error** (bool):<br> Remove the destination folder if the copy process
+    or one of the tasks fails. True by default.
 
-- **subdirectory** (str):<br> Path to a sub-folder to use as the root of the template
-  when generating the project. If not specified, the root of the git repository is used.
+-   **subdirectory** (str):<br> Path to a sub-folder to use as the root of the template
+    when generating the project. If not specified, the root of the git repository is
+    used.

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -30,9 +30,9 @@ The `copier.yml` (or `copier.yaml`) file is found in the root of the template, a
 the main entrypoint for managing your template configuration. It will be read and used
 for two purposes:
 
-- [Prompting the user for information](#questions).
-- [Applying template settings](#available-settings) (excluding files, setting arguments
-  defaults, etc.).
+-   [Prompting the user for information](#questions).
+-   [Applying template settings](#available-settings) (excluding files, setting
+    arguments defaults, etc.).
 
 ### Questions
 
@@ -65,77 +65,77 @@ to ask users for data. To use it, the value must be a dict.
 
 Supported keys:
 
-- **type**: User input must match this type. Options are: `bool`, `float`, `int`,
-  `json`, `str`, `yaml` (default).
-- **help**: Additional text to help the user know what's this question for.
-- **choices**: To restrict possible values.
-- **default**: Leave empty to force the user to answer. Provide a default to save him
-  from typing it if it's quite common. When using **choices**, the default must be the
-  choice _value_, not its _key_. If values are quite long, you can use
-  [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html).
+-   **type**: User input must match this type. Options are: `bool`, `float`, `int`,
+    `json`, `str`, `yaml` (default).
+-   **help**: Additional text to help the user know what's this question for.
+-   **choices**: To restrict possible values.
+-   **default**: Leave empty to force the user to answer. Provide a default to save him
+    from typing it if it's quite common. When using **choices**, the default must be the
+    choice _value_, not its _key_. If values are quite long, you can use
+    [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html).
 
 ```yaml
 love_copier:
-  type: bool # This makes Copier ask for y/n
-  help: Do you love Copier?
-  default: yes # Without a default, you force the user to answer
+    type: bool # This makes Copier ask for y/n
+    help: Do you love Copier?
+    default: yes # Without a default, you force the user to answer
 
 project_name:
-  type: str # Any value will be treated raw as a string
-  help: An awesome project needs an awesome name. Tell me yours.
-  default: paradox-specifier
+    type: str # Any value will be treated raw as a string
+    help: An awesome project needs an awesome name. Tell me yours.
+    default: paradox-specifier
 
 rocket_launch_password:
-  type: str
-  secret: true # This value will not be logged into .copier-answers.yml
-  default: my top secret password
+    type: str
+    secret: true # This value will not be logged into .copier-answers.yml
+    default: my top secret password
 
 # I'll avoid default and help here, but you can use them too
 age:
-  type: int
+    type: int
 
 height:
-  type: float
+    type: float
 
 any_json:
-  help: Tell me anything, but format it as a one-line JSON string
-  type: json
+    help: Tell me anything, but format it as a one-line JSON string
+    type: json
 
 any_yaml:
-  help: Tell me anything, but format it as a one-line YAML string
-  type: yaml # This is the default type, also for short syntax questions
+    help: Tell me anything, but format it as a one-line YAML string
+    type: yaml # This is the default type, also for short syntax questions
 
 your_favorite_book:
-  # User will type 1 or 2, but your template will get the value
-  choices:
-    - The Bible
-    - The Hitchhiker's Guide to the Galaxy
+    # User will type 1 or 2, but your template will get the value
+    choices:
+        - The Bible
+        - The Hitchhiker's Guide to the Galaxy
 
 project_license:
-  # User will type 1 or 2 and will see only the dict key, but you will
-  # get the dict value in your template
-  choices:
-    MIT: &mit_text |
-      Here I can write the full text of the MIT license.
-      This will be a long text, shortened here for example purposes.
-    Apache2: |
-      Full text of Apache2 license.
-  # When using choices, the default value is the value, **not** the key;
-  # that's why I'm using the YAML anchor declared above to avoid retyping the
-  # whole license
-  default: *mit_text
-  # You can still define the type, to make sure answers that come from --data
-  # CLI argument match the type that your template expects
-  type: str
+    # User will type 1 or 2 and will see only the dict key, but you will
+    # get the dict value in your template
+    choices:
+        MIT: &mit_text |
+            Here I can write the full text of the MIT license.
+            This will be a long text, shortened here for example purposes.
+        Apache2: |
+            Full text of Apache2 license.
+    # When using choices, the default value is the value, **not** the key;
+    # that's why I'm using the YAML anchor declared above to avoid retyping the
+    # whole license
+    default: *mit_text
+    # You can still define the type, to make sure answers that come from --data
+    # CLI argument match the type that your template expects
+    type: str
 
 close_to_work:
-  help: Do you live close to your work?
-  # This format works just like the dict one
-  choices:
-    - [at home, I work at home]
-    - [less than 10km, quite close]
-    - [more than 10km, not so close]
-    - [more than 100km, quite far away]
+    help: Do you live close to your work?
+    # This format works just like the dict one
+    choices:
+        - [at home, I work at home]
+        - [less than 10km, quite close]
+        - [more than 10km, not so close]
+        - [more than 100km, quite far away]
 ```
 
 #### Prompt templating
@@ -152,42 +152,42 @@ cannot use Jinja templating in your answers.
 ```yaml
 # default
 username:
-  type: str
+    type: str
 
 organization:
-  type: str
+    type: str
 
 email:
-  type: str
-  # Notice that both `username` and `organization` have been already asked
-  default: "[[ username ]]@[[ organization ]].com"
+    type: str
+    # Notice that both `username` and `organization` have been already asked
+    default: "[[ username ]]@[[ organization ]].com"
 
 # help
 copyright_holder:
-  type: str
-  help: The person or entity within [[ organization ]] that holds copyrights.
+    type: str
+    help: The person or entity within [[ organization ]] that holds copyrights.
 
 # type
 target:
-  type: str
-  choices:
-    - humans
-    - machines
+    type: str
+    choices:
+        - humans
+        - machines
 
 user_config:
-  type: "[% if target == 'humans' %]yaml[% else %]json[% endif %]"
+    type: "[% if target == 'humans' %]yaml[% else %]json[% endif %]"
 
 # choices
 title:
-  type: str
-  help: Your title within [[ organization ]]
+    type: str
+    help: Your title within [[ organization ]]
 
 contact:
-  choices:
-    Copyright holder: "[[ copyright_holder ]]"
-    CEO: Alice Bob
-    CTO: Carl Dave
-    "[[ title ]]": "[[ username ]]"
+    choices:
+        Copyright holder: "[[ copyright_holder ]]"
+        CEO: Alice Bob
+        CTO: Carl Dave
+        "[[ title ]]": "[[ username ]]"
 ```
 
 ### Include other YAML files
@@ -227,9 +227,9 @@ Remember that **the key must be prefixed with an underscore if you use it in
 
 ### `answers_file`
 
-- Format: `str`
-- CLI flags: `-a`, `--answers-file`
-- Default value: `.copier-answers.yml`
+-   Format: `str`
+-   CLI flags: `-a`, `--answers-file`
+-   Default value: `.copier-answers.yml`
 
 File where answers will be recorded by default. Remember to add that file to your Git
 template if you want to support updates.
@@ -244,9 +244,9 @@ _answers_file: .my-custom-answers.yml
 
 ### `data`
 
-- Format: `dict|List[str=str]`
-- CLI flags: `-d`, `--data`
-- Default value: N/A
+-   Format: `dict|List[str=str]`
+-   CLI flags: `-d`, `--data`
+-   Default value: N/A
 
 Give answers to questions through CLI/API.
 
@@ -262,10 +262,10 @@ copier -fd 'user_name=Manuel Calavera' copy template destination
 
 ### `exclude`
 
-- Format: `List[str]`
-- CLI flags: `-x`, `--exclude`
-- Default value:
-  `["copier.yaml", "copier.yml", "~*", "*.py[co]", "__pycache__", ".git", ".DS_Store", ".svn"]`
+-   Format: `List[str]`
+-   CLI flags: `-x`, `--exclude`
+-   Default value:
+    `["copier.yaml", "copier.yml", "~*", "*.py[co]", "__pycache__", ".git", ".DS_Store", ".svn"]`
 
 [Patterns](#patterns-syntax) for files/folders that must not be copied.
 
@@ -275,8 +275,8 @@ Example `copier.yml`:
 
 ```yaml
 _exclude:
-  - "*.bar"
-  - ".git"
+    - "*.bar"
+    - ".git"
 ```
 
 Example CLI usage to copy only a single file from the template:
@@ -287,9 +287,9 @@ copier --exclude '*' --exclude '!file-i-want' copy template destination
 
 ### `extra_paths`
 
-- Format: `List[str]`
-- CLI flags: `-p`, `--extra-paths`
-- Default value: N/A
+-   Format: `List[str]`
+-   CLI flags: `-p`, `--extra-paths`
+-   Default value: N/A
 
 Additional paths from where to search for templates.
 
@@ -297,14 +297,14 @@ Example `copier.yml`:
 
 ```yaml
 _extra_paths:
-  - ~/Projects/templates
+    - ~/Projects/templates
 ```
 
 ### `force`
 
-- Format: `bool`
-- CLI flags: `-q`, `--force`
-- Default value: `False`
+-   Format: `bool`
+-   CLI flags: `-q`, `--force`
+-   Default value: `False`
 
 Overwrite files that already exist, without asking.
 
@@ -315,20 +315,20 @@ It makes no sense to define this in `copier.yml`.
 
 ### `migrations`
 
-- Format: `List[dict]`
-- CLI flags: N/A
-- Default value: N/A
+-   Format: `List[dict]`
+-   CLI flags: N/A
+-   Default value: N/A
 
 Migrations are like [tasks](#tasks), but each item in the list is a `dict` with these
 keys:
 
-- **version**: Indicates the version that the template update has to go through to
-  trigger this migration. It is evaluated using
-  [PEP 440](https://www.python.org/dev/peps/pep-0440/).
-- **before** (optional): Commands to execute before performing the update. The answers
-  file is reloaded after running migrations in this stage, to let you migrate answer
-  values.
-- **after** (optional): Commands to execute after performing the update.
+-   **version**: Indicates the version that the template update has to go through to
+    trigger this migration. It is evaluated using
+    [PEP 440](https://www.python.org/dev/peps/pep-0440/).
+-   **before** (optional): Commands to execute before performing the update. The answers
+    file is reloaded after running migrations in this stage, to let you migrate answer
+    values.
+-   **after** (optional): Commands to execute after performing the update.
 
 Migrations will run in the same order as declared here (so you could even run a
 migration for a higher version before running a migration for a lower version if the
@@ -347,20 +347,20 @@ Example `copier.yml`:
 
 ```yaml
 _migrations:
-  - version: v1.0.0
-    before:
-      - rm ./old-folder
-    after:
-      # [[ _copier_conf.src_path ]] points to the path where the template was
-      # cloned, so it can be helpful to run migration scripts stored there.
-      - invoke -r [[ _copier_conf.src_path ]] -c migrations migrate $VERSION_CURRENT
+    - version: v1.0.0
+      before:
+          - rm ./old-folder
+      after:
+          # [[ _copier_conf.src_path ]] points to the path where the template was
+          # cloned, so it can be helpful to run migration scripts stored there.
+          - invoke -r [[ _copier_conf.src_path ]] -c migrations migrate $VERSION_CURRENT
 ```
 
 ### `min_copier_version`
 
-- Format: `str`
-- CLI flags: N/A
-- Default value: N/A
+-   Format: `str`
+-   CLI flags: N/A
+-   Default value: N/A
 
 Specifies the minimum required version of Copier to generate a project from this
 template. The version must be follow the
@@ -376,9 +376,9 @@ _min_copier_version: "4.1.0"
 
 ### `pretend`
 
-- Format: `bool`
-- CLI flags: `-q`, `--pretend`
-- Default value: `False`
+-   Format: `bool`
+-   CLI flags: `-q`, `--pretend`
+-   Default value: `False`
 
 Run but do not make any changes.
 
@@ -386,9 +386,9 @@ It makes no sense to define this in `copier.yml`.
 
 ### `quiet`
 
-- Format: `bool`
-- CLI flags: `-q`, `--quiet`
-- Default value: `False`
+-   Format: `bool`
+-   CLI flags: `-q`, `--quiet`
+-   Default value: `False`
 
 Suppress status output.
 
@@ -396,9 +396,9 @@ It makes no sense to define this in `copier.yml`.
 
 ### `skip_if_exists`
 
-- Format: `List[str]`
-- CLI flags: `-s`, `--skip`
-- Default value: N/A
+-   Format: `List[str]`
+-   CLI flags: `-s`, `--skip`
+-   Default value: N/A
 
 [Patterns](#patterns-syntax) for files/folders that must be skipped if they already
 exist.
@@ -418,9 +418,9 @@ _skip_if_exists: .secret_password.yml
 
 ### `subdirectory`
 
-- Format: `str`
-- CLI flags: `-b`, `--subdirectory`
-- Default value: N/A
+-   Format: `str`
+-   CLI flags: `-b`, `--subdirectory`
+-   Default value: N/A
 
 Subdirectory to use as the template root when generating a project. If not specified,
 the root of the template is used.
@@ -439,9 +439,9 @@ copier --subdirectory template2 -b copy template destination
 
 ### `tasks`
 
-- Format: `List[str|List[str]]`
-- CLI flags: N/A
-- Default value: N/A
+-   Format: `List[str|List[str]]`
+-   CLI flags: N/A
+-   Default value: N/A
 
 Commands to execute after generating or updating a project from your template.
 
@@ -453,21 +453,21 @@ Example `copier.yml`:
 
 ```yaml
 _tasks:
-  # Strings get executed under system's default shell
-  - "git init"
-  - "rm [[ name_of_the_project ]]/README.md"
-  # Arrays are executed without shell, saving you the work of escaping arguments
-  - [invoke, "--search-root=[[ _copier_conf.src_path ]]", after-copy]
-  # You are able to output the full conf to JSON, to be parsed by your script,
-  # but you cannot use the normal `|tojson` filter; instead, use `.json()`
-  - [invoke, end-process, "--full-conf=[[ _copier_conf.json() ]]"]
+    # Strings get executed under system's default shell
+    - "git init"
+    - "rm [[ name_of_the_project ]]/README.md"
+    # Arrays are executed without shell, saving you the work of escaping arguments
+    - [invoke, "--search-root=[[ _copier_conf.src_path ]]", after-copy]
+    # You are able to output the full conf to JSON, to be parsed by your script,
+    # but you cannot use the normal `|tojson` filter; instead, use `.json()`
+    - [invoke, end-process, "--full-conf=[[ _copier_conf.json() ]]"]
 ```
 
 ### `templates_suffix`
 
-- Format: `str`
-- CLI flags: N/A
-- Default value: `.tmpl`
+-   Format: `str`
+-   CLI flags: N/A
+-   Default value: `.tmpl`
 
 Suffix that instructs which files are to be processed by Jinja as templates.
 
@@ -479,9 +479,9 @@ _templates_suffix: .jinja
 
 ### `vcs_ref`
 
-- Format: `str`
-- CLI flags: `-r`, `-vcs-ref`
-- Default value: N/A (use latest release)
+-   Format: `str`
+-   CLI flags: `-r`, `-vcs-ref`
+-   Default value: N/A (use latest release)
 
 When copying or updating from a git-versioned template, indicate which template version
 to copy.
@@ -510,10 +510,10 @@ files ending with `txt` from being copied to the destination folder, except the 
 
 ```yaml
 _exclude:
-  # match all text files...
-  - "*.txt"
-  # .. but not this one:
-  - "!a.txt"
+    # match all text files...
+    - "*.txt"
+    # .. but not this one:
+    - "!a.txt"
 ```
 
 ## The `.copier-answers.yml` file

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -24,26 +24,26 @@ Copier includes:
 
 ### Builtin variables/functions
 
-- `now()` to get current UTC time.
-- `make_secret()` to get a random string.
-- `_copier_answers` includes the current answers dict, but slightly modified to make it
-  suitable to [autoupdate your project safely](configuring.md#the-answers-file):
-  - It doesn't contain secret answers.
-  - It doesn't contain any data that is not easy to render to JSON or YAML.
-  - It contains special keys like `_commit` and `_src_path`, indicating how the last
-    template update was done.
-- `_copier_conf` includes the current copier `ConfigData` object, also slightly
-  modified:
-  - It only contains JSON-serializable data.
-  - But you have to serialize it with `[[ _copier_conf.json() ]]` instead of
-    `[[ _copier_conf|tojson ]]`.
-  - ⚠️ It contains secret answers inside its `.data` key.
-  - Modifying it doesn't alter the current rendering configuration.
+-   `now()` to get current UTC time.
+-   `make_secret()` to get a random string.
+-   `_copier_answers` includes the current answers dict, but slightly modified to make
+    it suitable to [autoupdate your project safely](configuring.md#the-answers-file):
+    -   It doesn't contain secret answers.
+    -   It doesn't contain any data that is not easy to render to JSON or YAML.
+    -   It contains special keys like `_commit` and `_src_path`, indicating how the last
+        template update was done.
+-   `_copier_conf` includes the current copier `ConfigData` object, also slightly
+    modified:
+    -   It only contains JSON-serializable data.
+    -   But you have to serialize it with `[[ _copier_conf.json() ]]` instead of
+        `[[ _copier_conf|tojson ]]`.
+    -   ⚠️ It contains secret answers inside its `.data` key.
+    -   Modifying it doesn't alter the current rendering configuration.
 
 ### Builtin filters
 
-- `anything|to_nice_yaml` to print as pretty-formatted YAML.
+-   `anything|to_nice_yaml` to print as pretty-formatted YAML.
 
-  Without arguments it defaults to:
-  `anything|to_nice_yaml(indent=2, width=80, allow_unicode=True)`, but you can modify
-  those.
+    Without arguments it defaults to:
+    `anything|to_nice_yaml(indent=2, width=80, allow_unicode=True)`, but you can modify
+    those.

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -18,8 +18,8 @@ copier.copy("path/to/project/template", "path/to/destination")
 
 The "template" parameter can be a local path, an URL, or a shortcut URL:
 
-- GitHub: `gh:namespace/project`
-- GitLab: `gl:namespace/project`
+-   GitHub: `gh:namespace/project`
+-   GitLab: `gl:namespace/project`
 
 Use the `--data` command-line argument or the `data` parameter of the `copier.copy()`
 function to pass whatever extra context you want to be available in the templates. The

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -34,11 +34,11 @@ this:
 ```yaml
 # .pre-commit-config.yaml
 repos:
-  - repo: local
-    hooks:
-      - id: forbidden-files
-        name: forbidden files
-        entry: found copier update rejection files; review them and remove them
-        language: fail
-        files: "\\.rej$"
+    - repo: local
+      hooks:
+          - id: forbidden-files
+            name: forbidden files
+            entry: found copier update rejection files; review them and remove them
+            language: fail
+            files: "\\.rej$"
 ```


### PR DESCRIPTION
Mkdocs uses `python-markdown`, and [they say](https://python-markdown.github.io/#differences):

> The syntax rules clearly state that when a list item consists of multiple paragraphs, “each subsequent paragraph in a list item must be indented by either 4 spaces or one tab” (emphasis added). However, many implementations do not enforce this rule and allow less than 4 spaces of indentation. The implementers of Python-Markdown consider it a bug to not enforce this rule.

As we were using 2 spaces for markdown files (which looks better in source code), some indented lists were not displaying properly in the docs page.

Thus I change the setting to 4 spaces. Prettier will now enforce them, and mkdocs will display things properly.

![imagen](https://user-images.githubusercontent.com/973709/89782905-fd5cda00-db0d-11ea-8b78-e1b2f71d74ef.png)
![2020-08-10_13-34](https://user-images.githubusercontent.com/973709/89783064-3ac16780-db0e-11ea-840e-52a04e5c0fbd.png)
