### PR TITLE
test: make sure copier won't delete a preexisting folder

### DIFF
--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -28,6 +28,9 @@ def test_do_not_cleanup(tmp_path):
 
 def test_no_cleanup_when_folder_existed(tmp_path):
     """Copier will not delete a folder if it didn't create it."""
+    preexisting_file = tmp_path / "something"
+    preexisting_file.touch()
     with pytest.raises(CalledProcessError):
         copier.copy("./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=True)
-    assert (tmp_path).exists()
+    assert tmp_path.exists()
+    assert preexisting_file.exists()


### PR DESCRIPTION
This was already happening, but the test is now more complete.

Fix https://github.com/copier-org/copier/issues/262 by just asserting it was fixed already.