### PR TITLE
docs: Change diagram colors when switching between dark and light themes

### DIFF
--- a/docs/js/refresh_on_theme_switch.js
+++ b/docs/js/refresh_on_theme_switch.js
@@ -1,0 +1,10 @@
+var paletteSwitcher1 = document.getElementById("__palette_1");
+var paletteSwitcher2 = document.getElementById("__palette_2");
+
+paletteSwitcher1.addEventListener("change", function () {
+    location.reload();
+});
+
+paletteSwitcher2.addEventListener("change", function () {
+    location.reload();
+});

--- a/docs/js/refresh_on_theme_switch.js
+++ b/docs/js/refresh_on_theme_switch.js
@@ -1,6 +1,6 @@
-const ref = document.querySelector("[data-md-component=palette]")
-component$.subscribe(component => {
+const ref = document.querySelector("[data-md-component=palette]");
+component$.subscribe((component) => {
     if (component.ref === ref) {
-        location.reload()
+        location.reload();
     }
-})
+});

--- a/docs/js/refresh_on_theme_switch.js
+++ b/docs/js/refresh_on_theme_switch.js
@@ -1,10 +1,6 @@
-var paletteSwitcher1 = document.getElementById("__palette_1");
-var paletteSwitcher2 = document.getElementById("__palette_2");
-
-paletteSwitcher1.addEventListener("change", function () {
-    location.reload();
-});
-
-paletteSwitcher2.addEventListener("change", function () {
-    location.reload();
-});
+const ref = document.querySelector("[data-md-component=palette]")
+component$.subscribe(component => {
+    if (component.ref === ref) {
+        location.reload()
+    }
+})

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -118,8 +118,8 @@ diff("diff")
       project_applied --> |apply post-migrations| project_full
 
 %% style ----------------------------------------------------------
-classDef grey fill:#e8e8e8;
-class compare,update,apply grey;
+classDef blackborder stroke:#000;
+class compare,update,apply blackborder;
 ```
 
 As you can see here, `copier` does several things:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,9 @@ theme:
 extra_css:
   - css/mkdocstrings.css
 
+extra_javascript:
+  - js/refresh_on_theme_switch.js
+
 markdown_extensions:
   - admonition
   - codehilite:
@@ -68,6 +71,8 @@ plugins:
   - search
   - mermaid2:
       arguments:
+        theme: |
+          ^(JSON.parse(__md_get("__palette").index == 1)) ? 'dark' : 'light'
         flowchart:
           curve: basis
   - mkdocstrings:


### PR DESCRIPTION
Fixes #541 

Not as pretty as the Material for MkDocs Insiders integration, but I guess users don't usually switch theme that often, even less so while looking at a diagram, so I think that is totally acceptable (also, glitches in the GIF just come from my way of recording, using peek).

![mermaid_theme_switch](https://user-images.githubusercontent.com/3999221/149631009-f77ec5e0-b363-44d3-a8a4-c2158849b583.gif)
