### PR TITLE
Remove YAML casting for bool types

### DIFF
--- a/copier/config/user_data.py
+++ b/copier/config/user_data.py
@@ -485,9 +485,6 @@ def cast_answer_type(answer: Any, type_fn: Callable) -> Any:
     # Skip casting None into "None"
     if type_fn is str and answer is None:
         return answer
-    # Parse correctly bools as 1, true, yes...
-    if type_fn is bool and isinstance(answer, str):
-        return parse_yaml_string(answer)
     try:
         return type_fn(answer)
     except (TypeError, AttributeError):


### PR DESCRIPTION
~~If calling Copier through CLI, it's normal to convert all strings to expected data, but if calling through API, you should know what kind of data you're passing in, so it shouldn't try to be smarter than you.~~

This was going to fix #280, but after all that's not a real issue.

I'm just going to merge the improvements done while attempting to fix that, without changing Copier behavior.