### PR TITLE
Update dependencies and tests for python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,12 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
-        python-version: [3.6, 3.7, 3.8]
-        include:
-          - os: windows-latest
-            python-version: 3.8
+          - windows-latest
+        python-version: [3.6, 3.7, 3.8, 3.9]
+        exclude:
+          # Windows is only supported on Python 3.8+
+          - {os: windows-latest, python-version: 3.6}
+          - {os: windows-latest, python-version: 3.7}
     runs-on: ${{ matrix.os }}
     steps:
       # HACK https://github.com/actions/cache/issues/315
@@ -71,6 +73,10 @@ jobs:
           poetry install -E docs -vvv
       - name: Run pytest
         run: poetry run poe test -ra .
+        # HACK https://github.com/samuelcolvin/pydantic/issues/1985
+        # HACK https://github.com/samuelcolvin/pydantic/issues/2009
+        # FIXME Remove when fixed upstream
+        continue-on-error: ${{ matrix.python-version == 3.9 }}
 
   publish:
     if: github.event_name == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install poetry
-          poetry install -vvv
+          poetry install -E docs -vvv
       - name: Run pytest
         run: poetry run poe test -ra .
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
             hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - run: git config --global user.name copier-ci
       - run: git config --global user.email copier@copier
-      - run: poetry install
+      - run: poetry install -E docs
       - name: Generate coverage report
         run: |
           poetry run pytest --cov=./ --cov-report=xml

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,4 +8,4 @@ tasks:
       exit
   - init: |
       export PIP_USER=no
-      poetry install
+      poetry install -E docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
 
   # isorting our imports
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.2.2
+    rev: 5.6.4
     hooks:
       - id: isort
         additional_dependencies:
@@ -48,6 +48,7 @@ repos:
 
   # prettier to format our many yaml files
   - repo: https://github.com/prettier/prettier
