### PR TITLE
Improve conflict resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ Summary:
 -   Changed `--force` to be the same as `--defaults --overwrite`.
 -   Copied files will reflect permissions on the same files in the template.
 -   Copier now uses `git clone --filter=blob:none` when cloning, to be faster.
+-   Improved `copier update` conficts resolution by replacing the `.rej` files by merge
+    markers put in the destination file directly.
 
 ### Deprecated
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -45,7 +45,7 @@ else:
     from backports.cached_property import cached_property
 
 # Backport of `shutil.copytree` for python 3.7 to accept `dirs_exist_ok` argument
-if sys.version_info <= (3, 8):
+if sys.version_info >= (3, 8):
     from shutil import copytree
 else:
     from distutils.dir_util import copy_tree

--- a/copier/main.py
+++ b/copier/main.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 from contextlib import suppress
 from dataclasses import asdict, field, replace
-from distutils.dir_util import copy_tree
 from functools import partial
 from itertools import chain
 from pathlib import Path

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -30,9 +30,9 @@ equivalent) hook that detects them, just like this:
 ```yaml title=".pre-commit-config.yaml"
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
-        rev: v4.0.1
-        hooks:
-        - id: check-merge-conflict
+      rev: v4.0.1
+      hooks:
+          - id: check-merge-conflict
             args: [--assume-in-merge]
 ```
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -22,25 +22,18 @@ other git ref you want.
 
 When updating, Copier will do its best to respect your project evolution by using the
 answers you provided when copied last time. However, sometimes it's impossible for
-Copier to know what to do with a diff code hunk. In those cases, you will find `*.rej`
-files that contain the unresolved diffs. _You should review those manually_ before
-committing.
-
-You probably don't want `*.rej` files in your git history, but if you add them to
-`.gitignore`, some important changes could pass unnoticed to you. That's why the
-recommended way to deal with them is to _not_ add them to add a
-[pre-commit](https://pre-commit.com/) (or equivalent) hook that forbids them, just like
-this:
+Copier to know what to do with a diff code hunk. In those cases, each conflicted files
+will contain the unresolved diffs. _Those conflicts must be reviewed before committing_.
+That's why we recommand to add them to add a [pre-commit](https://pre-commit.com/) (or
+equivalent) hook that detects them, just like this:
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
-    - repo: local
-      hooks:
-          - id: forbidden-files
-            name: forbidden files
-            entry: found copier update rejection files; review them and remove them
-            language: fail
-            files: "\\.rej$"
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+        rev: v4.0.1
+        hooks:
+        - id: check-merge-conflict
+            args: [--assume-in-merge]
 ```
 
 ## Never change the answers file manually

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -25,7 +25,6 @@ def test_output_force(capsys, tmp_path):
     render(tmp_path, quiet=False, defaults=True, overwrite=True)
     _, err = capsys.readouterr()
     assert re.search(r"conflict[^\s]*  config\.py", err)
-    assert re.search(r"overwrite[^\s]*  config\.py", err)
     assert re.search(r"identical[^\s]*  pyproject\.toml", err)
     assert re.search(r"identical[^\s]*  doc[/\\]images[/\\]nslogo\.gif", err)
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -212,10 +212,13 @@ def test_new_version_uses_subdirectory(tmp_path_factory):
     copier.copy(dst_path=project_path, defaults=True, overwrite=True)
     assert "_commit: v2" in (project_path / ".copier-answers.yml").read_text()
 
-    # Assert that the README still exists, and was force updated to "upstream version 2"
+    # Assert that the README still exists with conflicts to solve
     assert (project_path / "README.md").exists()
     with (project_path / "README.md").open() as fd:
-        assert fd.read() == "upstream version 2\n"
+        assert fd.read() == (
+            "<<<<<<< modified\ndownstream version 1\n"
+            "=======\nupstream version 2\n>>>>>>> new upstream\n"
+        )
 
     # Also assert the subdirectory itself was not rendered
     assert not (project_path / "subdir").exists()

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -220,7 +220,6 @@ def test_updatediff(tmp_path_factory):
                 _src_path: {bundle}
                 author_name: Guybrush
                 project_name: to become a pirate\n
-                >>>>>>> new upstream
             """
         )
         assert readme.read_text() == dedent(

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -220,6 +220,7 @@ def test_updatediff(tmp_path_factory):
                 _src_path: {bundle}
                 author_name: Guybrush
                 project_name: to become a pirate\n
+                >>>>>>> new upstream
             """
         )
         assert readme.read_text() == dedent(


### PR DESCRIPTION
I propose this work to solve #613: it replaces the merging approach using the `rej` files during an update by a two-way merge. 

This PR is a based on the work of #407 with several differences:
- using two-way merge instead of three-way merge
- update the documentation to tell about how the conflict works and add an example of the `check-merge-conflict` pre-commit hook
- update the existing tests 

Why two-way instead of three : IMHO, I think the majority of the git users are used to the two-way merge instead of the three-way. I can be easily convince to change this behaviour. Maybe we can add an option to let the user choose what he wants. 

I still have some remaining questions :
1. How do we manage the retro compatibility ? The best way would be to add an option to keep the previous behaviour with warning to inform that it will be removed later.
2. What can we do with the `overwrite` option ?

Thanks in advance for your help and time.

