### PR TITLE
fix: stop remembering answers nobody asked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Summary:
 -   When comparing versions to update, PEP 440 is always used now. This way, we avoid
     fake ordering when git commit descriptions happen to be ordered in a non-predictable
     way.
+-   Answers file will only remember answers to questions specified in the questionary.
 
 ### Security
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -161,6 +161,7 @@ class Worker:
             for (k, v) in self.answers.combined.items()
             if not k.startswith("_")
             and k not in self.template.secret_questions
+            and k in self.template.questions_data
             and isinstance(k, JSONSerializable)
             and isinstance(v, JSONSerializable)
         )


### PR DESCRIPTION
Before this patch, an answers file could remember answers to questions that were not present in the questionary.

STR:

1. In one project, apply one template that has a `.copier-answers.yml` file.
2. Now apply another template that has a different default value in `_answers_file`.
3. The second answers file would contain answers to the 1st template too.

@moduon MT-616