### PR TITLE
Remove support for custom lexers temporarily

### DIFF
--- a/copier/config/user_data.py
+++ b/copier/config/user_data.py
@@ -11,9 +11,7 @@ import yaml
 from iteration_utilities import deepflatten
 from jinja2 import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
-from prompt_toolkit.lexers import PygmentsLexer
 from pydantic import BaseModel, Field, validator
-from pygments.lexers.data import JsonLexer, YamlLexer
 from questionary import prompt
 from questionary.prompts.common import Choice
 from yamlinclude import YamlIncludeConstructor
@@ -208,7 +206,6 @@ class Question(BaseModel):
 
     def get_questionary_structure(self):
         """Get the question in a format that the questionary lib understands."""
-        lexer = None
         result = {
             "default": self.get_default(for_rendering=True),
             "filter": self.filter_answer,
@@ -234,12 +231,6 @@ class Question(BaseModel):
         if questionary_type == "input":
             if self.secret:
                 questionary_type = "password"
-            elif self.type_name == "yaml":
-                lexer = PygmentsLexer(YamlLexer)
-            elif self.type_name == "json":
-                lexer = PygmentsLexer(JsonLexer)
-            if lexer:
-                result["lexer"] = lexer
             result["multiline"] = self.get_multiline()
             placeholder = self.get_placeholder()
             if placeholder:

--- a/poetry.lock
+++ b/poetry.lock
@@ -630,7 +630,7 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.7"
+version = "3.0.8"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
 optional = false
@@ -821,16 +821,13 @@ version = "1.6.0"
 description = "Python library to build pretty command line user prompts ⭐️"
 category = "main"
 optional = false
-python-versions = ">=3.6,<3.9"
+python-versions = "*"
 
 [package.dependencies]
-prompt_toolkit = ">=2.0,<4.0"
+prompt-toolkit = ">=2.0,<4.0"
 
-[package.source]
-type = "git"
-url = "https://github.com/Yajo/questionary.git"
-reference = "text-custom-lexer"
-resolved_reference = "4c54853fcd5d147f2a19ae2091c8dc6f23f0e131"
+[package.extras]
+test = ["pytest", "pytest-pycodestyle", "pytest-cov", "coveralls"]
 
 [[package]]
 name = "regex"
@@ -984,7 +981,7 @@ docs = ["mkdocstrings", "mkdocs-material", "mkdocs-mermaid2-plugin"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.9"
-content-hash = "0eeafc30d7464cce3ce241cefd03e18531d377020aaf60a66485fd4860f97056"
+content-hash = "380c2d740fcba3e5a842438aba70b4776e76c017462b12d43d2416d905dd8bf9"
 
 [metadata.files]
 apipkg = [
@@ -1298,8 +1295,8 @@ pre-commit = [
     {file = "pre_commit-2.7.1.tar.gz", hash = "sha256:c54fd3e574565fe128ecc5e7d2f91279772ddb03f8729645fa812fe809084a70"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.7-py3-none-any.whl", hash = "sha256:83074ee28ad4ba6af190593d4d4c607ff525272a504eb159199b6dd9f950c950"},
-    {file = "prompt_toolkit-3.0.7.tar.gz", hash = "sha256:822f4605f28f7d2ba6b0b09a31e25e140871e96364d1d377667b547bb3bf4489"},
+    {file = "prompt_toolkit-3.0.8-py3-none-any.whl", hash = "sha256:7debb9a521e0b1ee7d2fe96ee4bd60ef03c6492784de0547337ca4433e46aa63"},
+    {file = "prompt_toolkit-3.0.8.tar.gz", hash = "sha256:25c95d2ac813909f813c93fde734b6e44406d1477a9faef7c915ff37d39c0a8c"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.6.0-py2.py3-none-any.whl", hash = "sha256:d7cc528d76e76342423ca640335bd3633420dc1366f258cb31d05e865ef5ca1f"},
@@ -1385,7 +1382,10 @@ pyyaml-include = [
     {file = "pyyaml-include-1.2.tar.gz", hash = "sha256:2343c4dad744d3ce907ec50683b29b4383c7c967f142275bdad8ed56d4de9d94"},
     {file = "pyyaml_include-1.2-py2.py3-none-any.whl", hash = "sha256:2d4e3843110cf515aaf1568b217b05061f8e9f57cd3b35e8e654c838717796cb"},
 ]
-questionary = []
+questionary = [
+    {file = "questionary-1.6.0-py3-none-any.whl", hash = "sha256:747d0979115a3f1bb9c943073b95d25724f9145e0a3cd6c42d820a401352e09e"},
+    {file = "questionary-1.6.0.tar.gz", hash = "sha256:ec7a6f31096959b3080c4e041ad916773613d182eacf600506725a2fc578e28c"},
+]
 regex = [
     {file = "regex-2020.10.11-cp27-cp27m-win32.whl", hash = "sha256:4f5c0fe46fb79a7adf766b365cae56cafbf352c27358fda811e4a1dc8216d0db"},
     {file = "regex-2020.10.11-cp27-cp27m-win_amd64.whl", hash = "sha256:39a5ef30bca911f5a8a3d4476f5713ed4d66e313d9fb6755b32bec8a2e519635"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,7 @@ jinja2 = "^2.11.2"
 pathspec = "^0.8.0"
 plumbum = "^1.6.9"
 pydantic = "^1.5.1"
-# HACK https://github.com/tmbo/questionary/pull/70
-questionary = {git = "https://github.com/Yajo/questionary.git", rev = "text-custom-lexer"}
+questionary = "^1.6.0"
 pyyaml = "^5.3.1"
 pyyaml-include = "^1.2"
 # packaging is needed when installing from PyPI

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,3 +1,4 @@
+import inspect
 from pathlib import Path
 
 import pexpect
@@ -5,6 +6,7 @@ import pytest
 import yaml
 from plumbum import local
 from plumbum.cmd import git
+from questionary.prompts.text import text
 
 from .helpers import COPIER_PATH, Keyboard, build_file_tree
 
@@ -245,3 +247,13 @@ def test_multiline(tmp_path_factory, spawn, type_):
             "question_4": ("answer 4"),
             "question_5": ("answer 5"),
         }
+
+
+def questionary_supports_custom_lexer():
+    """Check that questionary doesn't support custom lexers.
+
+    If this test fails, it means that https://github.com/tmbo/questionary/pull/70
+    was merged and then you should revert https://github.com/copier-org/copier/pull/289
+    to enable lexer support.
+    """
+    assert "lexer" not in inspect.signature(text).parameters


### PR DESCRIPTION

When https://github.com/tmbo/questionary/pull/70 gets fixed, this commit should be rolled back.

For now, I have to remove this support because [otherwise I cannot publish Copier to Pypi](https://github.com/copier-org/copier/runs/1241180809?check_suite_focus=true).