### PR TITLE
fix: correct default for skipped questions

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -352,6 +352,11 @@ class Worker:
             except KeyboardInterrupt as err:
                 raise CopierAnswersInterrupt(result, question, self.template) from err
             previous_answer = result.combined.get(question.var_name)
+            # If question was skipped and it's the 1st
+            # run, you could be getting a raw templated value
+            default_answer = result.default.get(question.var_name)
+            if new_answer == default_answer:
+                new_answer = question.render_value(default_answer)
             if new_answer != previous_answer:
                 result.user[question.var_name] = new_answer
         return result

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -132,10 +132,44 @@ Supported keys:
 -   **multiline**: When set to `true`, it allows multiline input. This is especially
     useful when `type` is `json` or `yaml`.
 
--   **when**: Condition that, if `false`, skips the question. If it is a boolean, it is
-    used directly (although it's a bit absurd in that case). If it is a string, it is
-    converted to boolean using a parser similar to YAML, but only for boolean values.
+-   **when**: Condition that, if `false`, skips the question.
+
+    If it is a boolean, it is used directly, but it's a bit absurd in that case.
+
+    If it is a string, it is converted to boolean using a parser similar to YAML, but
+    only for boolean values.
+
     This is most useful when [templated](#prompt-templating).
+
+    If a question is skipped, its answer will be:
+
+    -   The default value, if you're generating the project for the 1st time.
+    -   The last answer recorded, if you're updating the project.
+
+    !!! example
+
+        ```yaml title="copier.yaml"
+        project_creator:
+            type: str
+
+        project_license:
+            type: str
+            choices:
+                - GPLv3
+                - Public domain
+
+        copyright_holder:
+            type: str
+            default: |-
+                {% if project_license == 'Public domain' -%}
+                    {#- Nobody owns public projects -#}
+                    nobody
+                {%- else -%}
+                    {#- By default, project creator is the owner -#}
+                    {{ project_creator }}
+                {%- endif %}
+            # Only ask for copyright if project is not in the public domain
+            when: "{{ project_license != 'Public domain' }}"
 
 !!! example
 


### PR DESCRIPTION
A skipped question was not saved by Questionary, so I need to check if the answer is exactly like the question and, in that case, re-render it again.

Docs clarified to avoid false expectations on what should be the answer.

Fixes https://github.com/copier-org/copier/issues/529