### PR TITLE
feat: Add `__main__` module allowing to run `python -m copier`

### DIFF
--- a/copier/__main__.py
+++ b/copier/__main__.py
@@ -1,0 +1,4 @@
+from copier.cli import CopierApp
+
+if __name__ == "__main__":
+    CopierApp.run()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,6 @@
+import subprocess
+import sys
+
 import pytest
 import yaml
 
@@ -38,3 +41,8 @@ def test_good_cli_run(tmp_path, template_path):
 
 def test_help():
     COPIER_CMD("--help-all")
+
+
+def test_python_run():
+    cmd = [sys.executable, "-m", "copier", "--help-all"]
+    assert subprocess.run(cmd, check=True).returncode == 0


### PR DESCRIPTION
Being able to run Copier with `python -m copier` is really useful for debugging purposes.
For example in PyCharm and VSCode, you can create a new "Run" configuration by only providing a module name (not a script path or anything else, just the module name).
Without the `__main__` module, these configurations do not work:

```console
% poetry run python -m copier
/home/pawamoy/.cache/pypoetry/virtualenvs/copier-AExR1Oeb-py3.9/bin/python: No module named copier.__main__; 'copier' is a package and cannot be directly executed
```