+    # TODO Update when fixed https://github.com/prettier/prettier/issues/9430
     rev: 2.0.5
     hooks:
       - id: prettier

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ git clone git@github.com:copier-org/copier.git
 3.  Use poetry to setup a virtualenv to develop in
 
 ```bash
-poetry install # create's a virtualenv with all dependencies from pyproject.toml
+poetry install -E docs # create's a virtualenv with all dependencies from pyproject.toml
 poetry shell   # creates a new shell with the virtualenv activated
 ```
 

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -142,7 +142,8 @@ class CopierApp(cli.Application):
     )
     quiet: cli.Flag = cli.Flag(["-q", "--quiet"], help="Suppress status output")
     prereleases: cli.Flag = cli.Flag(
-        ["-g", "--prereleases"], help="Use prereleases to compare template VCS tags.",
+        ["-g", "--prereleases"],
+        help="Use prereleases to compare template VCS tags.",
     )
 
     @cli.switch(
@@ -303,7 +304,8 @@ class CopierUpdateSubApp(cli.Application):
                 working directory is used.
         """
         self.parent._copy(
-            dst_path=destination_path, only_diff=True,
+            dst_path=destination_path,
+            only_diff=True,
         )
         return 0
 

--- a/copier/config/user_data.py
+++ b/copier/config/user_data.py
@@ -204,7 +204,7 @@ class Question(BaseModel):
         """Render and obtain the placeholder."""
         return self.render_value(self.placeholder)
 
-    def get_questionary_structure(self):
+    def get_questionary_structure(self) -> AnyByStrDict:
         """Get the question in a format that the questionary lib understands."""
         result = {
             "default": self.get_default(for_rendering=True),
@@ -355,9 +355,11 @@ class Questionary(BaseModel):
         """
         previous_answers = self.get_best_answers()
         if self.ask_user:
+            # HACK https://github.com/tmbo/questionary/pull/79
+            # TODO Remove type: ignore comments when fixed
             self.answers_user = prompt(
-                (question.get_questionary_structure() for question in self.questions),
-                answers=previous_answers,
+                (question.get_questionary_structure() for question in self.questions),  # type: ignore
+                answers=previous_answers,  # type: ignore
             )
             # HACK https://github.com/tmbo/questionary/issues/74
             if not self.answers_user and self.questions:

--- a/copier/config/user_data.py
+++ b/copier/config/user_data.py
@@ -398,7 +398,9 @@ def load_yaml_data(conf_path: Path, quiet: bool = False) -> AnyByStrDict:
     try:
         with open(conf_path) as f:
             flattened_result = deepflatten(
-                yaml.load_all(f, Loader=yaml.FullLoader), depth=2, types=(list,),
+                yaml.load_all(f, Loader=yaml.FullLoader),
+                depth=2,
+                types=(list,),
             )
             # HACK https://bugs.python.org/issue32792#msg311822
             # I'd use ChainMap, but it doesn't respect order in Python 3.6
@@ -425,8 +427,7 @@ def parse_yaml_string(string: str) -> Any:
 def load_config_data(
     src_path: StrOrPath, quiet: bool = False, _warning: bool = True
 ) -> AnyByStrDict:
-    """Try to load the content from a `copier.yml` or a `copier.yaml` file.
-    """
+    """Try to load the content from a `copier.yml` or a `copier.yaml` file."""
     conf_paths = [
         p
         for p in Path(src_path).glob("copier.*")
@@ -442,7 +443,8 @@ def load_config_data(
 
 
 def load_answersfile_data(
-    dst_path: StrOrPath, answers_file: OptStrOrPath = None,
+    dst_path: StrOrPath,
+    answers_file: OptStrOrPath = None,
 ) -> AnyByStrDict:
     """Load answers data from a `$dst_path/$answers_file` file if it exists."""
     try:

--- a/copier/config/user_data.py
+++ b/copier/config/user_data.py
@@ -11,7 +11,9 @@ import yaml
 from iteration_utilities import deepflatten
 from jinja2 import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
+from prompt_toolkit.lexers import PygmentsLexer
 from pydantic import BaseModel, Field, validator
+from pygments.lexers.data import JsonLexer, YamlLexer
 from questionary import prompt
 from questionary.prompts.common import Choice
 from yamlinclude import YamlIncludeConstructor
@@ -206,6 +208,7 @@ class Question(BaseModel):
 
     def get_questionary_structure(self) -> AnyByStrDict:
         """Get the question in a format that the questionary lib understands."""
+        lexer = None
         result = {
             "default": self.get_default(for_rendering=True),
             "filter": self.filter_answer,
@@ -231,6 +234,12 @@ class Question(BaseModel):
         if questionary_type == "input":
             if self.secret:
                 questionary_type = "password"
+            elif self.type_name == "yaml":
+                lexer = PygmentsLexer(YamlLexer)
+            elif self.type_name == "json":
+                lexer = PygmentsLexer(JsonLexer)
+            if lexer:
+                result["lexer"] = lexer
             result["multiline"] = self.get_multiline()
             placeholder = self.get_placeholder()
             if placeholder:

--- a/poetry.lock
+++ b/poetry.lock
@@ -119,7 +119,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "colorama"
-version = "0.4.3"
+version = "0.4.4"
 description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
@@ -242,7 +242,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "identify"
-version = "1.5.5"
+version = "1.5.6"
 description = "File identification library for Python"
 category = "dev"
 optional = false
@@ -290,7 +290,7 @@ docs = ["sphinx", "rst.linker", "jaraco.packaging"]
 
 [[package]]
 name = "iniconfig"
-version = "1.0.1"
+version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
@@ -373,11 +373,11 @@ languages = ["nltk (>=3.2.5,<3.5)", "nltk (>=3.2.5)"]
 
 [[package]]
 name = "markdown"
-version = "3.2.2"
+version = "3.3.1"
 description = "Python implementation of Markdown."
 category = "main"
 optional = true
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
@@ -823,7 +823,7 @@ prompt_toolkit = ">=2.0,<4.0"
 
 [[package]]
 name = "regex"
-version = "2020.10.11"
+version = "2020.10.15"
 description = "Alternative regular expression module, to replace re."
 category = "main"
 optional = false
@@ -889,7 +889,7 @@ python-versions = ">= 3.5"
 
 [[package]]
 name = "tqdm"
-version = "4.50.0"
+version = "4.50.2"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = true
@@ -929,7 +929,7 @@ socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.0.33"
+version = "20.0.35"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -957,7 +957,7 @@ python-versions = "*"
 
 [[package]]
 name = "zipp"
-version = "3.3.0"
+version = "3.3.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 category = "main"
 optional = false
@@ -972,8 +972,8 @@ docs = ["mkdocstrings", "mkdocs-material", "mkdocs-mermaid2-plugin"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.1,<3.9"
-content-hash = "66ea2fe28c02b964106468d3c25fa4a62a9570961ff5ba40ed3fd54fc113a446"
+python-versions = ">=3.6.1,<3.10"
+content-hash = "37b04fb5cd02547650d30a06534d716662f729e3b0d549ff2adbbc6531d00714"
 
 [metadata.files]
 apipkg = [
@@ -1021,8 +1021,8 @@ click = [
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
     {file = "coverage-5.3-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:bd3166bb3b111e76a4f8e2980fa1addf2920a4ca9b2b8ca36a3bc3dedc618270"},
@@ -1099,8 +1099,8 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 identify = [
-    {file = "identify-1.5.5-py2.py3-none-any.whl", hash = "sha256:da683bfb7669fa749fc7731f378229e2dbf29a1d1337cbde04106f02236eb29d"},
-    {file = "identify-1.5.5.tar.gz", hash = "sha256:7c22c384a2c9b32c5cc891d13f923f6b2653aa83e2d75d8f79be240d6c86c4f4"},
+    {file = "identify-1.5.6-py2.py3-none-any.whl", hash = "sha256:3139bf72d81dfd785b0a464e2776bd59bdc725b4cc10e6cf46b56a0db931c82e"},
+    {file = "identify-1.5.6.tar.gz", hash = "sha256:969d844b7a85d32a5f9ac4e163df6e846d73c87c8b75847494ee8f4bd2186421"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -1115,8 +1115,7 @@ importlib-resources = [
     {file = "importlib_resources-3.0.0.tar.gz", hash = "sha256:19f745a6eca188b490b1428c8d1d4a0d2368759f32370ea8fb89cad2ab1106c3"},
 ]
 iniconfig = [
-    {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
-    {file = "iniconfig-1.0.1.tar.gz", hash = "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 iteration-utilities = [
     {file = "iteration_utilities-0.10.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:958c2aa52795d1100d9caffc3ed6aeda0e23577e3bc5694b3c8b6177c85fa57d"},
@@ -1161,8 +1160,8 @@ lunr = [
     {file = "lunr-0.5.8.tar.gz", hash = "sha256:c4fb063b98eff775dd638b3df380008ae85e6cb1d1a24d1cd81a10ef6391c26e"},
 ]
 markdown = [
-    {file = "Markdown-3.2.2-py3-none-any.whl", hash = "sha256:c467cd6233885534bf0fe96e62e3cf46cfc1605112356c4f9981512b8174de59"},
-    {file = "Markdown-3.2.2.tar.gz", hash = "sha256:1fafe3f1ecabfb514a5285fca634a53c1b32a81cb0feb154264d55bf2ff22c17"},
+    {file = "Markdown-3.3.1-py3-none-any.whl", hash = "sha256:10db1204a6c4aff7c7cf3cf25cc02761703baea54b6fb5e2b9ce2c186d81116f"},
+    {file = "Markdown-3.3.1.tar.gz", hash = "sha256:c3ce9ebb035c078cac0f2036068d054e7dc34354eeecc49c173c33c96b124af6"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -1375,33 +1374,33 @@ questionary = [
     {file = "questionary-1.7.0.tar.gz", hash = "sha256:338f326d3d10204dc3a21a07cfa8243f32d8d8f3d9f3de244951066c0769f2ea"},
 ]
 regex = [
-    {file = "regex-2020.10.11-cp27-cp27m-win32.whl", hash = "sha256:4f5c0fe46fb79a7adf766b365cae56cafbf352c27358fda811e4a1dc8216d0db"},
-    {file = "regex-2020.10.11-cp27-cp27m-win_amd64.whl", hash = "sha256:39a5ef30bca911f5a8a3d4476f5713ed4d66e313d9fb6755b32bec8a2e519635"},
-    {file = "regex-2020.10.11-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:7c4fc5a8ec91a2254bb459db27dbd9e16bba1dabff638f425d736888d34aaefa"},
-    {file = "regex-2020.10.11-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d537e270b3e6bfaea4f49eaf267984bfb3628c86670e9ad2a257358d3b8f0955"},
-    {file = "regex-2020.10.11-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:a8240df4957a5b0e641998a5d78b3c4ea762c845d8cb8997bf820626826fde9a"},
-    {file = "regex-2020.10.11-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:4302153abb96859beb2c778cc4662607a34175065fc2f33a21f49eb3fbd1ccd3"},
-    {file = "regex-2020.10.11-cp36-cp36m-win32.whl", hash = "sha256:c077c9d04a040dba001cf62b3aff08fd85be86bccf2c51a770c77377662a2d55"},
-    {file = "regex-2020.10.11-cp36-cp36m-win_amd64.whl", hash = "sha256:46ab6070b0d2cb85700b8863b3f5504c7f75d8af44289e9562195fe02a8dd72d"},
-    {file = "regex-2020.10.11-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:d629d750ebe75a88184db98f759633b0a7772c2e6f4da529f0027b4a402c0e2f"},
-    {file = "regex-2020.10.11-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e7ef296b84d44425760fe813cabd7afbb48c8dd62023018b338bbd9d7d6f2f0"},
-    {file = "regex-2020.10.11-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:e490f08897cb44e54bddf5c6e27deca9b58c4076849f32aaa7a0b9f1730f2c20"},
-    {file = "regex-2020.10.11-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:850339226aa4fec04916386577674bb9d69abe0048f5d1a99f91b0004bfdcc01"},
-    {file = "regex-2020.10.11-cp37-cp37m-win32.whl", hash = "sha256:60c4f64d9a326fe48e8738c3dbc068e1edc41ff7895a9e3723840deec4bc1c28"},
-    {file = "regex-2020.10.11-cp37-cp37m-win_amd64.whl", hash = "sha256:8ba3efdd60bfee1aa784dbcea175eb442d059b576934c9d099e381e5a9f48930"},
-    {file = "regex-2020.10.11-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2308491b3e6c530a3bb38a8a4bb1dc5fd32cbf1e11ca623f2172ba17a81acef1"},
-    {file = "regex-2020.10.11-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b8806649983a1c78874ec7e04393ef076805740f6319e87a56f91f1767960212"},
-    {file = "regex-2020.10.11-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a2a31ee8a354fa3036d12804730e1e20d58bc4e250365ead34b9c30bbe9908c3"},
-    {file = "regex-2020.10.11-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d9d53518eeed12190744d366ec4a3f39b99d7daa705abca95f87dd8b442df4ad"},
-    {file = "regex-2020.10.11-cp38-cp38-win32.whl", hash = "sha256:3d5a8d007116021cf65355ada47bf405656c4b3b9a988493d26688275fde1f1c"},
-    {file = "regex-2020.10.11-cp38-cp38-win_amd64.whl", hash = "sha256:f579caecbbca291b0fcc7d473664c8c08635da2f9b1567c22ea32311c86ef68c"},
-    {file = "regex-2020.10.11-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8c8c42aa5d3ac9a49829c4b28a81bebfa0378996f9e0ca5b5ab8a36870c3e5ee"},
-    {file = "regex-2020.10.11-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:c529ba90c1775697a65b46c83d47a2d3de70f24d96da5d41d05a761c73b063af"},
-    {file = "regex-2020.10.11-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:6cf527ec2f3565248408b61dd36e380d799c2a1047eab04e13a2b0c15dd9c767"},
-    {file = "regex-2020.10.11-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:671c51d352cfb146e48baee82b1ee8d6ffe357c292f5e13300cdc5c00867ebfc"},
-    {file = "regex-2020.10.11-cp39-cp39-win32.whl", hash = "sha256:a63907332531a499b8cdfd18953febb5a4c525e9e7ca4ac147423b917244b260"},
-    {file = "regex-2020.10.11-cp39-cp39-win_amd64.whl", hash = "sha256:1a16afbfadaadc1397353f9b32e19a65dc1d1804c80ad73a14f435348ca017ad"},
-    {file = "regex-2020.10.11.tar.gz", hash = "sha256:463e770c48da76a8da82b8d4a48a541f314e0df91cbb6d873a341dbe578efafd"},
+    {file = "regex-2020.10.15-cp27-cp27m-win32.whl", hash = "sha256:e935a166a5f4c02afe3f7e4ce92ce5a786f75c6caa0c4ce09c922541d74b77e8"},
+    {file = "regex-2020.10.15-cp27-cp27m-win_amd64.whl", hash = "sha256:d81be22d5d462b96a2aa5c512f741255ba182995efb0114e5a946fe254148df1"},
+    {file = "regex-2020.10.15-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:6d4cdb6c20e752426b2e569128488c5046fb1b16b1beadaceea9815c36da0847"},
+    {file = "regex-2020.10.15-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:25991861c6fef1e5fd0a01283cf5658c5e7f7aa644128e85243bc75304e91530"},
+    {file = "regex-2020.10.15-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:6e9f72e0ee49f7d7be395bfa29e9533f0507a882e1e6bf302c0a204c65b742bf"},
+    {file = "regex-2020.10.15-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:578ac6379e65eb8e6a85299b306c966c852712c834dc7eef0ba78d07a828f67b"},
+    {file = "regex-2020.10.15-cp36-cp36m-win32.whl", hash = "sha256:65b6b018b07e9b3b6a05c2c3bb7710ed66132b4df41926c243887c4f1ff303d5"},
+    {file = "regex-2020.10.15-cp36-cp36m-win_amd64.whl", hash = "sha256:2f60ba5c33f00ce9be29a140e6f812e39880df8ba9cb92ad333f0016dbc30306"},
+    {file = "regex-2020.10.15-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5d4a3221f37520bb337b64a0632716e61b26c8ae6aaffceeeb7ad69c009c404b"},
+    {file = "regex-2020.10.15-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:26b85672275d8c7a9d4ff93dbc4954f5146efdb2ecec89ad1de49439984dea14"},
+    {file = "regex-2020.10.15-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:828618f3c3439c5e6ef8621e7c885ca561bbaaba90ddbb6a7dfd9e1ec8341103"},
+    {file = "regex-2020.10.15-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:aef23aed9d4017cc74d37f703d57ce254efb4c8a6a01905f40f539220348abf9"},
+    {file = "regex-2020.10.15-cp37-cp37m-win32.whl", hash = "sha256:6c72adb85adecd4522a488a751e465842cdd2a5606b65464b9168bf029a54272"},
+    {file = "regex-2020.10.15-cp37-cp37m-win_amd64.whl", hash = "sha256:ef3a55b16c6450574734db92e0a3aca283290889934a23f7498eaf417e3af9f0"},
+    {file = "regex-2020.10.15-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8958befc139ac4e3f16d44ec386c490ea2121ed8322f4956f83dd9cad8e9b922"},
+    {file = "regex-2020.10.15-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3dd952f3f8dc01b72c0cf05b3631e05c50ac65ddd2afdf26551638e97502107b"},
+    {file = "regex-2020.10.15-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:608d6c05452c0e6cc49d4d7407b4767963f19c4d2230fa70b7201732eedc84f2"},
+    {file = "regex-2020.10.15-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:02686a2f0b1a4be0facdd0d3ad4dc6c23acaa0f38fb5470d892ae88584ba705c"},
+    {file = "regex-2020.10.15-cp38-cp38-win32.whl", hash = "sha256:137da580d1e6302484be3ef41d72cf5c3ad22a076070051b7449c0e13ab2c482"},
+    {file = "regex-2020.10.15-cp38-cp38-win_amd64.whl", hash = "sha256:20cdd7e1736f4f61a5161aa30d05ac108ab8efc3133df5eb70fe1e6a23ea1ca6"},
+    {file = "regex-2020.10.15-cp39-cp39-manylinux1_i686.whl", hash = "sha256:85b733a1ef2b2e7001aff0e204a842f50ad699c061856a214e48cfb16ace7d0c"},
+    {file = "regex-2020.10.15-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:af1f5e997dd1ee71fb6eb4a0fb6921bf7a778f4b62f1f7ef0d7445ecce9155d6"},
+    {file = "regex-2020.10.15-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:b5eeaf4b5ef38fab225429478caf71f44d4a0b44d39a1aa4d4422cda23a9821b"},
+    {file = "regex-2020.10.15-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:aeac7c9397480450016bc4a840eefbfa8ca68afc1e90648aa6efbfe699e5d3bb"},
+    {file = "regex-2020.10.15-cp39-cp39-win32.whl", hash = "sha256:698f8a5a2815e1663d9895830a063098ae2f8f2655ae4fdc5dfa2b1f52b90087"},
+    {file = "regex-2020.10.15-cp39-cp39-win_amd64.whl", hash = "sha256:a51e51eecdac39a50ede4aeed86dbef4776e3b73347d31d6ad0bc9648ba36049"},
+    {file = "regex-2020.10.15.tar.gz", hash = "sha256:d25f5cca0f3af6d425c9496953445bf5b288bb5b71afc2b8308ad194b714c159"},
 ]
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
@@ -1435,8 +1434,8 @@ tornado = [
     {file = "tornado-6.0.4.tar.gz", hash = "sha256:0fe2d45ba43b00a41cd73f8be321a44936dc1aba233dee979f17a042b83eb6dc"},
 ]
 tqdm = [
-    {file = "tqdm-4.50.0-py2.py3-none-any.whl", hash = "sha256:2dd75fdb764f673b8187643496fcfbeac38348015b665878e582b152f3391cdb"},
-    {file = "tqdm-4.50.0.tar.gz", hash = "sha256:93b7a6a9129fce904f6df4cf3ae7ff431d779be681a95c3344c26f3e6c09abfa"},
+    {file = "tqdm-4.50.2-py2.py3-none-any.whl", hash = "sha256:43ca183da3367578ebf2f1c2e3111d51ea161ed1dc4e6345b86e27c2a93beff7"},
+    {file = "tqdm-4.50.2.tar.gz", hash = "sha256:69dfa6714dee976e2425a9aab84b622675b7b1742873041e3db8a8e86132a4af"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
@@ -1471,14 +1470,14 @@ urllib3 = [
     {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.33-py2.py3-none-any.whl", hash = "sha256:35ecdeb58cfc2147bb0706f7cdef69a8f34f1b81b6d49568174e277932908b8f"},
-    {file = "virtualenv-20.0.33.tar.gz", hash = "sha256:a5e0d253fe138097c6559c906c528647254f437d1019af9d5a477b09bfa7300f"},
+    {file = "virtualenv-20.0.35-py2.py3-none-any.whl", hash = "sha256:0ebc633426d7468664067309842c81edab11ae97fcaf27e8ad7f5748c89b431b"},
+    {file = "virtualenv-20.0.35.tar.gz", hash = "sha256:2a72c80fa2ad8f4e2985c06e6fc12c3d60d060e410572f553c90619b0f6efaf3"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
     {file = "wcwidth-0.2.5.tar.gz", hash = "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"},
 ]
 zipp = [
-    {file = "zipp-3.3.0-py3-none-any.whl", hash = "sha256:eed8ec0b8d1416b2ca33516a37a08892442f3954dee131e92cfd92d8fe3e7066"},
-    {file = "zipp-3.3.0.tar.gz", hash = "sha256:64ad89efee774d1897a58607895d80789c59778ea02185dd846ac38394a8642b"},
+    {file = "zipp-3.3.1-py3-none-any.whl", hash = "sha256:16522f69653f0d67be90e8baa4a46d66389145b734345d68a257da53df670903"},
+    {file = "zipp-3.3.1.tar.gz", hash = "sha256:c1532a8030c32fd52ff6a288d855fe7adef5823ba1d26a29a68fd6314aa72baa"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -64,7 +64,7 @@ lxml = ["lxml"]
 
 [[package]]
 name = "black"
-version = "19.10b0"
+version = "20.8b1"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -72,14 +72,17 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 appdirs = "*"
-attrs = ">=18.1.0"
-click = ">=6.5"
+click = ">=7.1.2"
+dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
+mypy-extensions = ">=0.4.3"
 pathspec = ">=0.6,<1"
-regex = "*"
-toml = ">=0.9.4"
+regex = ">=2020.1.8"
+toml = ">=0.10.1"
 typed-ast = ">=1.4.0"
+typing-extensions = ">=3.7.4"
 
 [package.extras]
+colorama = ["colorama (>=0.4.3)"]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
@@ -192,14 +195,6 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 mccabe = ">=0.6.0,<0.7.0"
 pycodestyle = ">=2.6.0a1,<2.7.0"
 pyflakes = ">=2.2.0,<2.3.0"
-
-[[package]]
-name = "flake8-blind-except"
-version = "0.1.1"
-description = "A flake8 extension that checks for blind except: statements"
-category = "dev"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "flake8-bugbear"
@@ -485,7 +480,7 @@ tests = ["coverage (>=5.2.1,<6.0.0)", "invoke (>=1.4.1,<2.0.0)", "mkdocs-materia
 
 [[package]]
 name = "mypy"
-version = "0.782"
+version = "0.790"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -600,7 +595,7 @@ python-versions = ">=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*"
 
 [[package]]
 name = "poethepoet"
-version = "0.7.0"
+version = "0.9.0"
 description = "A task runner that works well with poetry."
 category = "dev"
 optional = false
@@ -608,7 +603,7 @@ python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
 pastel = ">=0.2.0,<0.3.0"
-tomlkit = ">=0.7.0,<0.8.0"
+tomlkit = ">=0.6.0,<1.0.0"
 
 [[package]]
 name = "pre-commit"
@@ -981,7 +976,7 @@ docs = ["mkdocstrings", "mkdocs-material", "mkdocs-mermaid2-plugin"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.9"
-content-hash = "380c2d740fcba3e5a842438aba70b4776e76c017462b12d43d2416d905dd8bf9"
+content-hash = "f0ba5207f484763f28e40090338909a0dc28643c811040e8cdc00df596c3af34"
 
 [metadata.files]
 apipkg = [
@@ -1009,8 +1004,8 @@ beautifulsoup4 = [
     {file = "beautifulsoup4-4.9.3.tar.gz", hash = "sha256:84729e322ad1d5b4d25f805bfa05b902dd96450f43842c4e99067d5e1369eb25"},
 ]
 black = [
-    {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
-    {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
+    {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
+    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 certifi = [
     {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
@@ -1091,10 +1086,6 @@ filelock = [
 flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
     {file = "flake8-3.8.4.tar.gz", hash = "sha256:aadae8761ec651813c24be05c6f7b4680857ef6afaae4651a4eccaef97ce6c3b"},
-]
-flake8-blind-except = [
-    {file = "flake8-blind-except-0.1.1.tar.gz", hash = "sha256:aca3356633825544cec51997260fe31a8f24a1a2795ce8e81696b9916745e599"},
-    {file = "flake8_blind_except-0.1.1-py2.7.egg", hash = "sha256:0d7d1adb4cabf2268d6eebb815a7a5014bcb7e8419f7a74339c46d0b8847b858"},
 ]
 flake8-bugbear = [
     {file = "flake8-bugbear-20.1.4.tar.gz", hash = "sha256:bd02e4b009fb153fe6072c31c52aeab5b133d508095befb2ffcf3b41c4823162"},
@@ -1236,20 +1227,20 @@ mkdocstrings = [
     {file = "mkdocstrings-0.13.6.tar.gz", hash = "sha256:79e5086c79f60d1ae1d4b222f658d348ebdd6302c970cc06ee8394f2839d7c4d"},
 ]
 mypy = [
-    {file = "mypy-0.782-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:2c6cde8aa3426c1682d35190b59b71f661237d74b053822ea3d748e2c9578a7c"},
-    {file = "mypy-0.782-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:9c7a9a7ceb2871ba4bac1cf7217a7dd9ccd44c27c2950edbc6dc08530f32ad4e"},
-    {file = "mypy-0.782-cp35-cp35m-win_amd64.whl", hash = "sha256:c05b9e4fb1d8a41d41dec8786c94f3b95d3c5f528298d769eb8e73d293abc48d"},
-    {file = "mypy-0.782-cp36-cp36m-macosx_10_6_x86_64.whl", hash = "sha256:6731603dfe0ce4352c555c6284c6db0dc935b685e9ce2e4cf220abe1e14386fd"},
-    {file = "mypy-0.782-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f05644db6779387ccdb468cc47a44b4356fc2ffa9287135d05b70a98dc83b89a"},
-    {file = "mypy-0.782-cp36-cp36m-win_amd64.whl", hash = "sha256:b7fbfabdbcc78c4f6fc4712544b9b0d6bf171069c6e0e3cb82440dd10ced3406"},
-    {file = "mypy-0.782-cp37-cp37m-macosx_10_6_x86_64.whl", hash = "sha256:3fdda71c067d3ddfb21da4b80e2686b71e9e5c72cca65fa216d207a358827f86"},
-    {file = "mypy-0.782-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d7df6eddb6054d21ca4d3c6249cae5578cb4602951fd2b6ee2f5510ffb098707"},
-    {file = "mypy-0.782-cp37-cp37m-win_amd64.whl", hash = "sha256:a4a2cbcfc4cbf45cd126f531dedda8485671545b43107ded25ce952aac6fb308"},
-    {file = "mypy-0.782-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6bb93479caa6619d21d6e7160c552c1193f6952f0668cdda2f851156e85186fc"},
-    {file = "mypy-0.782-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:81c7908b94239c4010e16642c9102bfc958ab14e36048fa77d0be3289dda76ea"},
-    {file = "mypy-0.782-cp38-cp38-win_amd64.whl", hash = "sha256:5dd13ff1f2a97f94540fd37a49e5d255950ebcdf446fb597463a40d0df3fac8b"},
-    {file = "mypy-0.782-py3-none-any.whl", hash = "sha256:e0b61738ab504e656d1fe4ff0c0601387a5489ca122d55390ade31f9ca0e252d"},
-    {file = "mypy-0.782.tar.gz", hash = "sha256:eff7d4a85e9eea55afa34888dfeaccde99e7520b51f867ac28a48492c0b1130c"},
+    {file = "mypy-0.790-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:bd03b3cf666bff8d710d633d1c56ab7facbdc204d567715cb3b9f85c6e94f669"},
+    {file = "mypy-0.790-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:2170492030f6faa537647d29945786d297e4862765f0b4ac5930ff62e300d802"},
+    {file = "mypy-0.790-cp35-cp35m-win_amd64.whl", hash = "sha256:e86bdace26c5fe9cf8cb735e7cedfe7850ad92b327ac5d797c656717d2ca66de"},
+    {file = "mypy-0.790-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e97e9c13d67fbe524be17e4d8025d51a7dca38f90de2e462243ab8ed8a9178d1"},
+    {file = "mypy-0.790-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0d34d6b122597d48a36d6c59e35341f410d4abfa771d96d04ae2c468dd201abc"},
+    {file = "mypy-0.790-cp36-cp36m-win_amd64.whl", hash = "sha256:72060bf64f290fb629bd4a67c707a66fd88ca26e413a91384b18db3876e57ed7"},
+    {file = "mypy-0.790-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:eea260feb1830a627fb526d22fbb426b750d9f5a47b624e8d5e7e004359b219c"},
+    {file = "mypy-0.790-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:c614194e01c85bb2e551c421397e49afb2872c88b5830e3554f0519f9fb1c178"},
+    {file = "mypy-0.790-cp37-cp37m-win_amd64.whl", hash = "sha256:0a0d102247c16ce93c97066443d11e2d36e6cc2a32d8ccc1f705268970479324"},
+    {file = "mypy-0.790-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cf4e7bf7f1214826cf7333627cb2547c0db7e3078723227820d0a2490f117a01"},
+    {file = "mypy-0.790-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:af4e9ff1834e565f1baa74ccf7ae2564ae38c8df2a85b057af1dbbc958eb6666"},
+    {file = "mypy-0.790-cp38-cp38-win_amd64.whl", hash = "sha256:da56dedcd7cd502ccd3c5dddc656cb36113dd793ad466e894574125945653cea"},
+    {file = "mypy-0.790-py3-none-any.whl", hash = "sha256:2842d4fbd1b12ab422346376aad03ff5d0805b706102e475e962370f874a5122"},
+    {file = "mypy-0.790.tar.gz", hash = "sha256:2b21ba45ad9ef2e2eb88ce4aeadd0112d0f5026418324176fd494a6824b74975"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -1287,8 +1278,8 @@ plumbum = [
     {file = "plumbum-1.6.9.tar.gz", hash = "sha256:16b9e19d96c80f2e9d051ef5f04927b834a6ac0ce5d2768eb8662b5cd53e43df"},
 ]
 poethepoet = [
-    {file = "poethepoet-0.7.0-py3-none-any.whl", hash = "sha256:b3644ac15b9b4979619cf514ed8a3465e6f55055bb124eedb5a4fe86d17cfbd8"},
-    {file = "poethepoet-0.7.0.tar.gz", hash = "sha256:1b2e073c6a97790ecfa5733b597324edb5ae8e27991c0c0274be9924036ffecc"},
+    {file = "poethepoet-0.9.0-py3-none-any.whl", hash = "sha256:6b1df9a755c297d5b10749cd4713924055b41edfa62055770c8bd6b5da8e2c69"},
+    {file = "poethepoet-0.9.0.tar.gz", hash = "sha256:ab2263fd7be81d16d38a4b4fe42a055d992d04421e61cad36498b1e4bd8ee2a6"},
 ]
 pre-commit = [
     {file = "pre_commit-2.7.1-py2.py3-none-any.whl", hash = "sha256:810aef2a2ba4f31eed1941fc270e72696a1ad5590b9751839c90807d0fff6b9a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -52,7 +52,7 @@ name = "beautifulsoup4"
 version = "4.9.3"
 description = "Screen-scraping library"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -90,7 +90,7 @@ name = "certifi"
 version = "2020.6.20"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -106,7 +106,7 @@ name = "chardet"
 version = "3.0.4"
 description = "Universal encoding detector for Python 2 and 3"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -157,7 +157,7 @@ name = "editorconfig"
 version = "0.12.2"
 description = "EditorConfig File Locator and Interpreter for Python"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -237,7 +237,7 @@ name = "future"
 version = "0.18.2"
 description = "Clean single-source support for Python 3 and 2"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -256,7 +256,7 @@ name = "idna"
 version = "2.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
@@ -328,7 +328,7 @@ name = "joblib"
 version = "0.17.0"
 description = "Lightweight pipelining: using Python functions as pipeline jobs."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [[package]]
@@ -336,7 +336,7 @@ name = "jsbeautifier"
 version = "1.13.0"
 description = "JavaScript unobfuscator and beautifier."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -348,7 +348,7 @@ name = "livereload"
 version = "2.6.3"
 description = "Python LiveReload is an awesome tool for web developers"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -360,7 +360,7 @@ name = "lunr"
 version = "0.5.8"
 description = "A Python implementation of Lunr.js"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -376,7 +376,7 @@ name = "markdown"
 version = "3.2.2"
 description = "Python implementation of Markdown."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -406,7 +406,7 @@ name = "mkdocs"
 version = "1.1.2"
 description = "Project documentation with Markdown."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -423,7 +423,7 @@ name = "mkdocs-material"
 version = "5.5.14"
 description = "A Material Design theme for MkDocs"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -438,7 +438,7 @@ name = "mkdocs-material-extensions"
 version = "1.0.1"
 description = "Extension pack for Python Markdown."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -449,7 +449,7 @@ name = "mkdocs-mermaid2-plugin"
 version = "0.5.0"
 description = "A MkDocs plugin for including mermaid graphs in markdown sources"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -466,7 +466,7 @@ name = "mkdocstrings"
 version = "0.13.6"
 description = "Automatic documentation from sources, for MkDocs."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
@@ -507,7 +507,7 @@ name = "nltk"
 version = "3.5"
 description = "Natural Language Toolkit"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -687,7 +687,7 @@ name = "pygments"
 version = "2.7.1"
 description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [[package]]
@@ -695,7 +695,7 @@ name = "pymdown-extensions"
 version = "8.0.1"
 description = "Extension pack for Python Markdown."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -781,7 +781,7 @@ name = "pytkdocs"
 version = "0.9.0"
 description = "Load Python objects documentation."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6,<4.0"
 
 [package.extras]
@@ -837,7 +837,7 @@ name = "requests"
 version = "2.24.0"
 description = "Python HTTP for Humans."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
@@ -863,7 +863,7 @@ name = "soupsieve"
 version = "2.0.1"
 description = "A modern CSS selector implementation for Beautiful Soup."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [[package]]
@@ -887,7 +887,7 @@ name = "tornado"
 version = "6.0.4"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
 category = "main"
-optional = false
+optional = true
 python-versions = ">= 3.5"
 
 [[package]]
@@ -895,7 +895,7 @@ name = "tqdm"
 version = "4.50.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*"
 
 [package.extras]
@@ -922,7 +922,7 @@ name = "urllib3"
 version = "1.25.10"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
@@ -976,7 +976,7 @@ docs = ["mkdocstrings", "mkdocs-material", "mkdocs-mermaid2-plugin"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.9"
-content-hash = "f0ba5207f484763f28e40090338909a0dc28643c811040e8cdc00df596c3af34"
+content-hash = "2c53a779cfe38da1104754030dec61857ef3c605e1ef8050ca3458b58653b228"
 
 [metadata.files]
 apipkg = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -812,17 +812,14 @@ toml = ["toml"]
 
 [[package]]
 name = "questionary"
-version = "1.6.0"
+version = "1.7.0"
 description = "Python library to build pretty command line user prompts ⭐️"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6,<3.10"
 
 [package.dependencies]
-prompt-toolkit = ">=2.0,<4.0"
-
-[package.extras]
-test = ["pytest", "pytest-pycodestyle", "pytest-cov", "coveralls"]
+prompt_toolkit = ">=2.0,<4.0"
 
 [[package]]
 name = "regex"
@@ -976,7 +973,7 @@ docs = ["mkdocstrings", "mkdocs-material", "mkdocs-mermaid2-plugin"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.6.1,<3.9"
-content-hash = "2c53a779cfe38da1104754030dec61857ef3c605e1ef8050ca3458b58653b228"
+content-hash = "66ea2fe28c02b964106468d3c25fa4a62a9570961ff5ba40ed3fd54fc113a446"
 
 [metadata.files]
 apipkg = [
@@ -1374,8 +1371,8 @@ pyyaml-include = [
     {file = "pyyaml_include-1.2-py2.py3-none-any.whl", hash = "sha256:2d4e3843110cf515aaf1568b217b05061f8e9f57cd3b35e8e654c838717796cb"},
 ]
 questionary = [
-    {file = "questionary-1.6.0-py3-none-any.whl", hash = "sha256:747d0979115a3f1bb9c943073b95d25724f9145e0a3cd6c42d820a401352e09e"},
-    {file = "questionary-1.6.0.tar.gz", hash = "sha256:ec7a6f31096959b3080c4e041ad916773613d182eacf600506725a2fc578e28c"},
+    {file = "questionary-1.7.0-py3-none-any.whl", hash = "sha256:bdbc9e9877f2b07cdf69893bb87fc798cb4992e262b6fcf702097994b82aaa3e"},
+    {file = "questionary-1.7.0.tar.gz", hash = "sha256:338f326d3d10204dc3a21a07cfa8243f32d8d8f3d9f3de244951066c0769f2ea"},
 ]
 regex = [
     {file = "regex-2020.10.11-cp27-cp27m-win32.whl", hash = "sha256:4f5c0fe46fb79a7adf766b365cae56cafbf352c27358fda811e4a1dc8216d0db"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,19 +46,18 @@ mkdocs-mermaid2-plugin = {version = "^0.5.0", optional = true}
 docs = ["mkdocstrings", "mkdocs-material", "mkdocs-mermaid2-plugin"]
 
 [tool.poetry.dev-dependencies]
-black = {version = "^19.10b0", allow-prereleases = true}
-flake8 = "*"
-flake8-blind-except = "*"
-flake8-bugbear = "*"
-flake8-comprehensions = "*"
-flake8-debugger = "*"
-mypy = "*"
+black = "^20.8b1"
+flake8 = "^3.8.4"
+flake8-bugbear = "^20.1.4"
+flake8-comprehensions = "^3.2.3"
+flake8-debugger = "^3.2.1"
+mypy = "^0.790"
 pexpect = "^4.8.0"
-poethepoet = "^0.7.0"
-pre-commit = "*"
-pytest = "*"
-pytest-cov = "*"
-pytest-xdist = "*"
+poethepoet = "^0.9.0"
+pre-commit = "^2.7.1"
+pytest = "^6.1.1"
+pytest-cov = "^2.10.1"
+pytest-xdist = "^2.1.0"
 
 # HACK https://github.com/python-poetry/poetry/issues/2555
 # TODO Remove from this section and install with poetry install -E docs when fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ mkdocs-mermaid2-plugin = {version = "^0.5.0", optional = true}
 docs = ["mkdocstrings", "mkdocs-material", "mkdocs-mermaid2-plugin"]
 
 [tool.poetry.dev-dependencies]
+autoflake = "^1.4"
 black = "^20.8b1"
 flake8 = "^3.8.4"
 flake8-bugbear = "^20.1.4"
@@ -58,13 +59,6 @@ pre-commit = "^2.7.1"
 pytest = "^6.1.1"
 pytest-cov = "^2.10.1"
 pytest-xdist = "^2.1.0"
-
-# HACK https://github.com/python-poetry/poetry/issues/2555
-# TODO Remove from this section and install with poetry install -E docs when fixed
-mkdocstrings = "^0.13.1"
-mkdocs-material = "^5.5.5"
-autoflake = "^1.4"
-mkdocs-mermaid2-plugin = "^0.5.0"
 
 [tool.poe.tasks.clean]
 script = "devtasks:clean"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,14 +25,13 @@ copier = "copier.cli:CopierApp.run"
 "Bug Tracker" = "https://github.com/pykong/copier/issues"
 
 [tool.poetry.dependencies]
-# HACK https://github.com/tmbo/questionary/pull/71
-python = ">=3.6.1,<3.9"
+python = ">=3.6.1,<3.10"
 colorama = "^0.4.3"
 iteration_utilities = "^0.10.1"
 jinja2 = "^2.11.2"
 pathspec = "^0.8.0"
 plumbum = "^1.6.9"
-pydantic = "^1.5.1"
+pydantic = "^1.6.1"
 questionary = "^1.7.0"
 pyyaml = "^5.3.1"
 pyyaml-include = "^1.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ jinja2 = "^2.11.2"
 pathspec = "^0.8.0"
 plumbum = "^1.6.9"
 pydantic = "^1.5.1"
-questionary = "^1.6.0"
+questionary = "^1.7.0"
 pyyaml = "^5.3.1"
 pyyaml-include = "^1.2"
 # packaging is needed when installing from PyPI

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,9 @@ def spawn():
     if platform.system() == "Windows":
         # HACK https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1243#issuecomment-706668723
         # FIXME Use pexpect or wexpect somehow to fix this
-        pytest.xfail("pexpect fails on Windows",)
+        pytest.xfail(
+            "pexpect fails on Windows",
+        )
     # Using PopenSpawn, although probably it would be best to use pexpect.spawn
     # instead. However, it's working fine and it seems easier to fix in the
     # future to work on Windows (where, this way, spawning actually works; it's just

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -18,7 +18,10 @@ def test_do_not_cleanup(tmp_path):
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
         copier.copy(
-            "./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False,
+            "./tests/demo_cleanup",
+            dst,
+            quiet=True,
+            cleanup_on_error=False,
         )
     assert (dst).exists()
 

--- a/tests/test_demo_update_tasks.py
+++ b/tests/test_demo_update_tasks.py
@@ -15,7 +15,10 @@ def test_update_tasks(tmpdir):
     tmp_path = tmpdir / "tmp_path"
     # Copy the 1st version
     copy(
-        str(REPO_BUNDLE_PATH), tmp_path, force=True, vcs_ref="v1",
+        str(REPO_BUNDLE_PATH),
+        tmp_path,
+        force=True,
+        vcs_ref="v1",
     )
     # Init destination as a new independent git repo
     with local.cwd(tmp_path):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,4 +1,3 @@
-import inspect
 from pathlib import Path
 
 import pexpect
@@ -6,7 +5,6 @@ import pytest
 import yaml
 from plumbum import local
 from plumbum.cmd import git
-from questionary.prompts.text import text
 
 from .helpers import COPIER_PATH, Keyboard, build_file_tree
 
@@ -247,13 +245,3 @@ def test_multiline(tmp_path_factory, spawn, type_):
             "question_4": ("answer 4"),
             "question_5": ("answer 5"),
         }
-
-
-def questionary_supports_custom_lexer():
-    """Check that questionary doesn't support custom lexers.
-
-    If this test fails, it means that https://github.com/tmbo/questionary/pull/70
-    was merged and then you should revert https://github.com/copier-org/copier/pull/289
-    to enable lexer support.
-    """
-    assert "lexer" not in inspect.signature(text).parameters

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -156,7 +156,12 @@ def test_templated_prompt_builtins():
     )
 
     data = query_user_data(
-        {"question": {"default": "[[ make_secret() ]]"}}, {}, {}, {}, False, envops,
+        {"question": {"default": "[[ make_secret() ]]"}},
+        {},
+        {},
+        {},
+        False,
+        envops,
     )
     assert isinstance(data["question"], str) and len(data["question"]) == 128
 
@@ -164,7 +169,12 @@ def test_templated_prompt_builtins():
 def test_templated_prompt_invalid():
     # assert no exception in non-strict mode
     query_user_data(
-        {"question": {"default": "[[ not_valid ]]"}}, {}, {}, {}, False, envops,
+        {"question": {"default": "[[ not_valid ]]"}},
+        {},
+        {},
+        {},
+        False,
+        envops,
     )
 
     # assert no exception in non-strict mode
@@ -174,12 +184,22 @@ def test_templated_prompt_invalid():
 
     with pytest.raises(InvalidTypeError):
         query_user_data(
-            {"question": {"type": "[[ not_valid ]]"}}, {}, {}, {}, False, envops,
+            {"question": {"type": "[[ not_valid ]]"}},
+            {},
+            {},
+            {},
+            False,
+            envops,
         )
 
     # assert no exception in non-strict mode
     query_user_data(
-        {"question": {"choices": ["[[ not_valid ]]"]}}, {}, {}, {}, False, envops,
+        {"question": {"choices": ["[[ not_valid ]]"]}},
+        {},
+        {},
+        {},
+        False,
+        envops,
     )
 
     # TODO: uncomment this later when EnvOps supports setting the undefined behavior


### PR DESCRIPTION
- Enhance status of #102 by trying to support python 3.9 and testing it. Not actually supported because of https://github.com/samuelcolvin/pydantic/issues/1985 and https://github.com/samuelcolvin/pydantic/issues/2009.
- Update pre-commit hooks that are possible to update (not prettier because of https://github.com/prettier/prettier/issues/9430).
- Update dev dependencies and pin their versions, to avoid possible future headaches.
- Reformat code with newer black release.
- Fix type problems.
- Update to new release of questionary.
- Revert https://github.com/copier-org/copier/pull/289 now that questionary supports custom lexers.