### PR TITLE
Warn major version difference

### DIFF
--- a/copier/errors.py
+++ b/copier/errors.py
@@ -8,19 +8,24 @@ from .tools import printf_exception
 from .types import PathSeq
 
 
-class UserMessageError(Exception):
+# Errors
+class CopierError(Exception):
+    """Base class for all other Copier errors."""
+
+
+class UserMessageError(CopierError):
     """Exit the program giving a message to the user."""
 
 
-class UnsupportedVersionError(UserMessageError):
+class UnsupportedVersionError(UserMessageError, CopierError):
     """Copier version does not support template version."""
 
 
-class ConfigFileError(ValueError):
+class ConfigFileError(ValueError, CopierError):
     """Parent class defining problems with the config file."""
 
 
-class InvalidConfigFileError(ConfigFileError):
+class InvalidConfigFileError(ConfigFileError, CopierError):
     """Indicates that the config file is wrong."""
 
     def __init__(self, conf_path: Path, quiet: bool):
@@ -29,7 +34,7 @@ class InvalidConfigFileError(ConfigFileError):
         super().__init__(msg)
 
 
-class MultipleConfigFilesError(ConfigFileError):
+class MultipleConfigFilesError(ConfigFileError, CopierError):
     """Both copier.yml and copier.yaml found, and that's an error."""
 
     def __init__(self, conf_paths: "PathSeq", quiet: bool):
@@ -38,19 +43,32 @@ class MultipleConfigFilesError(ConfigFileError):
         super().__init__(msg)
 
 
-class InvalidTypeError(TypeError):
+class InvalidTypeError(TypeError, CopierError):
     """The question type is not among the supported ones."""
 
 
-class PathNotAbsoluteError(_PathValueError):
+class PathNotAbsoluteError(_PathValueError, CopierError):
     """The path is not absolute, but it should be."""
 
     code = "path.not_absolute"
     msg_template = '"{path}" is not an absolute path'
 
 
-class PathNotRelativeError(_PathValueError):
+class PathNotRelativeError(_PathValueError, CopierError):
     """The path is not relative, but it should be."""
 
     code = "path.not_relative"
     msg_template = '"{path}" is not a relative path'
+
+
+# Warnings
+class CopierWarning(Warning):
+    """Base class for all other Copier warnings."""
+
+
+class UnknownCopierVersionWarning(UserWarning, CopierWarning):
+    """Cannot determine installed Copier version."""
+
+
+class OldTemplateWarning(UserWarning, CopierWarning):
+    """Template was designed for an older Copier version."""


### PR DESCRIPTION
Targeting #348, from now on, if we cannot check the copier version or the installed version's major part is bigger than the template's minimal major part, there'll be proper warnings.