### PR TITLE
docs: Fix a few typos

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -465,7 +465,7 @@ class Template:
                     dunamai.Version.from_git().serialize(style=dunamai.Style.Pep440)
                 )
         except ValueError:
-            # A fully descripted commit can be easily detected converted into a
+            # A fully descriptive commit can be easily detected converted into a
             # PEP440 version, because it has the format "<tag>-<count>-g<hash>"
             if re.match(r"^.+-\d+-g\w+$", self.commit):
                 base, count, git_hash = self.commit.rsplit("-", 2)

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -246,7 +246,7 @@ class Question:
         # Emptiness is expressed as an empty str
         if default is None:
             return ""
-        # JSON and YAML dumped depending on mutliline setting
+        # JSON and YAML dumped depending on multiline setting
         if self.get_type_name() == "json":
             return json.dumps(default, indent=2 if self.get_multiline() else None)
         if self.get_type_name() == "yaml":

--- a/devtasks.py
+++ b/devtasks.py
@@ -6,7 +6,7 @@ from subprocess import check_call
 
 def clean():
     """
-    Clean build, test or other process artefacrts from the project workspace
+    Clean build, test or other process artefacts from the project workspace
     """
     build_artefacts = (
         "build/",


### PR DESCRIPTION
There are small typos in:
- copier/template.py
- copier/user_data.py
- devtasks.py

Fixes:
- Should read `multiline` rather than `mutliline`.
- Should read `descriptive` rather than `descripted`.
- Should read `artefacts` rather than `artefacrts`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md