### PR TITLE
perf(clone): clone faster without blobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Summary:
     complicated anyway (warn added to docs).
 -   Changed `--force` to be the same as `--defaults --overwrite`.
 -   Copied files will reflect permissions on the same files in the template.
+-   Copier now uses `git clone --filter=blob:none` when cloning, to be faster.
 
 ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A library and CLI app for rendering project templates.
 ## Installation
 
 1. Install Python 3.6.1 or newer (3.8 or newer if you're on Windows).
-1. Install Git 2.24 or newer.
+1. Install Git 2.27 or newer.
 1. To use as a CLI app: `pipx install copier`
 1. To use as a library: `pip install copier`
 


### PR DESCRIPTION
When git 2.27 or newer is installed, we can add `--filter=blob:none` to avoid getting useless information from the git server. This makes clone much faster if your template has a big history.

Close https://github.com/copier-org/copier/issues/450 (it does not exactly fix it, but maybe makes it irrelevant).