### PR TITLE
Instantiate template from subdirectory of repo

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -131,6 +131,17 @@ class CopierApp(cli.Application):
         ),
     )
 
+    repo_subdir: cli.SwitchAttr = cli.SwitchAttr(
+        ["-c", "--repo-subdir"],
+        str,
+        help=(
+            "If using a VCS repository as a source, indicates that the template"
+            " (i.e. the directory containing copier.yml) is found in the given"
+            " subdirectory. If not specified, the template is assumed to be at"
+            " the root of the repository."
+        )
+    )
+
     pretend: cli.Flag = cli.Flag(
         ["-n", "--pretend"], help="Run but do not make any changes"
     )
@@ -184,6 +195,7 @@ class CopierApp(cli.Application):
             src_path=src_path,
             vcs_ref=self.vcs_ref,
             subdirectory=self.subdirectory,
+            repo_subdir=self.repo_subdir,
             use_prereleases=self.prereleases,
             **kwargs,
         )

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -1,6 +1,7 @@
 """Functions used to generate configuration data."""
 
 from collections import ChainMap
+import os.path
 from typing import Tuple
 
 from packaging import version
@@ -106,6 +107,8 @@ def make_config(
         repo = vcs.get_repo(src_path)
         if repo:
             src_path = vcs.clone(repo, vcs_ref or "HEAD")
+            if subdirectory:
+                src_path = os.path.join(src_path, subdirectory)
             vcs_ref = vcs_ref or vcs.checkout_latest_tag(src_path, use_prereleases)
             with local.cwd(src_path):
                 init_args["commit"] = git("describe", "--tags", "--always").strip()

--- a/copier/config/factory.py
+++ b/copier/config/factory.py
@@ -96,6 +96,7 @@ def make_config(
     if src_path is None:
         try:
             src_path = init_args["data_from_answers_file"]["_src_path"]
+            subdirectory = init_args["data_from_answers_file"].get("_subdirectory", None)
         except KeyError:
             raise NoSrcPathError(
                 "No copier answers file found, or it didn't include "
@@ -109,6 +110,7 @@ def make_config(
             src_path = vcs.clone(repo, vcs_ref or "HEAD")
             if subdirectory:
                 src_path = os.path.join(src_path, subdirectory)
+                init_args["subdirectory"] = subdirectory
             vcs_ref = vcs_ref or vcs.checkout_latest_tag(src_path, use_prereleases)
             with local.cwd(src_path):
                 init_args["commit"] = git("describe", "--tags", "--always").strip()

--- a/copier/config/objects.py
+++ b/copier/config/objects.py
@@ -67,6 +67,7 @@ class ConfigData(BaseModel):
 
     src_path: Path
     subdirectory: OptStr
+    repo_subdir: OptStr
     dst_path: Path
     extra_paths: PathSeq = ()
     exclude: StrOrPathSeq = DEFAULT_EXCLUDE

--- a/copier/main.py
+++ b/copier/main.py
@@ -180,8 +180,6 @@ def copy_local(conf: ConfigData) -> None:
     rel_folder: StrOrPath
 
     src_path = conf.src_path
-    if conf.subdirectory is not None:
-        src_path /= conf.subdirectory
 
     for folder, sub_dirs, files in os.walk(src_path):
         rel_folder = str(folder).replace(str(src_path), "", 1).lstrip(os.path.sep)

--- a/copier/main.py
+++ b/copier/main.py
@@ -59,6 +59,7 @@ def copy(
     vcs_ref: OptStr = None,
     only_diff: OptBool = True,
     subdirectory: OptStr = None,
+    repo_subdir: OptStr = None,
     use_prereleases: OptBool = False,
 ) -> None:
     """Uses the template in `src_path` to generate a new project at `dst_path`.
@@ -180,6 +181,8 @@ def copy_local(conf: ConfigData) -> None:
     rel_folder: StrOrPath
 
     src_path = conf.src_path
+    if conf.subdirectory is not None:
+        src_path /= conf.subdirectory
 
     for folder, sub_dirs, files in os.walk(src_path):
         rel_folder = str(folder).replace(str(src_path), "", 1).lstrip(os.path.sep)

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -168,8 +168,8 @@ class Renderer:
         # All internal values must appear first
         if conf.commit:
             answers["_commit"] = conf.commit
-        if conf.subdirectory:
-            answers["_subdirectory"] = conf.subdirectory
+        if conf.repo_subdir:
+            answers["_repo_subdir"] = conf.repo_subdir
         if conf.original_src_path is not None:
             answers["_src_path"] = conf.original_src_path
         # Other data goes next

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -168,6 +168,8 @@ class Renderer:
         # All internal values must appear first
         if conf.commit:
             answers["_commit"] = conf.commit
+        if conf.subdirectory:
+            answers["_subdirectory"] = conf.subdirectory
         if conf.original_src_path is not None:
             answers["_src_path"] = conf.original_src_path
         # Other data goes next


### PR DESCRIPTION
Pursuant to problems described in issue #315. The use case is that we have a template in a subdirectory of a git repo. While I originally believed this is what the subdirectory flag is for, it became apparent reading through the tests that this option was conceived for other uses.

This pull request adds a command line option "--repo-subdir", which is added to the src_path as soon as the repository is checked out, allowing the copier.yml to be pulled from the subdirectory.

In addition, this subdirectory is stored in the copier-answers (as "_repo_subdir") allowing one to `copier update` without re-specifying the command line option.

I'll note that I'm on windows, where many of the tests are marked xfail, so I can't check that these haven't broken.