### PR TITLE
fixed typo

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -347,7 +347,7 @@ _extra_paths:
 ### `force`
 
 -   Format: `bool`
--   CLI flags: `-q`, `--force`
+-   CLI flags: `-f`, `--force`
 -   Default value: `False`
 
 Overwrite files that already exist, without asking.


### PR DESCRIPTION
"-f" makes more sense and matches https://github.com/copier-org/copier/blob/master/copier/cli.py#L138 ;)