### PR TITLE
docs: Tell about creating the venv in the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ MANIFEST
 # Environments
 __pypackages__
 .pdm.toml
+poetry.toml
 .env
 .venv
 covreport

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,6 +74,9 @@ Ready to contribute? Here's how to set up the project for local development.
 3.  Use poetry to setup a development environment
 
     ```sh
+    # Tell Poetry to create the virtualenv in the project directory
+    poetry config virtualenvs.in-project true --local
+
     # Create a virtualenv with all dependencies from pyproject.toml
     poetry install -E docs
 


### PR DESCRIPTION
Fixes #154 

The docs tell the user to run `poetry config virtualenvs.in-project true --local`, which will create a `poetry.toml` file, which is why we ignore it in `.gitignore`. If you believe the file should be tracked instead, let me know, though I'd probably argue against.