### PR TITLE
Make exclude extend if called from CLI/API

### DIFF
--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -9,7 +9,13 @@ from plumbum.cmd import git
 
 from .. import vcs
 from ..types import AnyByStrDict, OptAnyByStrDict, OptBool, OptStr, OptStrSeq
-from .objects import ConfigData, EnvOps, NoSrcPathError, UserMessageError
+from .objects import (
+    DEFAULT_EXCLUDE,
+    ConfigData,
+    EnvOps,
+    NoSrcPathError,
+    UserMessageError,
+)
 from .user_data import load_answersfile_data, load_config_data, query_user_data
 
 __all__ = ("make_config",)
@@ -73,6 +79,7 @@ def make_config(
     The order of precedence for the merger of configuration objects is:
     function_args > user_data > defaults.
     """
+    exclude = list(exclude or [])
     # These args are provided by API or CLI call
     init_args = {k: v for k, v in locals().items() if v is not None and v != []}
     # Store different answer sources
@@ -107,6 +114,9 @@ def make_config(
         pass
 
     template_config_data, questions_data = filter_config(file_data)
+    init_args["exclude"] = (
+        list(template_config_data.get("exclude", DEFAULT_EXCLUDE)) + exclude
+    )
     init_args["data_from_template_defaults"] = {
         k: v.get("default") for k, v in questions_data.items()
     }

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -309,11 +309,25 @@ _exclude:
     - ".git"
 ```
 
+!!! info
+
+    When you define this parameter in `copier.yml`, it will **replace** the default
+    value.
+
+    In the above example, for instance, `"copier.yml"` will **not** be excluded.
+
 Example CLI usage to copy only a single file from the template:
 
 ```sh
 copier --exclude '*' --exclude '!file-i-want' copy template destination
 ```
+
+!!! info
+
+    When you add this parameter from CLI or API, it will **not replace** the values
+    defined in `copier.yml` (or the defaults, if missing).
+
+    Instead, CLI/API definitions **will extend** those from `copier.yml`.
 
 ### `extra_paths`
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -273,9 +273,15 @@ def test_make_config_good_data(tmp_path):
     "test_input, expected",
     [
         # func_args > defaults
-        ({"src_path": ".", "exclude": ["aaa"]}, {"exclude": ["aaa"]}),
+        (
+            {"src_path": ".", "exclude": ["aaa"]},
+            {"exclude": list(DEFAULT_EXCLUDE) + ["aaa"]},
+        ),
         # func_args > user_data
-        ({"src_path": "tests/demo_data", "exclude": ["aaa"]}, {"exclude": ["aaa"]}),
+        (
+            {"src_path": "tests/demo_data", "exclude": ["aaa"]},
+            {"exclude": ["exclude1", "exclude2", "aaa"]},
+        ),
     ],
 )
 def test_make_config_precedence(tmp_path, test_input, expected):


### PR DESCRIPTION

When adding the `exclude` option from CLI/API, it extends the definitions found in `copier.yml`.

When adding it in `copier.yml`, it replaces the defaults.

Fixes #215, which explains that it was very unexpected that excluding some extra things included a lot of other things by accident.