### PR TITLE
fix: Fix unicode error on binary files

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -427,13 +427,18 @@ class Worker:
             return
         if src_abspath.name.endswith(self.template.templates_suffix):
             try:
-                tpl = self.jinja_env.get_template(str(src_relpath))
+                tpl = self.jinja_env.get_template(src_relpath)
             except UnicodeDecodeError:
                 if self.template.templates_suffix:
                     # suffix is not emtpy, re-raise
+                    print(
+                        colors.warn
+                        | f"{src_relpath} could not be read as a Jinja2 template, falling back to a simply copy",
+                        file=sys.stderr,
+                    )
                     raise
                 # suffix is empty, fallback to copy
-                new_content = src_relpath.read_bytes()
+                new_content = src_abspath.read_bytes()
             else:
                 new_content = tpl.render(**self._render_context()).encode()
         else:

--- a/copier/main.py
+++ b/copier/main.py
@@ -433,11 +433,6 @@ class Worker:
                     # suffix is not emtpy, re-raise
                     raise
                 # suffix is empty, fallback to copy
-                print(
-                    colors.warn
-                    | f"{src_relpath} could not be read as a Jinja2 template, falling back to a simple copy",
-                    file=sys.stderr,
-                )
                 new_content = src_abspath.read_bytes()
             else:
                 new_content = tpl.render(**self._render_context()).encode()

--- a/copier/main.py
+++ b/copier/main.py
@@ -431,13 +431,13 @@ class Worker:
             except UnicodeDecodeError:
                 if self.template.templates_suffix:
                     # suffix is not emtpy, re-raise
-                    print(
-                        colors.warn
-                        | f"{src_relpath} could not be read as a Jinja2 template, falling back to a simply copy",
-                        file=sys.stderr,
-                    )
                     raise
                 # suffix is empty, fallback to copy
+                print(
+                    colors.warn
+                    | f"{src_relpath} could not be read as a Jinja2 template, falling back to a simple copy",
+                    file=sys.stderr,
+                )
                 new_content = src_abspath.read_bytes()
             else:
                 new_content = tpl.render(**self._render_context()).encode()

--- a/copier/main.py
+++ b/copier/main.py
@@ -426,8 +426,16 @@ class Worker:
         if dst_relpath is None:
             return
         if src_abspath.name.endswith(self.template.templates_suffix):
-            tpl = self.jinja_env.get_template(str(src_relpath))
-            new_content = tpl.render(**self._render_context()).encode()
+            try:
+                tpl = self.jinja_env.get_template(str(src_relpath))
+            except UnicodeDecodeError:
+                if self.template.templates_suffix:
+                    # suffix is not emtpy, re-raise
+                    raise
+                # suffix is empty, fallback to copy
+                new_content = src_relpath.read_bytes()
+            else:
+                new_content = tpl.render(**self._render_context()).encode()
         else:
             new_content = src_abspath.read_bytes()
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -788,7 +788,10 @@ Suffix that instructs which files are to be processed by Jinja as templates.
     ```
 
 An empty suffix is also valid, and will instruct Copier to copy and render _every file_,
-except those that are [excluded by default](#default).
+except those that are [excluded by default](#default). If an error happens while trying
+to read a file as a template, it will fallback to a simple copy (it will typically
+happen for binary files like images). At the contrary, if such an error happens and the
+templates suffix is _not_ empty, Copier will abort and print an error message.
 
 !!! example
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -94,8 +94,10 @@ def build_file_tree(spec: Dict[StrOrPath, str], dedent: bool = True):
     """Builds a file tree based on the received spec."""
     for path, contents in spec.items():
         path = Path(path)
-        if dedent:
+        binary = isinstance(contents, bytes)
+        if not binary and dedent:
             contents = textwrap.dedent(contents)
         path.parent.mkdir(parents=True, exist_ok=True)
-        with path.open("w") as fd:
+        mode = "wb" if binary else "w"
+        with path.open(mode) as fd:
             fd.write(contents)


### PR DESCRIPTION
If a unicode decode error is raised
while trying to compile a file as a Jinja2 template,
and the templates suffix is empty,
we fallback to copying this file as is.

Fixes #433.