### PR TITLE
fix: wrong usage of expect_exact([...])

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import platform
 import sys
 
 import pytest
+from coverage.tracer import CTracer
 from pexpect.popen_spawn import PopenSpawn
 
 
@@ -14,9 +15,10 @@ def spawn():
         pytest.xfail(
             "pexpect fails on Windows",
         )
-    # Disable subprocess timeout if debugging, for commodity
+    # Disable subprocess timeout if debugging (except coverage), for commodity
     # See https://stackoverflow.com/a/67065084/1468388
-    if getattr(sys, "gettrace", lambda: None)() is not None:
+    tracer = getattr(sys, "gettrace", lambda: None)()
+    if not isinstance(tracer, (CTracer, type(None))):
         return lambda cmd, timeout=None, *args, **kwargs: PopenSpawn(
             cmd, None, *args, **kwargs
         )

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -136,10 +136,7 @@ def test_api(tmp_path, template_path):
 
 def test_cli_interactive(tmp_path, spawn, template_path):
     """Test copier correctly processes advanced questions and answers through CLI."""
-    invalid = [
-        "Invalid value",
-        "please try again",
-    ]
+    invalid = ["Invalid input"]
     tui = spawn(COPIER_PATH + ("copy", template_path, str(tmp_path)), timeout=10)
     deque(
         map(
@@ -290,10 +287,7 @@ def test_cli_interatively_with_flag_data_and_type_casts(
     tmp_path: Path, spawn, template_path
 ):
     """Assert how choices work when copier is invoked with --data interactively."""
-    invalid = [
-        "Invalid value",
-        "please try again",
-    ]
+    invalid = "Invalid input"
     tui = spawn(
         COPIER_PATH
         + (
@@ -321,28 +315,31 @@ def test_cli_interatively_with_flag_data_and_type_casts(
         )
     )
     tui.sendline("Guybrush Threpwood")
-    q = ["How old are you?", "your_age", "Format: int"]
-    deque(map(tui.expect_exact, q))
-    tui.sendline("wrong your_age")
-    deque(map(tui.expect_exact, (invalid + q)))
+    deque(map(tui.expect_exact, ["How old are you?", "your_age", "Format: int"]))
+    tui.send("wrong your_age")
+    tui.expect_exact(invalid)
+    tui.sendline()  # Does nothing, "wrong your_age still on screen"
     tui.send((Keyboard.Alt + Keyboard.Backspace) * 2)
     tui.sendline("22")
-    q = ["What's your height?", "your_height", "Format: float"]
-    deque(map(tui.expect_exact, (q)))
-    tui.sendline("wrong your_height")
-    deque(map(tui.expect_exact, (invalid + q)))
+    deque(
+        map(tui.expect_exact, ["What's your height?", "your_height", "Format: float"])
+    )
+    tui.send("wrong your_height")
+    tui.expect_exact(invalid)
     tui.send((Keyboard.Alt + Keyboard.Backspace) * 2)
     tui.sendline("1.56")
-    q = ["more_json_info", "Format: json"]
-    deque(map(tui.expect_exact, (q)))
+    deque(map(tui.expect_exact, ["more_json_info", "Format: json"]))
     tui.sendline('{"objective":')
-    deque(map(tui.expect_exact, (invalid + q)))
+    tui.expect_exact(invalid)
     tui.sendline('"be a pirate"}')
     tui.send(Keyboard.Esc + Keyboard.Enter)
-    q = ["Wanna give me any more info?", "anything_else", "Format: yaml"]
-    deque(map(tui.expect_exact, (q)))
+    deque(
+        map(
+            tui.expect_exact,
+            ["Wanna give me any more info?", "anything_else", "Format: yaml"],
+        )
+    )
     tui.sendline("- Want some grog?")
-    deque(map(tui.expect_exact, (invalid + q)))
     tui.sendline("- I'd love it")
     tui.send(Keyboard.Esc + Keyboard.Enter)
     deque(map(tui.expect_exact, ["minutes_under_water", "Format: int", "10"]))

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -1,4 +1,5 @@
 import json
+from collections import deque
 from pathlib import Path
 from textwrap import dedent
 
@@ -140,9 +141,16 @@ def test_cli_interactive(tmp_path, spawn, template_path):
         "please try again",
     ]
     tui = spawn(COPIER_PATH + ("copy", template_path, str(tmp_path)), timeout=10)
-    tui.expect_exact(["I need to know it. Do you love me?", "love_me", "Format: bool"])
+    deque(
+        map(
+            tui.expect_exact,
+            ["I need to know it. Do you love me?", "love_me", "Format: bool"],
+        )
+    )
     tui.send("y")
-    tui.expect_exact(["Please tell me your name.", "your_name", "Format: str"])
+    deque(
+        map(tui.expect_exact, ["Please tell me your name.", "your_name", "Format: str"])
+    )
     tui.sendline("Guybrush Threpwood")
     q = ["How old are you?", "your_age", "Format: int"]
     tui.expect_exact(q)
@@ -168,43 +176,57 @@ def test_cli_interactive(tmp_path, spawn, template_path):
     tui.expect_exact(invalid + q)
     tui.sendline("- I'd love it")
     tui.send(Keyboard.Esc + Keyboard.Enter)
-    tui.expect_exact(
-        [
-            "You see the value of the list items",
-            "choose_list",
-            "Format: str",
-            "first",
-            "second",
-            "third",
-        ]
+    deque(
+        map(
+            tui.expect_exact,
+            [
+                "You see the value of the list items",
+                "choose_list",
+                "Format: str",
+                "first",
+                "second",
+                "third",
+            ],
+        )
     )
     tui.sendline()
-    tui.expect_exact(
-        [
-            "You see the 1st tuple item, but I get the 2nd item as a result",
-            "choose_tuple",
-            "one",
-            "two",
-            "three",
-        ]
+    deque(
+        map(
+            tui.expect_exact,
+            [
+                "You see the 1st tuple item, but I get the 2nd item as a result",
+                "choose_tuple",
+                "one",
+                "two",
+                "three",
+            ],
+        )
     )
     tui.sendline()
-    tui.expect_exact(
-        [
-            "You see the dict key, but I get the dict value",
-            "choose_dict",
-            "one",
-            "two",
-            "three",
-        ]
+    deque(
+        map(
+            tui.expect_exact,
+            [
+                "You see the dict key, but I get the dict value",
+                "choose_dict",
+                "one",
+                "two",
+                "three",
+            ],
+        )
     )
     tui.sendline()
-    tui.expect_exact(["This must be a number", "choose_number", "-1.1", "0", "1"])
+    deque(
+        map(
+            tui.expect_exact,
+            ["This must be a number", "choose_number", "-1.1", "0", "1"],
+        )
+    )
     tui.sendline()
-    tui.expect_exact(["minutes_under_water", "Format: int", "10"])
+    deque(map(tui.expect_exact, ["minutes_under_water", "Format: int", "10"]))
     tui.send(Keyboard.Backspace)
     tui.sendline()
-    tui.expect_exact(["optional_value", "Format: yaml"])
+    deque(map(tui.expect_exact, ["optional_value", "Format: yaml"]))
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
     results_file = tmp_path / "results.txt"
@@ -285,37 +307,47 @@ def test_cli_interatively_with_flag_data_and_type_casts(
         ),
         timeout=10,
     )
-    tui.expect_exact(["I need to know it. Do you love me?", "love_me", "Format: bool"])
+    deque(
+        map(
+            tui.expect_exact,
+            ["I need to know it. Do you love me?", "love_me", "Format: bool"],
+        )
+    )
     tui.send("y")
-    tui.expect_exact(["Please tell me your name.", "your_name", "Format: str"])
+    deque(
+        map(
+            tui.expect_exact,
+            ["Please tell me your name.", "your_name", "Format: str"],
+        )
+    )
     tui.sendline("Guybrush Threpwood")
     q = ["How old are you?", "your_age", "Format: int"]
-    tui.expect_exact(q)
+    deque(map(tui.expect_exact, q))
     tui.sendline("wrong your_age")
-    tui.expect_exact(invalid + q)
+    deque(map(tui.expect_exact, (invalid + q)))
     tui.send((Keyboard.Alt + Keyboard.Backspace) * 2)
     tui.sendline("22")
     q = ["What's your height?", "your_height", "Format: float"]
-    tui.expect_exact(q)
+    deque(map(tui.expect_exact, (q)))
     tui.sendline("wrong your_height")
-    tui.expect_exact(invalid + q)
+    deque(map(tui.expect_exact, (invalid + q)))
     tui.send((Keyboard.Alt + Keyboard.Backspace) * 2)
     tui.sendline("1.56")
     q = ["more_json_info", "Format: json"]
-    tui.expect_exact(q)
+    deque(map(tui.expect_exact, (q)))
     tui.sendline('{"objective":')
-    tui.expect_exact(invalid + q)
+    deque(map(tui.expect_exact, (invalid + q)))
     tui.sendline('"be a pirate"}')
     tui.send(Keyboard.Esc + Keyboard.Enter)
     q = ["Wanna give me any more info?", "anything_else", "Format: yaml"]
-    tui.expect_exact(q)
+    deque(map(tui.expect_exact, (q)))
     tui.sendline("- Want some grog?")
-    tui.expect_exact(invalid + q)
+    deque(map(tui.expect_exact, (invalid + q)))
     tui.sendline("- I'd love it")
     tui.send(Keyboard.Esc + Keyboard.Enter)
-    tui.expect_exact(["minutes_under_water", "Format: int", "10"])
+    deque(map(tui.expect_exact, ["minutes_under_water", "Format: int", "10"]))
     tui.sendline()
-    tui.expect_exact(["optional_value", "Format: yaml"])
+    deque(map(tui.expect_exact, ["optional_value", "Format: yaml"]))
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
     results_file = tmp_path / "results.txt"
@@ -361,11 +393,11 @@ def test_tui_inherited_default(tmp_path_factory, spawn):
         COPIER_PATH + ("copy", str(src), str(dst)),
         timeout=10,
     )
-    tui.expect_exact(["owner1?", "Format: str"])
+    deque(map(tui.expect_exact, ["owner1?", "Format: str"]))
     tui.sendline("example")
-    tui.expect_exact(["has_2_owners?", "Format: bool", "(y/N)"])
+    deque(map(tui.expect_exact, ["has_2_owners?", "Format: bool", "(y/N)"]))
     tui.send("y")
-    tui.expect_exact(["owner2?", "Format: str", "example"])
+    deque(map(tui.expect_exact, ["owner2?", "Format: str", "example"]))
     tui.sendline("2")
     tui.expect_exact(pexpect.EOF)
     assert json.loads((dst / "answers.json").read_bytes()) == {

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,3 +1,4 @@
+from collections import deque
 from pathlib import Path
 
 import pexpect
@@ -67,17 +68,27 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
             COPIER_PATH + (str(template), ".", "--vcs-ref=v1") + args, timeout=10
         )
         # Check what was captured
-        tui.expect_exact(["in_love?", "Format: bool", "(Y/n)"])
+        deque(map(tui.expect_exact, ["in_love?", "Format: bool", "(Y/n)"]))
         tui.sendline()
-        tui.expect_exact(["Yes"])
+        tui.expect_exact("Yes")
         if not args:
             tui.expect_exact(
                 ["If you have a name, tell me now.", "your_name?", "Format: str", name]
             )
             tui.sendline()
-        tui.expect_exact(["Secret enemy name", "your_enemy?", "Format: str", "******"])
+        deque(
+            map(
+                tui.expect_exact,
+                ["Secret enemy name", "your_enemy?", "Format: str", "******"],
+            )
+        )
         tui.sendline()
-        tui.expect_exact(["what_enemy_does?", "Format: str", f"Bowser hates {name}"])
+        deque(
+            map(
+                tui.expect_exact,
+                ["what_enemy_does?", "Format: str", f"Bowser hates {name}"],
+            )
+        )
         tui.sendline()
         tui.expect_exact(pexpect.EOF)
         assert "_commit: v1" in Path(".copier-answers.yml").read_text()
@@ -88,17 +99,30 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
         git("commit", "-m", "v1")
         tui = spawn(COPIER_PATH, timeout=30)
         # Check what was captured
-        tui.expect_exact(["in_love?", "Format: bool", "(Y/n)"])
+        deque(map(tui.expect_exact, ["in_love?", "Format: bool", "(Y/n)"]))
         tui.sendline()
-        tui.expect_exact(
-            ["If you have a name, tell me now.", "your_name?", "Format: str", name]
+        deque(
+            map(
+                tui.expect_exact,
+                ["If you have a name, tell me now.", "your_name?", "Format: str", name],
+            )
         )
         tui.sendline()
-        tui.expect_exact(["Secret enemy name", "your_enemy?", "Format: str", "Bowser"])
+        deque(
+            map(
+                tui.expect_exact,
+                ["Secret enemy name", "your_enemy?", "Format: str", "Bowser"],
+            )
+        )
         tui.sendline()
-        tui.expect_exact(["what_enemy_does?", "Format: str", f"Bowser hates {name}"])
+        deque(
+            map(
+                tui.expect_exact,
+                ["what_enemy_does?", "Format: str", f"Bowser hates {name}"],
+            )
+        )
         tui.sendline()
-        tui.expect_exact(["Overwrite", ".copier-answers.yml", "[Y/n]"])
+        deque(map(tui.expect_exact, ["Overwrite", ".copier-answers.yml", "[Y/n]"]))
         tui.sendline()
         tui.expect_exact(pexpect.EOF)
         assert "_commit: v2" in Path(".copier-answers.yml").read_text()
@@ -169,10 +193,15 @@ def test_when(tmp_path_factory, question_1, question_2_when, spawn, asks):
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    tui.expect_exact(["question_1?", f"Format: {type(question_1).__name__}", "(Y/n)"])
+    deque(
+        map(
+            tui.expect_exact,
+            ["question_1?", f"Format: {type(question_1).__name__}", "(Y/n)"],
+        )
+    )
     tui.sendline()
     if asks:
-        tui.expect_exact(["question_2?", "Format: yaml"])
+        deque(map(tui.expect_exact, ["question_2?", "Format: yaml"]))
         tui.sendline()
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
@@ -208,10 +237,17 @@ def test_placeholder(tmp_path_factory, spawn):
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    tui.expect_exact(["question_1?", "Format: str", "answer 1"])
+    deque(map(tui.expect_exact, ["question_1?", "Format: str", "answer 1"]))
     tui.sendline()
-    tui.expect_exact(
-        ["question_2?", "Format: yaml", "Write something like answer 1, but better"]
+    deque(
+        map(
+            tui.expect_exact,
+            [
+                "question_2?",
+                "Format: yaml",
+                "Write something like answer 1, but better",
+            ],
+        )
     )
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
@@ -254,17 +290,17 @@ def test_multiline(tmp_path_factory, spawn, type_):
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    tui.expect_exact(["question_1?", "Format: str", "answer 1"])
+    deque(map(tui.expect_exact, ["question_1?", "Format: str", "answer 1"]))
     tui.sendline()
-    tui.expect_exact(["question_2?", f"Format: {type_}"])
+    deque(map(tui.expect_exact, ["question_2?", f"Format: {type_}"]))
     tui.sendline('"answer 2"')
-    tui.expect_exact(["question_3?", f"Format: {type_}"])
+    deque(map(tui.expect_exact, ["question_3?", f"Format: {type_}"]))
     tui.sendline('"answer 3"')
     tui.send(Keyboard.Alt + Keyboard.Enter)
-    tui.expect_exact(["question_4?", f"Format: {type_}"])
+    deque(map(tui.expect_exact, ["question_4?", f"Format: {type_}"]))
     tui.sendline('"answer 4"')
     tui.send(Keyboard.Alt + Keyboard.Enter)
-    tui.expect_exact(["question_5?", f"Format: {type_}"])
+    deque(map(tui.expect_exact, ["question_5?", f"Format: {type_}"]))
     tui.sendline('"answer 5"')
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
@@ -326,7 +362,7 @@ def test_update_choice(tmp_path_factory, spawn, choices):
         git("tag", "v1")
     # Copy
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    tui.expect_exact(["pick_one?"])
+    tui.expect_exact("pick_one?")
     tui.sendline(Keyboard.Up)
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
@@ -337,9 +373,9 @@ def test_update_choice(tmp_path_factory, spawn, choices):
         git("commit", "-m1")
     # Update
     tui = spawn(COPIER_PATH + (str(subproject),), timeout=10)
-    tui.expect_exact(["pick_one?"])
+    tui.expect_exact("pick_one?")
     tui.sendline(Keyboard.Down)
-    tui.expect_exact(["Overwrite", ".copier-answers.yml", "[Y/n]"])
+    deque(map(tui.expect_exact, ["Overwrite", ".copier-answers.yml", "[Y/n]"]))
     tui.sendline("y")
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -111,7 +111,7 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
         deque(
             map(
                 tui.expect_exact,
-                ["Secret enemy name", "your_enemy?", "Format: str", "Bowser"],
+                ["Secret enemy name", "your_enemy?", "Format: str", "******"],
             )
         )
         tui.sendline()
@@ -183,7 +183,7 @@ def test_when(tmp_path_factory, question_1, question_2_when, spawn, asks):
         "_envops": BRACKET_ENVOPS,
         "_templates_suffix": SUFFIX_TMPL,
         "question_1": question_1,
-        "question_2": {"default": "something", "when": question_2_when},
+        "question_2": {"default": "something", "type": "yaml", "when": question_2_when},
     }
     build_file_tree(
         {
@@ -196,7 +196,7 @@ def test_when(tmp_path_factory, question_1, question_2_when, spawn, asks):
     deque(
         map(
             tui.expect_exact,
-            ["question_1?", f"Format: {type(question_1).__name__}", "(Y/n)"],
+            ["question_1?", f"Format: {type(question_1).__name__}"],
         )
     )
     tui.sendline()
@@ -244,7 +244,7 @@ def test_placeholder(tmp_path_factory, spawn):
             tui.expect_exact,
             [
                 "question_2?",
-                "Format: yaml",
+                "Format: str",
                 "Write something like answer 1, but better",
             ],
         )

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -1,3 +1,4 @@
+import json
 from collections import deque
 from datetime import datetime
 
@@ -32,7 +33,7 @@ main_question = {
         (
             {"templated_default": {"default": "[[ main ]]default"}},
             "copierdefault",
-            ["[copierdefault]"],
+            ["Format: str", "copierdefault"],
         ),
         (
             {
@@ -42,7 +43,7 @@ main_question = {
                 },
             },
             0,
-            ["Format: int", "[0]"],
+            ["Format: int", "0"],
         ),
         (
             {
@@ -52,17 +53,25 @@ main_question = {
                 },
             },
             main_default,
-            ["THIS copier HELP IS TEMPLATED"],
+            [
+                "THIS copier HELP IS TEMPLATED",
+                "templated_help?",
+                "Format: str",
+                "copier",
+            ],
         ),
         (
             {
                 "templated_choices_dict_1": {
                     "default": "[[ main ]]",
-                    "choices": {"choice 1": "[[ main ]]", "[[ main ]]": "value 2"},
+                    "choices": {
+                        "choice 1": "[[ main ]]",
+                        "[[ main ]]": "value 2",
+                    },
                 },
             },
             main_default,
-            ["choice 1", "copier"],
+            ["(Use arrow keys)", "choice 1", "copier"],
         ),
         (
             {
@@ -72,7 +81,7 @@ main_question = {
                 },
             },
             "value 2",
-            ["(1) choice 1", "(2) copier", "Choice [2]"],
+            ["(Use arrow keys)", "choice 1", "copier"],
         ),
         (
             {
@@ -82,7 +91,7 @@ main_question = {
                 },
             },
             main_default,
-            ["(1) copier", "(2) choice 2", "Choice [1]"],
+            ["(Use arrow keys)", "copier", "choice 2"],
         ),
         (
             {
@@ -92,7 +101,7 @@ main_question = {
                 },
             },
             "choice 1",
-            ["(1) choice 1", "(2) copier", "Choice [1]"],
+            ["(Use arrow keys)", "choice 1", "copier"],
         ),
         (
             {
@@ -102,7 +111,7 @@ main_question = {
                 },
             },
             main_default,
-            ["(1) name 1", "(2) copier", "Choice [1]"],
+            ["(Use arrow keys)", "name 1", "copier"],
         ),
         (
             {
@@ -138,15 +147,15 @@ def test_templated_prompt(
     question_name = questions_data.copy().popitem()[0]
     build_file_tree(
         {
-            template / "copier.yml": yaml.dump(questions_combined),
+            template / "copier.yml": json.dumps(questions_combined),
             template
             / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    deque(map(tui.expect_exact, ["main?", "Format: yaml", main_default]))
+    deque(map(tui.expect_exact, ["main?", "Format: str", main_default]))
     tui.sendline()
-    deque(map(tui.expect_exact, [f"{question_name}?"] + expected_outputs))
+    deque(map(tui.expect_exact, expected_outputs))
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -1,3 +1,4 @@
+from collections import deque
 from datetime import datetime
 
 import pexpect
@@ -143,9 +144,9 @@ def test_templated_prompt(
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    tui.expect_exact(["main?", "Format: yaml", main_default])
+    deque(map(tui.expect_exact, ["main?", "Format: yaml", main_default]))
     tui.sendline()
-    tui.expect_exact([f"{question_name}?"] + expected_outputs)
+    deque(map(tui.expect_exact, [f"{question_name}?"] + expected_outputs))
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())


### PR DESCRIPTION
I was expecting that calls in this form matched all strings in sequence. It turns out that [the docs][1] clearly state that it only tries to match one of them.

Thus, fixing the tests to avoid false positives.

[1]: https://pexpect.readthedocs.io/en/stable/api/pexpect.html?highlight=expect_exact#pexpect.spawn.expect_exact