### PR TITLE
Add config-file option

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -82,6 +82,7 @@ class CopierApp(cli.Application):
 
     Attributes:
         answers_file: Set [answers_file][] option.
+        config_file: Set [config_file][] option.
         exclude: Set [exclude][] option.
         vcs_ref: Set [vcs_ref][] option.
         pretend: Set [pretend][] option.
@@ -127,6 +128,13 @@ class CopierApp(cli.Application):
         help=(
             "Update using this path (relative to `destination_path`) "
             "to find the answers file"
+        ),
+    )
+    config_file: cli.SwitchAttr = cli.SwitchAttr(
+        ["-c", "--config-file"],
+        default=None,
+        help=(
+            "Config file path instead of default copier.yml/copier.yaml in template dir"
         ),
     )
     exclude: cli.SwitchAttr = cli.SwitchAttr(
@@ -207,6 +215,7 @@ class CopierApp(cli.Application):
             data=self.data,
             dst_path=dst_path,
             answers_file=self.answers_file,
+            config_file=self.config_file,
             exclude=self.exclude,
             defaults=self.force or self.defaults,
             overwrite=self.force or self.overwrite,

--- a/copier/main.py
+++ b/copier/main.py
@@ -131,6 +131,7 @@ class Worker:
     src_path: Optional[str] = None
     dst_path: Path = field(default=".")
     answers_file: Optional[RelativePath] = None
+    config_file: Optional[str] = None
     vcs_ref: OptStr = None
     data: AnyByStrDict = field(default_factory=dict)
     exclude: StrSeq = ()
@@ -363,6 +364,17 @@ class Worker:
         return self.answers_file or self.template.answers_relpath
 
     @cached_property
+    def config_file(self) -> Path:
+        """Obtain the proper path for the config file.
+
+        It comes from:
+
+        1. User choice.
+        2. Copier default.
+        """
+        return self.config_file
+
+    @cached_property
     def all_exclusions(self) -> StrSeq:
         """Combine default, template and user-chosen exclusions."""
         return self.template.exclude + tuple(self.exclude)
@@ -540,7 +552,12 @@ class Worker:
             if self.subproject.template is None:
                 raise TypeError("Template not found")
             url = self.subproject.template.url
-        return Template(url=url, ref=self.vcs_ref, use_prereleases=self.use_prereleases)
+        return Template(
+            url=url,
+            ref=self.vcs_ref,
+            use_prereleases=self.use_prereleases,
+            config_file=self.config_file,
+        )
 
     @cached_property
     def template_copy_root(self) -> Path:

--- a/copier/main.py
+++ b/copier/main.py
@@ -83,6 +83,11 @@ class Worker:
             If it is `None`, the default value will be obtained from
             [copier.template.Template.answers_relpath][].
 
+        config_file:
+            Path to the config file.
+
+            If `None` copier.yml or copier.yaml in template directory will be used
+
         vcs_ref:
             Specify the VCS tag/commit to use in the template.
 
@@ -362,17 +367,6 @@ class Worker:
         3. Copier default.
         """
         return self.answers_file or self.template.answers_relpath
-
-    @cached_property
-    def config_file(self) -> Path:
-        """Obtain the proper path for the config file.
-
-        It comes from:
-
-        1. User choice.
-        2. Copier default.
-        """
-        return self.config_file
 
     @cached_property
     def all_exclusions(self) -> StrSeq:

--- a/copier/template.py
+++ b/copier/template.py
@@ -170,11 +170,17 @@ class Template:
 
             Helpful if you want to test templates before doing a proper release, but you
             need some features that require a proper PEP440 version identifier.
+
+        config_file:
+            Path to the file to be used instead copier.y?ml
+
+            If `None` copier.yml or copier.yaml in template directory will be used
     """
 
     url: str
     ref: OptStr = None
     use_prereleases: bool = False
+    config_file: OptStr = None
 
     @cached_property
     def _raw_config(self) -> AnyByStrDict:
@@ -182,11 +188,14 @@ class Template:
 
         It reads [the `copier.yml` file][the-copieryml-file].
         """
-        conf_paths = [
-            p
-            for p in self.local_abspath.glob("copier.*")
-            if p.is_file() and re.match(r"\.ya?ml", p.suffix, re.I)
-        ]
+        if self.config_file:
+            conf_paths = [self.config_file]
+        else:
+            conf_paths = [
+                p
+                for p in self.local_abspath.glob("copier.*")
+                if p.is_file() and re.match(r"\.ya?ml", p.suffix, re.I)
+            ]
         if len(conf_paths) > 1:
             raise MultipleConfigFilesError(conf_paths)
         elif len(conf_paths) == 1:

--- a/copier/template.py
+++ b/copier/template.py
@@ -172,7 +172,7 @@ class Template:
             need some features that require a proper PEP440 version identifier.
 
         config_file:
-            Path to the file to be used instead copier.y?ml
+            Path to the config file.
 
             If `None` copier.yml or copier.yaml in template directory will be used
     """

--- a/copier/template.py
+++ b/copier/template.py
@@ -189,7 +189,7 @@ class Template:
         It reads [the `copier.yml` file][the-copieryml-file].
         """
         if self.config_file:
-            conf_paths = [self.config_file]
+            conf_paths = [Path(self.config_file)]
         else:
             conf_paths = [
                 p

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -365,6 +365,14 @@ Don't forget to read [the docs about the answers file](#the-copier-answersyml-fi
     _answers_file: .my-custom-answers.yml
     ```
 
+### `config_file`
+
+-   Format: `str`
+-   CLI flags: `-c`, `--config-file`
+-   Default value: `copier.y?ml`
+
+Config file path instead of default copier.yml/copier.yaml in template dir.
+
 ### `cleanup_on_error`
 
 -   Format: `bool`

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -369,9 +369,9 @@ Don't forget to read [the docs about the answers file](#the-copier-answersyml-fi
 
 -   Format: `str`
 -   CLI flags: `-c`, `--config-file`
--   Default value: `copier.y?ml`
+-   Default value: `copier.yml` or `copier.yaml`
 
-Config file path instead of default copier.yml/copier.yaml in template dir.
+Config file path instead of default `copier.yml` or `copier.yaml` in template dir.
 
 ### `cleanup_on_error`
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,7 +100,7 @@ def test_read_data_with_config_file_option(tmp_path_factory):
         dst,
         defaults=True,
         overwrite=True,
-        config_file="cfg/copier-other.yaml",
+        config_file= cfg / "copier-other.yaml",
     )
     gen_file = dst / "user_data.txt"
     result = gen_file.read_text()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -75,7 +75,7 @@ def test_read_data_with_config_file_option(tmp_path_factory):
     build_file_tree(
         {
             cfg
-            / "copier-other.yaml": """\
+            / f"copier-other.yaml": f"""\
                 # This is a comment
                 _envops: {BRACKET_ENVOPS_JSON}
                 a_string: lorem ipsum
@@ -100,7 +100,7 @@ def test_read_data_with_config_file_option(tmp_path_factory):
         dst,
         defaults=True,
         overwrite=True,
-        config_file= cfg / "copier-other.yaml",
+        config_file=str(cfg / "copier-other.yaml"),
     )
     gen_file = dst / "user_data.txt"
     result = gen_file.read_text()


### PR DESCRIPTION
This feature allows to specify different config file instead of hardcoded copier.yaml/copier.yml in template directory. The file can be in any other place (ie. in destination dir) and allows to use one copier.yaml for multiple templates in my case.