### PR TITLE
docs: migration strategies across major copier versions

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -4,12 +4,42 @@ Command line entrypoint. This module declares the Copier CLI applications.
 
 Basically, there are 3 different commands you can run:
 
--   [`copier`][copier.cli.CopierApp], the main app, which includes shortcuts
-    for the `copy` and `update` subapps.
--   [`copier copy`][copier.cli.CopierApp], used to bootstrap a new project
-    from a template.
+-   [`copier`][copier.cli.CopierApp], the main app, which is a shortcut for the
+    `copy` and `update` subapps.
+
+    If the destination project is found and has [an answers
+    file][the-copier-answersyml-file] with enough information, it will become a
+    shortcut for `copier update`.
+
+    Otherwise it will be a shortcut for `copier copy`.
+
+    !!! example
+
+        ```sh
+        # Copy a new project
+        copier gh:copier-org/autopretty my-project
+        # Update it
+        cd my-project
+        copier
+        ```
+
+-   [`copier copy`][copier.cli.CopierApp], used to bootstrap a new project from
+    a template.
+
+    !!! example
+
+        ```sh
+        copier copy gh:copier-org/autopretty my-project
+        ```
+
 -   [`copier update`][copier.cli.CopierUpdateSubApp] to update a preexisting
     project to a newer version of its template.
+
+    !!! example
+
+        ```sh
+        copier update
+        ```
 
 Below are the docs of each one of those.
 """

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -30,4 +30,15 @@ the templates. The arguments can be any valid Python value, even a function.
 Use the `--vcs-ref` command-line argument to checkout a particular git ref before
 generating the project.
 
-All the available options are described with the `--help-all` option.
+[All the available options][copier.cli] are described with the `--help-all` option.
+
+## Regenerating a project
+
+When you execute `copier copy $template $project` again over a preexisting `$project`,
+Copier will just "recopy" it, ignoring previous history.
+
+!!! warning
+
+    This is not [the recommended approach for updating a project][updating-a-project],
+    where you usually want Copier to respect the project evolution wherever it doesn't
+    conflict with the template evolution.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -141,3 +141,26 @@ As you can see here, `copier` does several things:
     skip modifications, but in the end, it is possible that nothing has changed (except for
     the version in `.copier-answers.yml` of course). This is not a bug: although it can be
     quite surprising, this behavior is correct.
+
+## Migration across Copier major versions
+
+When there's a new major release of Copier (for example from Copier 5.x to 6.x), there
+are chances that there's something that changed. Maybe your template will not work as it
+did before.
+
+[As explained above][how-the-update-works], Copier needs to make a copy of the template
+in its old state with its old answers so it can actually produce a diff with the new
+state and answers and apply the smart update to the project. However, **how can I be
+sure that Copier will produce the same "old state" if I copied the template with an
+older Copier major release?**. Good question.
+
+We will do our best to respect older behaviors for at least one extra major release
+cycle, but the simpler answer is that you can't be sure of that.
+
+How to overcome that situation?
+
+1. You can write good [migrations][].
+1. Then you can test them on your template's CI on a matrix against several Copier
+   versions.
+1. Or you can just [recopy the project][regenerating-a-project] when you update to a
+   newer Copier major release.


### PR DESCRIPTION
Try to answer a good question: when you upgrade one subproject from template v1 to v2, the template itself needs to be properly rendered in v1 to be compared to the subproject and extract the diff... well, we all know this at this point. But if Copier 6 renders differently the template v1 as compared to how Copier 5 would, then the template developer is on big trouble: How to evolve a subproject from a Copier v5-only template to a Copier v6-only template?

Fix https://github.com/copier-org/copier/issues/348