### PR TITLE
fix: remember user answers while running interactively

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -326,21 +326,18 @@ class Worker:
                     **details,
                 )
             )
-        if self.force:
-            # Avoid prompting to not requiring a TTy when --force
-            for question in questions:
-                new_answer = question.get_default()
-                previous_answer = result.combined.get(question.var_name)
-                if new_answer != previous_answer:
-                    result.user[question.var_name] = new_answer
-        else:
-            # Display TUI and ask user interactively
-            result.user.update(
-                unsafe_prompt(
-                    (question.get_questionary_structure() for question in questions),
-                    answers=result.combined,
-                )
+        for question in questions:
+            # Display TUI and ask user interactively only without --force
+            new_answer = (
+                question.get_default()
+                if self.force
+                else unsafe_prompt(
+                    question.get_questionary_structure(), answers=result.combined
+                )[question.var_name]
             )
+            previous_answer = result.combined.get(question.var_name)
+            if new_answer != previous_answer:
+                result.user[question.var_name] = new_answer
         return result
 
     @cached_property

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -363,6 +363,7 @@ class Question:
             # value was not a string
             return value
         try:
+            # TODO Aquí, answers.combined tiene owner1:None
             return template.render(**self.answers.combined)
         except UndefinedError as error:
             raise UserMessageError(str(error)) from error

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import platform
+import sys
 
 import pytest
 from pexpect.popen_spawn import PopenSpawn
@@ -12,6 +13,12 @@ def spawn():
         # FIXME Use pexpect or wexpect somehow to fix this
         pytest.xfail(
             "pexpect fails on Windows",
+        )
+    # Disable subprocess timeout if debugging, for commodity
+    # See https://stackoverflow.com/a/67065084/1468388
+    if getattr(sys, "gettrace", lambda: False):
+        return lambda cmd, timeout=None, *args, **kwargs: PopenSpawn(
+            cmd, None, *args, **kwargs
         )
     # Using PopenSpawn, although probably it would be best to use pexpect.spawn
     # instead. However, it's working fine and it seems easier to fix in the

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -36,7 +36,10 @@ COPIER_CMD = local.get(
     "copier.cmd",
     "copier",
 )
-COPIER_PATH = str(COPIER_CMD.executable)
+
+# Executing copier this way allows to debug subprocesses using debugpy
+# See https://github.com/microsoft/debugpy/issues/596#issuecomment-824643237
+COPIER_PATH = (sys.executable, "-m", "copier")
 
 # Helpers to use with tests designed for old copier bracket envops defaults
 BRACKET_ENVOPS = {

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -138,7 +138,7 @@ def test_cli_interactive(tmp_path, spawn, template_path):
         "Invalid value",
         "please try again",
     ]
-    tui = spawn([COPIER_PATH, "copy", template_path, str(tmp_path)], timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", template_path, str(tmp_path)), timeout=10)
     tui.expect_exact(["I need to know it. Do you love me?", "love_me", "Format: bool"])
     tui.send("y")
     tui.expect_exact(["Please tell me your name.", "your_name", "Format: str"])
@@ -272,8 +272,8 @@ def test_cli_interatively_with_flag_data_and_type_casts(
         "please try again",
     ]
     tui = spawn(
-        [
-            COPIER_PATH,
+        COPIER_PATH
+        + (
             "--data=choose_list=second",
             "--data=choose_dict=first",
             "--data=choose_tuple=third",
@@ -281,7 +281,7 @@ def test_cli_interatively_with_flag_data_and_type_casts(
             "copy",
             template_path,
             str(tmp_path),
-        ],
+        ),
         timeout=10,
     )
     tui.expect_exact(["I need to know it. Do you love me?", "love_me", "Format: bool"])

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -57,14 +57,14 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
         git("tag", "v2")
     with local.cwd(subproject):
         # Copy the v1 template
-        args = []
+        args = ()
         if name is not DEFAULT:
-            args.append(f"--data=your_name={name}")
+            args += (f"--data=your_name={name}",)
         else:
             name = "Mario"  # Default in the template
         name = str(name)
         tui = spawn(
-            [COPIER_PATH, str(template), ".", "--vcs-ref=v1"] + args, timeout=10
+            COPIER_PATH + (str(template), ".", "--vcs-ref=v1") + args, timeout=10
         )
         # Check what was captured
         tui.expect_exact(["in_love?", "Format: bool", "(Y/n)"])
@@ -86,7 +86,7 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
         git("add", ".")
         assert "_commit: v1" in Path(".copier-answers.yml").read_text()
         git("commit", "-m", "v1")
-        tui = spawn([COPIER_PATH], timeout=30)
+        tui = spawn(COPIER_PATH, timeout=30)
         # Check what was captured
         tui.expect_exact(["in_love?", "Format: bool", "(Y/n)"])
         tui.sendline()
@@ -168,7 +168,7 @@ def test_when(tmp_path_factory, question_1, question_2_when, spawn, asks):
             / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
         }
     )
-    tui = spawn([COPIER_PATH, str(template), str(subproject)], timeout=10)
+    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
     tui.expect_exact(["question_1?", f"Format: {type(question_1).__name__}", "(Y/n)"])
     tui.sendline()
     if asks:
@@ -207,7 +207,7 @@ def test_placeholder(tmp_path_factory, spawn):
             / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
         }
     )
-    tui = spawn([COPIER_PATH, str(template), str(subproject)], timeout=10)
+    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
     tui.expect_exact(["question_1?", "Format: str", "answer 1"])
     tui.sendline()
     tui.expect_exact(
@@ -253,7 +253,7 @@ def test_multiline(tmp_path_factory, spawn, type_):
             / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
         }
     )
-    tui = spawn([COPIER_PATH, str(template), str(subproject)], timeout=10)
+    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
     tui.expect_exact(["question_1?", "Format: str", "answer 1"])
     tui.sendline()
     tui.expect_exact(["question_2?", f"Format: {type_}"])
@@ -325,7 +325,7 @@ def test_update_choice(tmp_path_factory, spawn, choices):
         git("commit", "-m one")
         git("tag", "v1")
     # Copy
-    tui = spawn([COPIER_PATH, str(template), str(subproject)], timeout=10)
+    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
     tui.expect_exact(["pick_one?"])
     tui.sendline(Keyboard.Up)
     tui.expect_exact(pexpect.EOF)
@@ -336,7 +336,7 @@ def test_update_choice(tmp_path_factory, spawn, choices):
         git("add", ".")
         git("commit", "-m1")
     # Update
-    tui = spawn([COPIER_PATH, str(subproject)], timeout=10)
+    tui = spawn(COPIER_PATH + (str(subproject),), timeout=10)
     tui.expect_exact(["pick_one?"])
     tui.sendline(Keyboard.Down)
     tui.expect_exact(["Overwrite", ".copier-answers.yml", "[Y/n]"])

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -142,7 +142,7 @@ def test_templated_prompt(
             / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
         }
     )
-    tui = spawn([COPIER_PATH, str(template), str(subproject)], timeout=10)
+    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
     tui.expect_exact(["main?", "Format: yaml", main_default])
     tui.sendline()
     tui.expect_exact([f"{question_name}?"] + expected_outputs)


### PR DESCRIPTION
This was the case when forced, but not when ran interactively. It was a regression from the v6 refactor.

Fixes https://github.com/copier-org/copier/issues/327.