### PR TITLE
raise CopierAnswersInterrupt on partial answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ Summary:
     `$VERSION_PEP440_CURRENT` and `$VERSION_PEP440_TO`, which will always get a valid
     PEP440 version identifier, without the `v` prefix, allowing your migration scripts
     to have a valid standard where to base their logic.
+-   Raise a CopierAnswersInterrupt instead of a bare KeyboardInterrupt to
+    provide callers with additional context - such as the partially completed
+    AnswersMap.
 
 ### Changed
 

--- a/copier/errors.py
+++ b/copier/errors.py
@@ -7,6 +7,11 @@ from pydantic.errors import _PathValueError
 from .tools import printf_exception
 from .types import PathSeq
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # always false
+    from .user_data import AnswersMap, Question, Template
+
 
 # Errors
 class CopierError(Exception):
@@ -63,6 +68,32 @@ class PathNotRelativeError(_PathValueError, CopierError):
 
 class ExtensionNotFoundError(UserMessageError):
     """Extensions listed in the configuration could not be loaded."""
+
+
+class CopierAnswersInterrupt(CopierError, KeyboardInterrupt):
+    """CopierAnswersInterrupt is raised during interactive question prompts.
+
+    It typically follows a KeyboardInterrupt (i.e. ctrl-c) and provides an
+    opportunity for the caller to conduct additional cleanup, such as writing
+    the partially completed answers to a file.
+
+    Attributes:
+        answers:
+            AnswersMap that contains the partially completed answers object.
+
+        last_question:
+            Question representing the last_question that was asked at the time
+            the interrupt was raised.
+
+        template:
+            Template that was being processed for answers.
+
+    """
+
+    def __init__(self, answers: 'AnswersMap', last_question: 'Question', template: 'Template') -> None:
+        self.answers = answers
+        self.last_question = last_question
+        self.template = template
 
 
 # Warnings

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -62,6 +62,7 @@ ISOFORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 class Keyboard(str, Enum):
     ControlH = REVERSE_ANSI_SEQUENCES[Keys.ControlH]
+    ControlC = REVERSE_ANSI_SEQUENCES[Keys.ControlC]
     Enter = "\r"
     Esc = REVERSE_ANSI_SEQUENCES[Keys.Escape]
 

--- a/tests/test_interrupts.py
+++ b/tests/test_interrupts.py
@@ -1,0 +1,84 @@
+from unittest.mock import patch
+
+import pytest
+import yaml
+
+from copier import Worker
+from copier.errors import CopierAnswersInterrupt
+
+from .helpers import build_file_tree
+
+
+@pytest.mark.parametrize(
+    "questions, side_effect, raises",
+    (
+        (
+            {
+                "question": {"type": "str"},
+            },
+            # We override the prompt method from questionary to raise this
+            # expection and expect our surrounding machinery to re-raise
+            # it as a CopierAnswersInterrupt.
+            KeyboardInterrupt,
+            CopierAnswersInterrupt,
+        ),
+        (
+            {
+                "question": {"type": "str"},
+            },
+            KeyboardInterrupt,
+            KeyboardInterrupt,
+        ),
+    ),
+)
+def test_keyboard_interrupt(tmp_path_factory, questions, side_effect, raises):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": yaml.safe_dump(questions),
+        }
+    )
+    worker = Worker(str(src), dst, defaults=False)
+
+    with patch("copier.main.unsafe_prompt", side_effect=side_effect):
+        with pytest.raises(raises):
+            worker.run_copy()
+
+
+@pytest.mark.parametrize(
+    "questions, side_effects, answers",
+    (
+        (
+            {
+                "question1": {"type": "str"},
+                "question2": {"type": "str"},
+                "question3": {"type": "str"},
+            },
+            [
+                {"question1": "foobar"},
+                {"question2": "yosemite"},
+                KeyboardInterrupt,
+            ],
+            {
+                "question1": "foobar",
+                "question2": "yosemite",
+            },
+        ),
+    ),
+)
+def test_multiple_questions_interrupt(
+    tmp_path_factory, questions, side_effects, answers
+):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": yaml.safe_dump(questions),
+        }
+    )
+    worker = Worker(str(src), dst, defaults=False)
+
+    with patch("copier.main.unsafe_prompt", side_effect=side_effects):
+        with pytest.raises(CopierAnswersInterrupt) as err:
+            worker.run_copy()
+        assert err.value.answers.user == answers
+        assert err.value.template == worker.template


### PR DESCRIPTION
Use case: I'm using the copier api and would like to capture partially completed answers. When completing long questionnaires it's sometimes :sadpanda: to ctrl-c and repeat your work. I plan on:

- catching this exception
- writing the `e.answers.user` out to a file.
- on subsequent runs, checking for it's existence and populating `run_copy(defaults=partial_answers)`.

I suspect the above procedure could likely be generalized as a first class feature in the project e.g. copier could handle writing a `~/.copier_answers_partial.json`  or `~/.coper_{{template_name}}_answers_partial.json`, or even write out to `SubProject.last_answers`.