### PR TITLE
Allow running copier when installed in editable mode

### DIFF
--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -47,6 +47,10 @@ def verify_minimum_version(version_str: str) -> None:
     # so instead we do a lazy import here
     from .. import __version__
 
+    # Disable check when running copier as editable installation
+    if __version__ == "0.0.0":
+        return
+
     if version.parse(__version__) < version.parse(version_str):
         raise UserMessageError(
             f"This template requires Copier version >= {version_str}, "

--- a/tests/test_minimum_version.py
+++ b/tests/test_minimum_version.py
@@ -8,7 +8,7 @@ from copier.config.objects import UserMessageError
 
 
 def test_version_less_than_required(monkeypatch):
-    monkeypatch.setattr("copier.__version__", "0.0.0")
+    monkeypatch.setattr("copier.__version__", "0.0.0a0")
     with pytest.raises(UserMessageError):
         make_config("./tests/demo_minimum_version")
 
@@ -36,7 +36,7 @@ def test_minimum_version_update(tmp_path, monkeypatch):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    monkeypatch.setattr("copier.__version__", "0.0.0")
+    monkeypatch.setattr("copier.__version__", "0.0.0.post0")
     with pytest.raises(UserMessageError):
         make_config("./tests/demo_minimum_version", tmp_path)
 
@@ -47,3 +47,9 @@ def test_minimum_version_update(tmp_path, monkeypatch):
     monkeypatch.setattr("copier.__version__", "99.99.99")
     # assert no error
     make_config("./tests/demo_minimum_version", tmp_path)
+
+
+def test_version_0_0_0_ignored(monkeypatch):
+    monkeypatch.setattr("copier.__version__", "0.0.0")
+    # assert no error
+    make_config("./tests/demo_minimum_version")


### PR DESCRIPTION

Without this patch, any template with `_min_copier_version` would fail without need.