### PR TITLE
allow overriden defaults in questionnaire

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Summary:
 -   Raise a CopierAnswersInterrupt instead of a bare KeyboardInterrupt to
     provide callers with additional context - such as the partially completed
     AnswersMap.
+-   Support for `user_defaults`, which take precedence over template defaults.
 
 ### Changed
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -111,6 +111,9 @@ class Worker:
 
             See [defaults][].
 
+        user_defaults:
+            Specify user defaults that may override a template's defaults during question prompts.
+
         overwrite:
             When `True`, Overwrite files that already exist, without asking.
 
@@ -137,6 +140,7 @@ class Worker:
     skip_if_exists: StrSeq = ()
     cleanup_on_error: bool = True
     defaults: bool = False
+    user_defaults: AnyByStrDict = field(default_factory=dict)
     overwrite: bool = False
     pretend: bool = False
     quiet: bool = False
@@ -317,6 +321,7 @@ class Worker:
         """
         result = AnswersMap(
             default=self.template.default_answers,
+            user_defaults=self.user_defaults,
             init=self.data,
             last=self.subproject.last_answers,
             metadata=self.template.metadata,

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -97,6 +97,11 @@ class AnswersMap:
             Default data from the template.
 
             See [copier.template.Template.default_answers][].
+
+        user_defaults:
+            Default data from the user e.g. previously completed and restored data.
+
+            See [copier.main.Worker][].
     """
 
     # Private
@@ -107,6 +112,7 @@ class AnswersMap:
     init: AnyByStrDict = field(default_factory=dict)
     metadata: AnyByStrDict = field(default_factory=dict)
     last: AnyByStrDict = field(default_factory=dict)
+    user_defaults: AnyByStrDict = field(default_factory=dict)
     default: AnyByStrDict = field(default_factory=dict)
 
     @cached_property
@@ -118,6 +124,7 @@ class AnswersMap:
             self.init,
             self.metadata,
             self.last,
+            self.user_defaults,
             self.default,
             DEFAULT_DATA,
         )
@@ -208,7 +215,10 @@ class Question:
             try:
                 result = self.answers.last[self.var_name]
             except KeyError:
-                result = self.render_value(self.default)
+                try:
+                    result = self.answers.user_defaults[self.var_name]
+                except KeyError:
+                    result = self.render_value(self.default)
         result = cast_answer_type(result, cast_fn)
         return result
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 import pytest
 from plumbum import local
+from plumbum.cmd import git
 from pydantic import ValidationError
 
 import copier
@@ -22,6 +23,14 @@ GOOD_ENV_OPS = {
     "comment_end_string": "#>",
     "comment_start_string": "<#",
 }
+
+
+def git_init(message="hello world"):
+    git("init")
+    git("config", "user.name", "Copier Test")
+    git("config", "user.email", "test@copier")
+    git("add", ".")
+    git("commit", "-m", message)
 
 
 def test_config_data_is_loaded_from_file():
@@ -227,3 +236,207 @@ def test_worker_config_precedence(tmp_path, test_input, expected_exclusions):
 def test_config_data_transclusion():
     config = copier.Worker("tests/demo_transclude/demo")
     assert config.all_exclusions == ("exclude1", "exclude2")
