### PR TITLE
Remove --only-diff flag

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -231,7 +231,8 @@ class CopierApp(cli.Application):
 class CopierCopySubApp(cli.Application):
     """The `copier copy` subcommand.
 
-    Use this subcommand to bootstrap a new subproject from a template.
+    Use this subcommand to bootstrap a new subproject from a template, or to override
+    a preexisting subproject ignoring its history diff.
 
     Attributes:
         cleanup_on_error: Set [cleanup_on_error][] option.
@@ -259,7 +260,10 @@ class CopierCopySubApp(cli.Application):
                 Where to generate the new subproject. It must not exist or be empty.
         """
         self.parent._copy(
-            template_src, destination_path, cleanup_on_error=self.cleanup_on_error
+            template_src,
+            destination_path,
+            cleanup_on_error=self.cleanup_on_error,
+            only_diff=False,
         )
         return 0
 
@@ -270,9 +274,6 @@ class CopierUpdateSubApp(cli.Application):
 
     Use this subcommand to update an existing subproject from a template
     that supports updates.
-
-    Attributes:
-        only_diff: Set [only_diff][] option.
     """
 
     DESCRIPTION = "Update a copy from its original template"
@@ -284,12 +285,9 @@ class CopierUpdateSubApp(cli.Application):
 
         If that file contains also `_commit` and `destination_path` is a git
         repository, this command will do its best to respect the diff that you have
-        generated since the last `copier` execution. To disable that, use `--no-diff`.
+        generated since the last `copier` execution. To avoid that, use `copier copy`
+        instead.
         """
-    )
-
-    only_diff: cli.Flag = cli.Flag(
-        ["-D", "--no-diff"], default=True, help="Disable smart diff detection."
     )
 
     @handle_exceptions
@@ -305,7 +303,7 @@ class CopierUpdateSubApp(cli.Application):
                 working directory is used.
         """
         self.parent._copy(
-            dst_path=destination_path, only_diff=self.only_diff,
+            dst_path=destination_path, only_diff=True,
         )
         return 0
 

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -70,6 +70,7 @@ def make_config(
     quiet: OptBool = None,
     cleanup_on_error: OptBool = None,
     vcs_ref: OptStr = None,
+    only_diff: OptBool = True,
     subdirectory: OptStr = None,
     use_prereleases: OptBool = False,
     **kwargs,

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -423,8 +423,7 @@ _min_copier_version: "4.1.0"
 ### `only_diff`
 
 -   Format: `bool`
--   CLI flags: `-D`, `--no-diff` (used to disable this setting; only available in
-    `copier update` subcommand)
+-   CLI flags: Just use `copier copy` to disable it, or `copier update` to enable it.
 -   Default value: `True`
 
 When doing an update, by default Copier will do its best to understand how the template

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -139,6 +139,25 @@ def test_updatediff(tmpdir):
             Thanks for your grog.
             """
         )
+        commit("-m", "Subproject evolved")
+        # Reapply template ignoring subproject evolution
+        copy(
+            data={"author_name": "Largo LaGrande", "project_name": "to steal a lot"},
+            force=True,
+            vcs_ref="HEAD",
+            only_diff=False,
+        )
+        assert readme.read_text() == dedent(
+            """
+            Let me introduce myself.
+
+            My name is Largo LaGrande.
+
+            My project is to steal a lot.
+
+            Thanks for your attention.
+            """
+        )
 
 
 def test_commit_hooks_respected(tmp_path: Path):


### PR DESCRIPTION

This flag was not working fine, after all.

Also, the only difference between `copier copy` and `copier update` is that copying should ignore subproject history, while updating should respect it.

Thus, the real CLI reflection of the `only_diff` option is whether you're using `copier copy` or `copier update`. Well, that's how it is now.

Besides all this, the real behavior of `only_diff=False` wasn't being tested. Fixed also, and updated docs.

Fixes #270.