### PR TITLE
Add --prereleases support

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -57,6 +57,7 @@ class CopierApp(cli.Application):
         pretend: Set [pretend][] option.
         force: Set [force][] option.
         skip: Set [skip_if_exists][] option.
+        prereleases: Set [use_prereleases][] option.
         quiet: Set [quiet][] option.
     """
 
@@ -140,6 +141,9 @@ class CopierApp(cli.Application):
         ["-s", "--skip"], help="Skip files that already exist, without asking"
     )
     quiet: cli.Flag = cli.Flag(["-q", "--quiet"], help="Suppress status output")
+    prereleases: cli.Flag = cli.Flag(
+        ["-g", "--prereleases"], help="Use prereleases to compare template VCS tags.",
+    )
 
     @cli.switch(
         ["-d", "--data"],
@@ -179,6 +183,7 @@ class CopierApp(cli.Application):
             src_path=src_path,
             vcs_ref=self.vcs_ref,
             subdirectory=self.subdirectory,
+            use_prereleases=self.prereleases,
             **kwargs,
         )
 

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -65,6 +65,7 @@ def make_config(
     cleanup_on_error: OptBool = None,
     vcs_ref: OptStr = None,
     subdirectory: OptStr = None,
+    use_prereleases: OptBool = False,
     **kwargs,
 ) -> ConfigData:
     """Provides the configuration object, merged from the different sources.
