### PR TITLE
int-autotruncated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Summary:
 -   Running `copier copy` on a preexisting project now recopies the project instead of
     updating it. That means that it respects old answers, but ignores history diff.
 -   We use Jinja 2 defaults now. `{{ }}` instead of `[[ ]]` and similar.
+-   Multi-typed choices follow the same type-casting logic as any other question, so
+    it's easier to reason about them. However, if you were using this feature, you might
+    be surprised about its side effects if you don't specify the type explicitly. Just
+    add `type: yaml` to make it behave _mostly_ as before. Or just don't use that, it's
+    complicated anyway (warn added to docs).
 
 ### Deprecated
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -74,9 +74,49 @@ Supported keys:
     `json`, `str`, `yaml` (default).
 -   **help**: Additional text to help the user know what's this question for.
 -   **choices**: To restrict possible values.
+
+    !!! tip
+
+        A choice value of `null` makes it become the same as its key.
+
+    !!! warning
+
+        You are able to use different types for each choice value, but it is not
+        recommended because you can get to some weird scenarios.
+
+        For example, try to understand this 🥴
+
+        ```yaml
+        pick_one:
+            type: yaml # If you are mixing types, better be explicit
+            choices:
+                Nothing, thanks: "null" # Will be YAML-parsed and converted to null
+                Value is key: null # Value will be converted to "Value is key"
+                One and a half: 1.5
+                "Yes": true
+                Nope: no
+                Some array: "[yaml, converts, this]"
+        ```
+
+        It's better to stick with a simple type and reason about it later in
+        template code:
+
+        ```yaml
+        pick_one:
+            type: str
+            choices:
+                Nothing, thanks: ""
+                Value is key: null # Becomes "Value is key", which is a str
+                One and a half: "1.5"
+                "Yes": "true"
+                Nope: "no"
+                Some array: "[str, keeps, this, as, a, str]"
+        ```
+
 -   **default**: Leave empty to force the user to answer. Provide a default to save him
     from typing it if it's quite common. When using `choices`, the default must be the
-    choice _value_, not its _key_. If values are quite long, you can use
+    choice _value_, not its _key_, and it must match its _type_. If values are quite
+    long, you can use
     [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html).
 -   **secret**: When `true`, it hides the prompt displaying asterisks (`*****`) and
     doesn't save the answer in [the answers file](#the-copier-answersyml-file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def spawn():
         )
     # Disable subprocess timeout if debugging, for commodity
     # See https://stackoverflow.com/a/67065084/1468388
-    if getattr(sys, "gettrace", lambda: False):
+    if getattr(sys, "gettrace", lambda: None)() is not None:
         return lambda cmd, timeout=None, *args, **kwargs: PopenSpawn(
             cmd, None, *args, **kwargs
         )


### PR DESCRIPTION
- Inform about `null` value being converted to choice key.
- Warn about problems when using multiple types in choices.

Fixes https://github.com/copier-org/copier/issues/405.