### PR TITLE
Allow updating a shallow-cloned repo

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -268,7 +268,7 @@ def update_diff(conf: ConfigData) -> None:
             git("config", "--unset", "user.name")
             git("config", "--unset", "user.email")
             git("remote", "add", "real_dst", conf.dst_path)
-            git("fetch", "real_dst", "HEAD")
+            git("fetch", "--depth=1", "real_dst", "HEAD")
             diff_cmd = git["diff-tree", "--unified=1", "HEAD...FETCH_HEAD"]
             try:
                 diff = diff_cmd("--inter-hunk-context=-1")


### PR DESCRIPTION
Before this patch, if the repo you were updating was shallow, Copier failed to update it.

Now it should update any repo, no matter its depth. We only need to fetch 1 commit from it, after all.