### PR TITLE
feat: support getting template commit hash with `{{ _copier_conf.vcs_ref_hash }}`

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -200,6 +200,7 @@ class Worker:
             {
                 "answers_file": self.answers_relpath,
                 "src_path": self.template.local_abspath,
+                "vcs_ref_hash": self.template.commit_hash,
             }
         )
 

--- a/copier/template.py
+++ b/copier/template.py
@@ -215,6 +215,12 @@ class Template:
                 return git("describe", "--tags", "--always").strip()
 
     @cached_property
+    def commit_hash(self) -> OptStr:
+        """If the template is VCS-tracked, get its commit full hash."""
+        if self.vcs == "git":
+            return git("-C", self.local_abspath, "rev-parse", "HEAD").strip()
+
+    @cached_property
     def config_data(self) -> AnyByStrDict:
         """Get config from the template.
 

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -96,3 +96,5 @@ Copier includes:
     -   You can serialize it with `{{ _copier_conf|to_json }}`.
     -   ⚠️ It contains secret answers inside its `.data` key.
     -   Modifying it doesn't alter the current rendering configuration.
+    -   It contains the current commit hash from the template in
+        `{{ _copier_conf.vcs_ref_hash }}`.


### PR DESCRIPTION
When targeting reproducible builds, we need to have exact and immutable hashes.

Until now, there was only one way to get template commit. You could only get the tag, or the best serializable approach to obtain a commit from a tag.

Using this new helper, you can get what you need.

@moduon MT-83