### PR TITLE
feat: Add jinja variable "_copier_python" to get sys.executable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Summary:
 -   Copy dirty changes from a git-tracked template to the project by default, to make
     testing easier.
 -   Advertise clearly which version is being copied or updated in the CLI.
+-   Add jinja variable `_copier_python` to provide python `sys.executable`.
 
 ### Changed
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -207,6 +207,7 @@ class Worker:
             _copier_answers=self._answers_to_remember(),
             _copier_conf=conf,
             _folder_name=self.subproject.local_abspath.name,
+            _copier_python=sys.executable,
         )
 
     def _path_matcher(self, patterns: Iterable[str]) -> Callable[[Path], bool]:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -952,6 +952,8 @@ _tasks:
     - [invoke, "--search-root={{ _copier_conf.src_path }}", after-copy]
     # You are able to output the full conf to JSON, to be parsed by your script
     - [invoke, end-process, "--full-conf={{ _copier_conf|to_json }}"]
+    # Your script can be run by the same python environment used to run copier
+    - ["{{ _copier_python }}", task.py]
 ```
 
 ### `templates_suffix`

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -24,6 +24,7 @@ def demo_template(tmp_path_factory):
                     - mkdir hello
                     - cd hello && touch world
                     - touch [[ other_file ]]
+                    - ["[[ _copier_python ]]", "-c", "open('pyfile', 'w').close()"]
             """
         }
     )
@@ -41,3 +42,4 @@ def test_copy_tasks(tmp_path, demo_template):
     assert (tmp_path / "hello").is_dir()
     assert (tmp_path / "hello" / "world").exists()
     assert (tmp_path / "bye").is_file()
+    assert (tmp_path / "pyfile").is_file()


### PR DESCRIPTION
This PR proposes adding a new built-in jinja variable `_copier_python` that provides the `sys.executable` path such that it can be used to run a script in a repeatable fashion, always using the same python envinroment that copier is installed into.

### Background
In my usage of `copier` I want to run a python script as a `task` to manage some post-template operations. I'd prefer not to use invoke or any other third party tool that requires dependencies to be manually pre-installed.

``` yaml 
_tasks:
  - python update.py
```

Initially this appeared to be working fine, but then some other people re-using the template ran into a range of issues; `import yaml` failing, or `python` cannot be found etc. This issue: https://github.com/copier-org/copier/issues/324 is closely related.

I realised pretty quickly that yes, I'm at the mercy of the users PATH and which ever `python` it finds first (if any). Particularly the Windows (`py.exe`) vs Linux (`python3`) difference makes it very hard to have one template that works everywhere. 

This PR resolves the issue by allowing users to define their task like:
``` yaml 
_tasks:
  - "{{ _copier_python }} update.py"
  - ["{{ _copier_python }}", update.py]
```
guaranteeing the copier python will always be used on any platform.
