### PR TITLE
fix: inherit permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Summary:
     add `type: yaml` to make it behave _mostly_ as before. Or just don't use that, it's
     complicated anyway (warn added to docs).
 -   Changed `--force` to be the same as `--defaults --overwrite`.
+-   Copied files will reflect permissions on the same files in the template.
 
 ### Deprecated
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -248,7 +248,11 @@ class Worker:
         return bool(ask(f" Overwrite {dst_relpath}?", default=True))
 
     def _render_allowed(
-        self, dst_relpath: Path, is_dir: bool = False, expected_contents: bytes = b""
+        self,
+        dst_relpath: Path,
+        is_dir: bool = False,
+        expected_contents: bytes = b"",
+        expected_permissions=None,
     ) -> bool:
         """Determine if a file or directory can be rendered.
 
@@ -429,10 +433,16 @@ class Worker:
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
         if dst_abspath.is_dir():
             return
-        if not self._render_allowed(dst_relpath, expected_contents=new_content):
+        src_mode = src_abspath.stat().st_mode
+        if not self._render_allowed(
+            dst_relpath,
+            expected_contents=new_content,
+            expected_permissions=src_mode,
+        ):
             return
         if not self.pretend:
             dst_abspath.write_bytes(new_content)
+            dst_abspath.chmod(src_mode)
 
     def _render_folder(self, src_abspath: Path) -> None:
         """Recursively render a folder.


### PR DESCRIPTION
When copying a file, make sure its permissions are the same as those of the file in the template.

Fixes https://github.com/copier-org/copier/issues/361.