### PR TITLE
Allow multidoc copier.yml with glob include

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,13 @@ on:
     branches: [master]
   release:
     types: [published]
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      pytest_addopts:
+        description:
+          Extra options for pytest; use -vv for full details; see
+          https://docs.pytest.org/en/latest/example/simple.html#how-to-change-command-line-options-defaults
+        required: false
 
 env:
   LANG: "en_US.utf-8"
@@ -15,6 +21,7 @@ env:
   POETRY_CACHE_DIR: ${{ github.workspace }}/.cache/pypoetry
   POETRY_VIRTUALENVS_IN_PROJECT: "true"
   PRE_COMMIT_HOME: ${{ github.workspace }}/.cache/pre-commit
+  PYTEST_ADDOPTS: ${{ github.event.inputs.pytest_addopts }}
   PYTHONIOENCODING: "UTF-8"
 
 jobs:
@@ -77,7 +84,7 @@ jobs:
         run: poe types
       - name: Run pytest
         shell: bash
-        run: poe test --verbose .
+        run: poe test -ra .
 
   publish:
     if: github.event_name == 'release'

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -192,30 +192,42 @@ contact:
 
 ### Include other YAML files
 
-To reuse configurations across templates you can reference other yaml files. You just
-need to state the `!include` together with the absolute or relative path to the file to
-be included. Multiple files can be included per `copier.yml`. For more detailed
-instructions, see [pyyaml-include](https://github.com/tanbro/pyyaml-include#usage).
+The `copier.yml` file supports multiple documents. When found, they are merged (**not**
+deeply merged; just merged) and the latest one defined has priority.
 
-Example:
+It also supports using the `!include` tag to include other configurations from
+elsewhere.
 
-```yaml
-# other_place/include_me.yml
-common_setting: "1"
+These two features, combined, allow you to reuse common partial sections from your
+templates.
 
-# copier.yml
-!include other_place/include_me.yml
-```
+!!! hint
 
-**Warning**: You can't have in the same file a top `!include` tag and classic YAML
-syntax, see
-[this pyyaml-include issue](https://github.com/tanbro/pyyaml-include/issues/7).
+    You can use [git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
+    to sanely include shared code into templates.
 
-```yaml
-# Invalid file
-!include other_place/include_me.yml
-foo: "bar"
-```
+!!! example
+
+    This would be a valid `copier.yml` file:
+
+    ```yaml
+    ---
+    # Copier will load all these files
+    !include shared-conf/common.*.yml
+
+    # These 3 lines split the several YAML documents
+    ---
+    # These two documents include common questions for these kind of projects
+    !include common-questions/web_app.yml
+    ---
+    !include common-questions/python-project.yml
+    ---
+
+    # Here you can specify any settings or questions specific for your template,
+    _skip_if_exists:
+        - .password.txt
+    custom_question: default answer
+    ```
 
 ## Available settings
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -357,6 +357,19 @@ python-versions = "*"
 version = "0.2.0"
 
 [[package]]
+category = "main"
+description = "Utilities based on Pythons iterators and generators."
+name = "iteration-utilities"
+optional = false
+python-versions = ">=3.5"
+version = "0.10.1"
+
+[package.extras]
+all = ["pytest", "sphinx", "numpydoc"]
+doc = ["sphinx", "numpydoc"]
+test = ["pytest"]
+
+[[package]]
 category = "dev"
 description = "An autocompletion tool for Python that can be used for text editors."
 marker = "python_version >= \"3.4\""
@@ -1054,7 +1067,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 docs = ["mkdocstrings", "mkdocs-material"]
 
 [metadata]
-content-hash = "3d117e7552dc65bf20d15074ee30e04a6292090af7fabc9bff0726d2060db1a1"
+content-hash = "b3b931a58efc19984768288946c6f174244664303d587528b4e88ba9d3ce6d3f"
 lock-version = "1.0"
 python-versions = "^3.6"
 
@@ -1208,6 +1221,30 @@ ipython = [
 ipython-genutils = [
     {file = "ipython_genutils-0.2.0-py2.py3-none-any.whl", hash = "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"},
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
+]
+iteration-utilities = [
+    {file = "iteration_utilities-0.10.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:958c2aa52795d1100d9caffc3ed6aeda0e23577e3bc5694b3c8b6177c85fa57d"},
+    {file = "iteration_utilities-0.10.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:209e8a7b224445b66e8114392d7c8be7dc16a5d8d9cbdfca05592c460e037ad0"},
+    {file = "iteration_utilities-0.10.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:2fdd48be4cd26df65b7687761407e7d2cd7c9c4f50c9da2f6e0eda48d07a6523"},
+    {file = "iteration_utilities-0.10.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:a64e08b510c7599b6819a56634aa2b1049207e4402d7ff99f9d4931fd6453e0e"},
+    {file = "iteration_utilities-0.10.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:aa36a008900f3bedbb62407ffd4a5acd45f7332979a9be93a3d9f501e1fbbdb0"},
+    {file = "iteration_utilities-0.10.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6795db5161de263d606940a1994ab599ad608f6c0ff3229591776bb6898c0b8e"},
+    {file = "iteration_utilities-0.10.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:37b0f69583560f6c874b7bb7eb20ccaa6ee1a30858bee4e2d252ca6e8da744e0"},
+    {file = "iteration_utilities-0.10.1-cp36-cp36m-win32.whl", hash = "sha256:0128d3a4de0fada287304c603eee5cb09a454be7c708eee2330232791422afff"},
+    {file = "iteration_utilities-0.10.1-cp36-cp36m-win_amd64.whl", hash = "sha256:a985a46a05ff93e16966afd115c89bea5ddd8628593ac11a5208ac46ba69a120"},
+    {file = "iteration_utilities-0.10.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:fb3071c217f26f1cd3eb00f017522fb2366ce1cd8a9aa26b5786ea273faba61a"},
+    {file = "iteration_utilities-0.10.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ab514ba77e5bcde7f9950c481d4375b0a8936a96d242b3f05031bd9c4abf85cc"},
+    {file = "iteration_utilities-0.10.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:823573874438f947e003483e682d3d4e133098efbd073be03aa63f69113e957a"},
+    {file = "iteration_utilities-0.10.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:8bc6bb9ec4ac8a93dc0c6eb8eb6eab454b42dfa1f4caf9e90eb2774d6f5874c3"},
+    {file = "iteration_utilities-0.10.1-cp37-cp37m-win32.whl", hash = "sha256:20463e245382ba3ae245f106b6b5b2785461ad09d50bf7ba3e856493fea31feb"},
+    {file = "iteration_utilities-0.10.1-cp37-cp37m-win_amd64.whl", hash = "sha256:fbb7d325bf425f2a6090382b24ad3d596cbaf4cfcce826f409253116dc8f2c61"},
+    {file = "iteration_utilities-0.10.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:1ffd5c005ef6bc6f16477b97b2f45426b59a519bb4fee7439089b2c02941f8ca"},
+    {file = "iteration_utilities-0.10.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2e4b879e8ef248741eac50095e09437014e6e96768dba15bceff9689a8931c72"},
+    {file = "iteration_utilities-0.10.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:952afb5a8d41211ffde7fe88178aaf76745a9024ada7d093ce4949d905e3321c"},
+    {file = "iteration_utilities-0.10.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:e634c9d1f9f4c2276617e6c106ce7b3a36db83aa68d75a59a010a2fc242375f4"},
+    {file = "iteration_utilities-0.10.1-cp38-cp38-win32.whl", hash = "sha256:82bd428ae468b01230d5415f98373256067cf17ce7f754f031f1c7f43e322f52"},
+    {file = "iteration_utilities-0.10.1-cp38-cp38-win_amd64.whl", hash = "sha256:8233731c39d614b4939557fa409b57fe136c7570aa54d57bffe0271fe9682424"},
+    {file = "iteration_utilities-0.10.1.tar.gz", hash = "sha256:536e3e87c5c139c775f9d95bb771c4b366a1d58eb7a39436d4ac839b53742569"},
 ]
 jedi = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ copier = "copier.cli:CopierApp.run"
 [tool.poetry.dependencies]
 python = "^3.6"
 colorama = "^0.4.3"
+iteration_utilities = "^0.10.1"
 jinja2 = "^2.11.2"
 pathspec = "^0.8.0"
 plumbum = "^1.6.9"


### PR DESCRIPTION
Before this patch, using `!include` was a bit absurd because it would fail under any useful scenario:

- Including with a glob.
- Trying to include more than 1 file.

Now all those are supported, and they can coexist. Besides, the patch is quite simple, which makes it more attractive.

Fix #237.