### PR TITLE
Print header specify template version being used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Summary:
 -   Support for `user_defaults`, which take precedence over template defaults.
 -   Copy dirty changes from a git-tracked template to the project by default, to make
     testing easier.
+-   Advertise clearly which version is being copied or updated in the CLI.
 
 ### Changed
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -585,11 +585,14 @@ class Worker:
         See [generating a project][generating-a-project].
         """
         was_existing = self.subproject.local_abspath.exists()
-        if not self.quiet:
-            # TODO Unify printing tools
-            print("")  # padding space
         src_abspath = self.template_copy_root
         try:
+            if not self.quiet:
+                # TODO Unify printing tools
+                print(
+                    f"\nCopying from template version {self.template.version}",
+                    file=sys.stderr,
+                )
             self._render_folder(src_abspath)
             if not self.quiet:
                 # TODO Unify printing tools
@@ -642,6 +645,11 @@ class Worker:
             raise UserMessageError(
                 f"Your are downgrading from {self.subproject.template.version} to {self.template.version}. "
                 "Downgrades are not supported."
+            )
+        if not self.quiet:
+            # TODO Unify printing tools
+            print(
+                f"Updating to template version {self.template.version}", file=sys.stderr
             )
         # Copy old template into a temporary destination
         with TemporaryDirectory(prefix=f"{__name__}.update_diff.") as dst_temp:

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -32,6 +32,32 @@ generating the project.
 
 [All the available options][copier.cli] are described with the `--help-all` option.
 
+## Templates versions
+
+By default, copier will copy from the last release found in template git tags, sorted as
+[PEP 440][], regardless of whether the template is from a URL or a local clone of a git
+repository.
+
+The exception to this is if you use a local clone of a template repository that has had
+any modifications made, in this case Copier will use this modified working copy of the
+template to aid development of new template features.
+
+If you would like to override the version of template being installed, the
+[`--vcs-ref`](../configuring/#vcs_ref) argument can be used to specify a branch, tag or
+other reference to use.
+
+For example to use the latest master branch from a public repository:
+
+```
+copier --vcs-ref master https://github.com/foo/copier-template.git ./path/to/destination
+```
+
+Or to work from the current checked out revision of a local template:
+
+```
+copier --vcs-ref HEAD path/to/project/template path/to/destination
+```
+
 ## Regenerating a project
 
 When you execute `copier copy $template $project` again over a preexisting `$project`,


### PR DESCRIPTION
This PR simply adds a header message upon running copier to indicate to the user the template version being copied / updated from, eg.
```
~/copier$ python -m copier --force ~/my_template ~/new_project

Copying from template version v0.1.1
 identical  .
 identical  update.py
 identical  src
 identical  src/unix
...
```

I'm a relatively new user of copier and did not realise that its normal behavior is to always use the latest tag of a template repo, rather than the current master.

I found this particularly confusing when working from a local clone of a template under development. I'd make changes to the template, then re-run copier to check they all worked. Sometimes copier used my new changes, other times it seemed to copy really old files instead. It took me far longer than you'd think to figure out that when there were local changes it would use current head (as printed in the warning message) but once the template repo is clean it would ignore the current commit checked out in the template repo and skip back to an old tag.

I can see how this tag / release behaviour would often be sensible / desiable when pulling from a url, and there's the --vcs-ref arg available to override that. Once this had all clicked in my head it did make sense.

While there's a warning header message that shows when it is using the current dirty changes, there's currently no indication of what version / commit of the template is being used when the template repo is clean.
