### PR TITLE
fix: Fix issue with update subdirectory given an answers file path

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -191,9 +191,15 @@ class Worker:
         # Backwards compatibility
         # FIXME Remove it?
         conf = asdict(self)
+
+        # During update, the destination _subdirectory is joined with the rendered answers_file value.
+        # To avoid including the same folders twice in the path, write to the config the
+        # answers filename (without the path).
+        answers_file = self.answers_relpath.name
+
         conf.update(
             {
-                "answers_file": self.answers_relpath,
+                "answers_file": answers_file,
                 "src_path": self.template.local_abspath,
             }
         )

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -1,6 +1,8 @@
 import os
+from pathlib import Path
 
 import pytest
+import yaml
 from plumbum import local
 from plumbum.cmd import git
 
@@ -84,6 +86,66 @@ def test_update_subdirectory(demo_template, tmp_path):
     assert not (tmp_path / "api_project").exists()
     assert not (tmp_path / "api_readme.md").exists()
     assert (tmp_path / "conf_readme.md").exists()
+
+
+@pytest.mark.timeout(20)
+def test_update_subdirectory_given_answers_file_path(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    answers_filename = ".copier-answers.component-type1.yaml"
+    answers_file_relpath = Path("group1/component-type1/component1", answers_filename)
+    component_dir = answers_file_relpath.parent
+    component_type_dir = component_dir.parent
+
+    copier_yaml_contents = f"""\
+    _templates_suffix: ''
+    _subdirectory: '{{{{ template }}}}'
+
+    template:
+        type: str
+        choices:
+            - {component_type_dir}
+    """
+
+    with local.cwd(src):
+        answers_file_tree_key = str(
+            component_dir.joinpath("{{_copier_conf.answers_file}}")
+        )
+        test_file_tree_key = str(component_dir.joinpath("test.txt"))
+        build_file_tree(
+            {
+                "copier.yaml": copier_yaml_contents,
+                answers_file_tree_key: "{{ _copier_answers|to_yaml }}",
+                test_file_tree_key: "True",
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "1")
+        build_file_tree(
+            {"copier.yaml": copier_yaml_contents, test_file_tree_key: "False"}
+        )
+        git("commit", "-am2")
+        git("tag", "2")
+    copier.run_copy(
+        str(src),
+        str(dst),
+        vcs_ref="1",
+        data={"template": str(component_type_dir)},
+        defaults=True,
+        overwrite=True,
+        answers_file=answers_filename,
+    )
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        copier.run_update(
+            defaults=True, overwrite=True, answers_file=f"component1/{answers_filename}"
+        )
+    answers = yaml.safe_load(dst.joinpath("component1", answers_filename).read_bytes())
+    assert answers["_commit"] == "2"
+    assert dst.joinpath("component1/test.txt").read_text() == "False"
 
 
 def test_new_version_uses_subdirectory(tmp_path_factory):


### PR DESCRIPTION
Fixes https://github.com/copier-org/copier/issues/451

## Justification
During update, the destination _subdirectory is joined with the rendered answers_file value. We want to avoid including the same folders twice in the path.

## Implementation
Write the answers filename to the config, but without the path.

## Testing
Added unit test for this case.