### PR TITLE
feat: do not ask for overwriting copier answers file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Summary:
 -   Running `copier copy` on a preexisting project now recopies the project instead of
     updating it. That means that it respects old answers, but ignores history diff.
 -   We use Jinja 2 defaults now. `{{ }}` instead of `[[ ]]` and similar.
+-   Copier will never ask for overwriting the answers file.
 -   Multi-typed choices follow the same type-casting logic as any other question, so
     it's easier to reason about them. However, if you were using this feature, you might
     be surprised about its side effects if you don't specify the type explicitly. Just

--- a/copier/main.py
+++ b/copier/main.py
@@ -236,7 +236,7 @@ class Worker:
                 file_=sys.stderr,
             )
             return False
-        if self.overwrite:
+        if self.overwrite or dst_relpath == self.answers_relpath:
             printf(
                 "overwrite",
                 dst_relpath,

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -122,8 +122,6 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
             )
         )
         tui.sendline()
-        deque(map(tui.expect_exact, ["Overwrite", ".copier-answers.yml", "[Y/n]"]))
-        tui.sendline()
         tui.expect_exact(pexpect.EOF)
         assert "_commit: v2" in Path(".copier-answers.yml").read_text()
 
@@ -375,8 +373,6 @@ def test_update_choice(tmp_path_factory, spawn, choices):
     tui = spawn(COPIER_PATH + (str(subproject),), timeout=10)
     tui.expect_exact("pick_one?")
     tui.sendline(Keyboard.Down)
-    deque(map(tui.expect_exact, ["Overwrite", ".copier-answers.yml", "[Y/n]"]))
-    tui.sendline("y")
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
     assert answers["pick_one"] == 3.0


### PR DESCRIPTION
The copier answers file (`.copier-answers.yml` by default) should be updated always, and everybody is almost excessively warned to NOT touch that file by hand and let Copier handle it. Thus, it makes no sense to ask users whether it should be updated on conflict.

Fixes https://github.com/copier-org/copier/issues/325.