### PR TITLE
Allow to trigger CI manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
     branches: [master]
   release:
     types: [created]
+  workflow_dispatch: {}
+
 env:
   LANG: "en_US.utf-8"
   LC_ALL: "en_US.utf-8"

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -5,6 +5,7 @@ name: Coverage
 on:
   push:
     branches: [master]
+  workflow_dispatch: {}
 
 jobs:
   upload-coverage:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # ![Copier](https://github.com/copier-org/copier/raw/master/img/copier-logotype.png)
 
 [![codecov](https://codecov.io/gh/copier-org/copier/branch/master/graph/badge.svg)](https://codecov.io/gh/copier-org/copier)
-![](https://github.com/copier-org/copier/workflows/CI/badge.svg)
+[![CI](https://github.com/copier-org/copier/workflows/CI/badge.svg)](https://github.com/copier-org/copier/actions?query=branch%3Amaster)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 ![](https://img.shields.io/pypi/pyversions/copier)
 ![](https://img.shields.io/pypi/v/copier)


### PR DESCRIPTION
This is needed to test the master branch if it was automerged (which doesn't trigger workflows).

Also I fixed the link for that CI badge.