### PR TITLE
Better docs for CLI

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -374,6 +374,22 @@ Example `copier.yml`:
 _min_copier_version: "4.1.0"
 ```
 
+### `only_diff`
+
+-   Format: `bool`
+-   CLI flags: `-D`, `--no-diff` (used to disable this setting; only available in
+    `copier update` subcommand)
+-   Default value: `True`
+
+When doing an update, by default Copier will do its best to understand how the template
+has evolved since the last time you updated it, and will try to apply only that diff to
+your subproject, respecting the subproject's own evolution as much as possible.
+
+Update with `only_diff=False` to avoid this behavior and let Copier override any changes
+in the subproject.
+
+It makes no sense to define this in `copier.yml`.
+
 ### `pretend`
 
 -   Format: `bool`

--- a/poetry.lock
+++ b/poetry.lock
@@ -59,7 +59,7 @@ version = "0.2.0"
 category = "main"
 description = "Screen-scraping library"
 name = "beautifulsoup4"
-optional = true
+optional = false
 python-versions = "*"
 version = "4.9.1"
 
@@ -244,7 +244,7 @@ pycodestyle = "*"
 category = "main"
 description = "Clean single-source support for Python 3 and 2"
 name = "future"
-optional = true
+optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "0.18.2"
 
@@ -392,7 +392,7 @@ category = "main"
 description = "Lightweight pipelining: using Python functions as pipeline jobs."
 marker = "python_version > \"2.7\""
 name = "joblib"
-optional = true
+optional = false
 python-versions = ">=3.6"
 version = "0.16.0"
 
@@ -400,7 +400,7 @@ version = "0.16.0"
 category = "main"
 description = "Python LiveReload is an awesome tool for web developers"
 name = "livereload"
-optional = true
+optional = false
 python-versions = "*"
 version = "2.6.2"
 
@@ -415,7 +415,7 @@ version = "*"
 category = "main"
 description = "A Python implementation of Lunr.js"
 name = "lunr"
-optional = true
+optional = false
 python-versions = "*"
 version = "0.5.8"
 
@@ -435,7 +435,7 @@ languages = ["nltk (>=3.2.5,<3.5)", "nltk (>=3.2.5)"]
 category = "main"
 description = "Python implementation of Markdown."
 name = "markdown"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "3.2.2"
 
@@ -467,7 +467,7 @@ version = "0.6.1"
 category = "main"
 description = "Project documentation with Markdown."
 name = "mkdocs"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.1.2"
 
@@ -487,9 +487,9 @@ version = "0.5.8"
 category = "main"
 description = "A Material Design theme for MkDocs"
 name = "mkdocs-material"
-optional = true
+optional = false
 python-versions = "*"
-version = "5.5.2"
+version = "5.5.5"
 
 [package.dependencies]
 Pygments = ">=2.4"
@@ -502,7 +502,7 @@ pymdown-extensions = ">=7.0"
 category = "main"
 description = "Extension pack for Python Markdown."
 name = "mkdocs-material-extensions"
-optional = true
+optional = false
 python-versions = ">=3.5"
 version = "1.0"
 
@@ -513,7 +513,7 @@ mkdocs-material = ">=5.0.0"
 category = "main"
 description = "Automatic documentation from sources, for MkDocs."
 name = "mkdocstrings"
-optional = true
+optional = false
 python-versions = ">=3.6,<4.0"
 version = "0.12.2"
 
@@ -560,7 +560,7 @@ category = "main"
 description = "Natural Language Toolkit"
 marker = "python_version > \"2.7\""
 name = "nltk"
-optional = true
+optional = false
 python-versions = "*"
 version = "3.5"
 
@@ -762,7 +762,7 @@ version = "2.6.1"
 category = "main"
 description = "Extension pack for Python Markdown."
 name = "pymdown-extensions"
-optional = true
+optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 version = "7.1"
 
@@ -863,7 +863,7 @@ testing = ["filelock"]
 category = "main"
 description = "Load Python objects documentation."
 name = "pytkdocs"
-optional = true
+optional = false
 python-versions = ">=3.6,<4.0"
 version = "0.7.0"
 
@@ -891,7 +891,7 @@ all = ["toml"]
 toml = ["toml"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Alternative regular expression module, to replace re."
 name = "regex"
 optional = false
@@ -910,7 +910,7 @@ version = "1.15.0"
 category = "main"
 description = "A modern CSS selector implementation for Beautiful Soup."
 name = "soupsieve"
-optional = true
+optional = false
 python-versions = "*"
 version = "1.9.6"
 
@@ -926,7 +926,7 @@ version = "0.10.1"
 category = "main"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 name = "tornado"
-optional = true
+optional = false
 python-versions = ">= 3.5"
 version = "6.0.4"
 
@@ -935,7 +935,7 @@ category = "main"
 description = "Fast, Extensible Progress Meter"
 marker = "python_version > \"2.7\""
 name = "tqdm"
-optional = true
+optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 version = "4.48.1"
 
@@ -1027,7 +1027,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 docs = ["mkdocs", "mkdocstrings", "mkdocs-material"]
 
 [metadata]
-content-hash = "fd11d6ca7f81e5d73c3a0d41bcbf4827db0ec7eca12f48372006ad060ff8d7a2"
+content-hash = "321a33f34540934e7ae3be15dd616764f62b40ee60a5509d065047071bd4c1ee"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -1249,8 +1249,8 @@ mkdocs = [
     {file = "mkdocs-1.1.2.tar.gz", hash = "sha256:f0b61e5402b99d7789efa032c7a74c90a20220a9c81749da06dbfbcbd52ffb39"},
 ]
 mkdocs-material = [
-    {file = "mkdocs-material-5.5.2.tar.gz", hash = "sha256:48fe20256fddf4a45a0db76d14c1e3b2e631d48e1868b2939b98c0dcdabbea6f"},
-    {file = "mkdocs_material-5.5.2-py2.py3-none-any.whl", hash = "sha256:362f4e04b381622f004ba146b533686766370cb19a98c917763a4cf5698dca7f"},
+    {file = "mkdocs-material-5.5.5.tar.gz", hash = "sha256:22fa5d626c55f8019f54633f76a244f920d5b5cd79f10b21db85e64ad4255a1d"},
+    {file = "mkdocs_material-5.5.5-py2.py3-none-any.whl", hash = "sha256:9f4dde07196726a06139c37af7851059d6b3cb4e3236a44c6ea11ad3ef41aa2b"},
 ]
 mkdocs-material-extensions = [
     {file = "mkdocs-material-extensions-1.0.tar.gz", hash = "sha256:17d7491e189af75700310b7ec33c6c48a22060b8b445001deca040cb60471cde"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,11 @@ pyyaml = "^5.3.1"
 pyyaml-include = "^1.2"
 # packaging is needed when installing from PyPI
 packaging = "^20.4"
-mkdocs = {version = "^1.1.2", optional = true}
 mkdocstrings = {version = "^0.12.2", optional = true}
 mkdocs-material = {version = "^5.5.2", optional = true}
 
 [tool.poetry.extras]
-docs = ["mkdocs", "mkdocstrings", "mkdocs-material"]
+docs = ["mkdocstrings", "mkdocs-material"]
 
 [tool.poetry.dev-dependencies]
 black = {version = "^19.10b0", allow-prereleases = true}
@@ -59,6 +58,11 @@ pytest = "*"
 pytest-cov = "*"
 pytest-xdist = "*"
 pytest-timeout = "^1.4.1"
+
+# HACK https://github.com/python-poetry/poetry/issues/2555
+# TODO Remove from this section and install with poetry install -E docs when fixed
+mkdocstrings = "^0.12.2"
+mkdocs-material = "^5.5.5"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION


- Add `only_diff` docs.
- Link CLI docs with those from configuration.
- Add link on `copier --help` to the docs.
- Include `copier --help-all` in the online docs.

---

Inclues this commit too:

Add docs dependencies to dev dependencies 



This is a workaround for python-poetry/poetry#2555 that should be reverted after it's fixed and a new poetry is released.

