### PR TITLE
test: fix date comparison not working in my timezone

### DIFF
--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -217,7 +217,7 @@ def test_templated_prompt_builtins(tmp_path_factory):
     )
     Worker(str(src), dst, defaults=True, overwrite=True).run_copy()
     that_now = datetime.fromisoformat((dst / "now").read_text())
-    assert that_now <= datetime.now()
+    assert that_now <= datetime.utcnow()
     assert len((dst / "make_secret").read_text()) == 128
 
 


### PR DESCRIPTION
The now() template builtin is being used in the test and is an alias
for datetime.utcnow(). The now however, just uses datetime.now(). This
means that my datetime.now() will always make this test fail.

Signed-off-by: David Stanek <dstanek@dstanek.com>