### PR TITLE
Forbid downgrades

### DIFF
--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -10,6 +10,7 @@ from plumbum import local
 from plumbum.cmd import git
 
 from copier import copy
+from copier.config.objects import UserMessageError
 
 from .helpers import PROJECT_TEMPLATE, build_file_tree
 
@@ -211,3 +212,6 @@ def test_prereleases(tmp_path: Path):
     assert (dst / "v2.dev2").exists()
     assert (dst / "v2.a1").exists()
     assert not (dst / "v2.a2").exists()
+    # It should fail if downgrading
+    with pytest.raises(UserMessageError):
+        copy(dst_path=dst, force=True)


### PR DESCRIPTION
Scenario:

1. Your project is in version `v1`.
2. You update ito `v2a1` using `--prerelease`.
3. Later, you just update without passing `--prerelease`.

Current result: Copier will try to downgrade your project to the latest normal release. Migrations do not work backwards, so this will leave your project broken.

Expected result: Copier forbids downgrading.

@Tecnativa TT23705