@@ -93,7 +94,7 @@ def make_config(
         repo = vcs.get_repo(src_path)
         if repo:
             src_path = vcs.clone(repo, vcs_ref or "HEAD")
-            vcs_ref = vcs_ref or vcs.checkout_latest_tag(src_path)
+            vcs_ref = vcs_ref or vcs.checkout_latest_tag(src_path, use_prereleases)
             with local.cwd(src_path):
                 init_args["commit"] = git("describe", "--tags", "--always").strip()
         init_args["src_path"] = src_path

--- a/copier/config/objects.py
+++ b/copier/config/objects.py
@@ -86,6 +86,7 @@ class ConfigData(BaseModel):
     pretend: StrictBool = False
     quiet: StrictBool = False
     skip: StrictBool = False
+    use_prereleases: StrictBool = False
     vcs_ref: OptStr
     migrations: Sequence[Migrations] = ()
     secret_questions: StrSeq = ()

--- a/copier/main.py
+++ b/copier/main.py
@@ -58,6 +58,7 @@ def copy(
     vcs_ref: OptStr = None,
     only_diff: OptBool = True,
     subdirectory: OptStr = None,
+    use_prereleases: OptBool = False,
 ) -> None:
     """
     Uses the template in `src_path` to generate a new project at `dst_path`.
@@ -125,6 +126,8 @@ def copy(
 
         subdirectory:
             Specify a subdirectory to use when generating the project.
+
+        use_prereleases: See [use_prereleases][].
     """
     conf = make_config(**locals())
     is_update = conf.original_src_path != conf.src_path and vcs.is_git_repo_root(

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -311,7 +311,9 @@ Overwrite files that already exist, without asking.
 Also don't ask questions to the user; just use default values
 [obtained from other sources](#configuration-sources).
 
-It makes no sense to define this in `copier.yml`.
+Info:
+
+    It makes no sense to define this in `copier.yml`.
 
 ### `migrations`
 
@@ -398,7 +400,9 @@ It makes no sense to define this in `copier.yml`.
 
 Run but do not make any changes.
 
-It makes no sense to define this in `copier.yml`.
+Info:
+
+    It makes no sense to define this in `copier.yml`.
 
 ### `quiet`
 
@@ -408,7 +412,9 @@ It makes no sense to define this in `copier.yml`.
 
 Suppress status output.
 
-It makes no sense to define this in `copier.yml`.
+Info:
+
+    It makes no sense to define this in `copier.yml`.
 
 ### `skip_if_exists`
 
@@ -493,6 +499,29 @@ Example `copier.yml`:
 _templates_suffix: .jinja
 ```
 
+### `use_prereleases`
+
+-   Format: `bool`
+-   CLI flags: `g`, `--prereleases`
+-   Default value: `False`
+
+Imagine that the template supports updates and contains these 2 git tags: `v1.0.0` and
+`v2.0.0a1`. Copier will copy by default `v1.0.0` unless you add `--prereleases`.
+
+<!-- prettier-ignore-start -->
+Also, if you run [`copier update`][copier.cli.CopierUpdateSubApp], Copier would ignore
+the `v2.0.0a1` tag unless this flag is enabled.
+<!-- prettier-ignore-end -->
+
+Warning:
+
+    This behavior is new from Copier 5.0.0. Before that release, prereleases were never
+    ignored.
+
+Info:
+
+    It makes no sense to define this in `copier.yml`.
+
 ### `vcs_ref`
 
 -   Format: `str`
@@ -508,7 +537,9 @@ This is stored automatically in the answers file, like this:
 _vcs_ref: v1.0.0
 ```
 
-It makes no sense to define this in `copier.yml`.
+Info:
+
+    It makes no sense to define this in `copier.yml`.
 
 By default, copier will copy from the last release found in template git tags, sorted as
 [PEP 440](https://www.python.org/dev/peps/pep-0440/).

--- a/poetry.lock
+++ b/poetry.lock
@@ -489,7 +489,7 @@ description = "A Material Design theme for MkDocs"
 name = "mkdocs-material"
 optional = false
 python-versions = "*"
-version = "5.5.5"
+version = "5.5.6"
 
 [package.dependencies]
 Pygments = ">=2.4"
@@ -937,7 +937,7 @@ marker = "python_version > \"2.7\""
 name = "tqdm"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
-version = "4.48.1"
+version = "4.48.2"
 
 [package.extras]
 dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
@@ -981,7 +981,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.29"
+version = "20.0.30"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -1024,10 +1024,10 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [extras]
-docs = ["mkdocs", "mkdocstrings", "mkdocs-material"]
+docs = ["mkdocstrings", "mkdocs-material", "pymdown-extensions"]
 
 [metadata]
-content-hash = "321a33f34540934e7ae3be15dd616764f62b40ee60a5509d065047071bd4c1ee"
+content-hash = "3e912cd9956127a2e8019fe88e1d20b6643c37a19bffbbcd2df05a1fc7bc3a95"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -1249,8 +1249,8 @@ mkdocs = [
     {file = "mkdocs-1.1.2.tar.gz", hash = "sha256:f0b61e5402b99d7789efa032c7a74c90a20220a9c81749da06dbfbcbd52ffb39"},
 ]
 mkdocs-material = [
-    {file = "mkdocs-material-5.5.5.tar.gz", hash = "sha256:22fa5d626c55f8019f54633f76a244f920d5b5cd79f10b21db85e64ad4255a1d"},
-    {file = "mkdocs_material-5.5.5-py2.py3-none-any.whl", hash = "sha256:9f4dde07196726a06139c37af7851059d6b3cb4e3236a44c6ea11ad3ef41aa2b"},
+    {file = "mkdocs-material-5.5.6.tar.gz", hash = "sha256:08af704cdfaf2a07fd5f135831df9106c589bfd422f9ef026929981433e80b9d"},
+    {file = "mkdocs_material-5.5.6-py2.py3-none-any.whl", hash = "sha256:29f3637d5fb758d076344b026a67b8e316743d0c2da84b9303383f6cbeabfd5f"},
 ]
 mkdocs-material-extensions = [
     {file = "mkdocs-material-extensions-1.0.tar.gz", hash = "sha256:17d7491e189af75700310b7ec33c6c48a22060b8b445001deca040cb60471cde"},
@@ -1461,8 +1461,8 @@ tornado = [
     {file = "tornado-6.0.4.tar.gz", hash = "sha256:0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc"},
 ]
 tqdm = [
-    {file = "tqdm-4.48.1-py2.py3-none-any.whl", hash = "sha256:44b896c38f70f91826a3f83a3195b23c0460322bfc729566ec8e4e89bb5ad713"},
-    {file = "tqdm-4.48.1.tar.gz", hash = "sha256:7b7dd59cd9f03b89365ba67eb8515f5d2803fd1eb707abdbb914691a3123d9df"},
+    {file = "tqdm-4.48.2-py2.py3-none-any.whl", hash = "sha256:1a336d2b829be50e46b84668691e0a2719f26c97c62846298dd5ae2937e4d5cf"},
+    {file = "tqdm-4.48.2.tar.gz", hash = "sha256:564d632ea2b9cb52979f7956e093e831c28d441c11751682f84c86fc46e4fd21"},
 ]
 traitlets = [
     {file = "traitlets-4.3.3-py2.py3-none-any.whl", hash = "sha256:70b4c6a1d9019d7b4f6846832288f86998aa3b9207c6821f3578a6a6a467fe44"},
@@ -1497,8 +1497,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.2.tar.gz", hash = "sha256:79ee589a3caca649a9bfd2a8de4709837400dfa00b6cc81962a1e6a1815969ae"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.29-py2.py3-none-any.whl", hash = "sha256:8aa9c37b082664dbce2236fa420759c02d64109d8e6013593ad13914718a30fd"},
-    {file = "virtualenv-20.0.29.tar.gz", hash = "sha256:f14a0a98ea4397f0d926cff950361766b6a73cd5975ae7eb259d12919f819a25"},
+    {file = "virtualenv-20.0.30-py2.py3-none-any.whl", hash = "sha256:8cd7b2a4850b003a11be2fc213e206419efab41115cc14bca20e69654f2ac08e"},
+    {file = "virtualenv-20.0.30.tar.gz", hash = "sha256:7b54fd606a1b85f83de49ad8d80dbec08e983a2d2f96685045b262ebc7481ee5"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,12 @@ pyyaml-include = "^1.2"
 packaging = "^20.4"
 mkdocstrings = {version = "^0.12.2", optional = true}
 mkdocs-material = {version = "^5.5.2", optional = true}
+# HACK https://readthedocs.org/api/v2/build/11653917.txt
+# TODO Remove this dependency when mkdocstrings supports pymdown-extensions==8.0
+pymdown-extensions = {version = "<8.0,>=6.3", optional = true}
 
 [tool.poetry.extras]
-docs = ["mkdocstrings", "mkdocs-material"]
+docs = ["mkdocstrings", "mkdocs-material", "pymdown-extensions"]
 
 [tool.poetry.dev-dependencies]
 black = {version = "^19.10b0", allow-prereleases = true}
@@ -63,6 +66,9 @@ pytest-timeout = "^1.4.1"
 # TODO Remove from this section and install with poetry install -E docs when fixed
 mkdocstrings = "^0.12.2"
 mkdocs-material = "^5.5.5"
+# HACK https://readthedocs.org/api/v2/build/11653917.txt
+# TODO Remove this dependency when mkdocstrings supports pymdown-extensions==8.0
+pymdown-extensions = "<8.0,>=6.3"
 
 [tool.poetry-dynamic-versioning]
 enable = true


### PR DESCRIPTION
Before this patch, Copier didn't ignore prereleases when detecting latest template tag.

This is mostly a bug because there's no way to safely upgrade a template to the latest non-prerelease tag automatically.

This a behavioral change that probably didn't hit anybody out there, but enough to make a new big release.