### PR TITLE
feat: add support to parse yaml files as data input

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -385,7 +385,7 @@ running `copier update`, this setting has no effect.
 
 ### `data`
 
--   Format: `dict|List[str=str]`
+-   Format: `dict|List[str=str]|yamlfile`
 -   CLI flags: `-d`, `--data`
 -   Default value: N/A
 
@@ -401,6 +401,27 @@ questions with default answers.
 
     ```sh
     copier -fd 'user_name=Manuel Calavera' copy template destination
+    ```
+
+As alternative you can also pass the path to yaml file that contains your data. This
+cannot be used in the API.
+
+!!! example You have a input.yml file that contains:
+
+    ```yml
+    user_name: Alice Bob
+    age: 7
+    height: 1.83
+    ```
+
+    Calling this:
+    ```sh
+    copier -d input.yml copy template destination
+    ```
+
+    does the same thing as:
+    ```sh
+    copier -d "user_name=Alice Bob" -d "age=7" -d "height=1.83" copy template destination
     ```
 
 ### `envops`


### PR DESCRIPTION
The `--data/-d` option now accepts yaml files instead of only key
value pairs. It parses the the yaml file and updates the data
dictionary with the content.

This shall make it easier for the user to configure more complex
projects. It also allows sending someone your project template
configuration.

# From the documentation:

As alternative you can also pass the path to a yaml file that contains your data. This
cannot be used in the API.

You have a input.yml file that contains:

```yml
user_name: Alice Bob
age: 7
height: 1.83
```

Calling this:
```sh
copier -d input.yml copy template destination
```

does the same thing as:
```sh
copier -d "user_name=Alice Bob" -d "age=7" -d "height=1.83" copy template destination
```