+
+
+@pytest.mark.parametrize(
+    "user_defaults, data, expected",
+    [
+        # Nothing overridden.
+        (
+            {},
+            {},
+            dedent(
+                """\
+            A string: lorem ipsum
+            A number: 12345
+            A boolean: True
+            A list: one, two, three
+            """
+            ),
+        ),
+        # User defaults provided.
+        (
+            {
+                "a_string": "foo",
+                "a_number": 42,
+                "a_boolean": False,
+                "a_list": ["four", "five", "six"],
+            },
+            {},
+            dedent(
+                """\
+            A string: foo
+            A number: 42
+            A boolean: False
+            A list: four, five, six
+            """
+            ),
+        ),
+        # User defaults + data provided.
+        (
+            {
+                "a_string": "foo",
+                "a_number": 42,
+                "a_boolean": False,
+                "a_list": ["four", "five", "six"],
+            },
+            {
+                "a_string": "yosemite",
+            },
+            dedent(
+                """\
+            A string: yosemite
+            A number: 42
+            A boolean: False
+            A list: four, five, six
+            """
+            ),
+        ),
+    ],
+)
+def test_user_defaults(tmp_path_factory, user_defaults, data, expected):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src
+            / "copier.yaml": """\
+                a_string:
+                    default: lorem ipsum
+                    type: str
+                a_number:
+                    default: 12345
+                    type: int
+                a_boolean:
+                    default: true
+                    type: bool
+                a_list:
+                    default:
+                        - one
+                        - two
+                        - three
+                    type: json
+            """,
+            src
+            / "user_data.txt.jinja": """\
+                A string: {{ a_string }}
+                A number: {{ a_number }}
+                A boolean: {{ a_boolean }}
+                A list: {{ ", ".join(a_list) }}
+            """,
+            src
+            / "{{ _copier_conf.answers_file }}.jinja": """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+            """,
+        }
+    )
+    copier.copy(
+        str(src),
+        dst,
+        defaults=True,
+        overwrite=True,
+        user_defaults=user_defaults,
+        data=data,
+    )
+    gen_file = dst / "user_data.txt"
+    result = gen_file.read_text()
+    assert result == dedent(expected)
+
+
+@pytest.mark.parametrize(
+    "user_defaults_initial, user_defaults_updated, data_initial, data_updated, expected",
+    [
+        # User defaults + secondary defaults.
+        (
+            {
+                "a_string": "foo",
+            },
+            {
+                "a_string": "foobar",
+            },
+            {},
+            {},
+            dedent(
+                """\
+            A string: foo
+            """
+            ),
+        ),
+        # User defaults + data provided.
+        (
+            {
+                "a_string": "foo",
+            },
+            {
+                "a_string": "foobar",
+            },
+            {
+                "a_string": "yosemite",
+            },
+            {
+                "a_string": "red rocks",
+            },
+            dedent(
+                """\
+            A string: yosemite
+            """
+            ),
+        ),
+    ],
+)
+def test_user_defaults_updated(
+    tmp_path_factory,
+    user_defaults_initial,
+    user_defaults_updated,
+    data_initial,
+    data_updated,
+    expected,
+):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    with local.cwd(src):
+        build_file_tree(
+            {
+                src
+                / "copier.yaml": """\
+                    a_string:
+                        default: lorem ipsum
+                        type: str
+                """,
+                src
+                / "user_data.txt.jinja": """\
+                    A string: {{ a_string }}
+                """,
+                src
+                / "{{ _copier_conf.answers_file }}.jinja": """\
+                    # Changes here will be overwritten by Copier
+                    {{ _copier_answers|to_nice_yaml }}
+                """,
+            }
+        )
+        git_init()
+
+    copier.copy(
+        str(src),
+        dst,
+        defaults=True,
+        overwrite=True,
+        user_defaults=user_defaults_initial,
+        data=data_initial,
+    )
+    gen_file = dst / "user_data.txt"
+    result = gen_file.read_text()
+    assert result == dedent(expected)
+
+    with local.cwd(dst):
+        git_init()
+
+    copier.run_update(
+        dst,
+        defaults=True,
+        overwrite=True,
+        user_defaults=user_defaults_updated,
+        data=data_updated,
+    )
+    gen_file = dst / "user_data.txt"
+    result = gen_file.read_text()
+    assert result == dedent(expected)


### PR DESCRIPTION
This works in conjunction with https://github.com/copier-org/copier/pull/476, but is independent of it. If partial answers are written out to a file, they can be re-loaded as default overrides to whatever is specified in the template allowing one to resume progress.

Some code that uses the combination of these two MRs:

```
PARTIAL_ANSWERS = Path('~/.copier_partial.json').expanduser()

kwargs = {}

if Path(PARTIAL_ANSWERS).exists():
    with open(PARTIAL_ANSWERS) as f:
        kwargs['default_overrides'] = json.load(f)

try:
    result = copier.run_auto(TEMPLATES_SRC, os.getcwd(), **kwargs)
except copier.CopierAnswersInterrupt as e:
    with open(PARTIAL_ANSWERS, "w") as f:
        f.write(json.dumps(e.answers.user))
    print("Wrote partial answers to %s" % PARTIAL_ANSWERS)
```

Demo of these two features working together: https://asciinema.org/a/iVJvC8wAb8s3nSVKkmnhDjeZE
- First pass, I make some modifications and bail.
- Second pass, you can see the prior inputs being used.
- Prior to the third pass I modify the previous answers that were saved ala the snippet above.
- Third pass it's using the template defaults again because I emptied the javascript object.