### PR TITLE
test(migrations): add test for new PEP 440 environment variables in migrations

### DIFF
--- a/tests/demo_migrations/migrations.py
+++ b/tests/demo_migrations/migrations.py
@@ -3,7 +3,11 @@ import json
 import os
 import sys
 
-NAME = "{VERSION_FROM}-{VERSION_CURRENT}-{VERSION_TO}-{STAGE}.json"
+NAMES = (
+    "{VERSION_FROM}-{VERSION_CURRENT}-{VERSION_TO}-{STAGE}.json",
+    "PEP440-{VERSION_PEP440_FROM}-{VERSION_PEP440_CURRENT}-{VERSION_PEP440_TO}-{STAGE}.json",
+)
 
-with open(NAME.format(**os.environ), "w") as fd:
-    json.dump(sys.argv, fd)
+for name in NAMES:
+    with open(name.format(**os.environ), "w") as fd:
+        json.dump(sys.argv, fd)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -69,6 +69,8 @@ def test_migrations_and_tasks(tmp_path: Path):
     assert not (dst / "tasks.py").exists()
     assert (dst / "v1.0.0-v2-v2.0-before.json").is_file()
     assert (dst / "v1.0.0-v2-v2.0-after.json").is_file()
+    assert (dst / "PEP440-1.0.0-2-2.0-before.json").is_file()
+    assert (dst / "PEP440-1.0.0-2-2.0-after.json").is_file()
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers == {"_commit": "v2.0", "_src_path": str(git_src)}
 


### PR DESCRIPTION
In 745a4904152058b1095ce72480a3dc30c446c88a I added this new feature, but did not add a test for it.