### PR TITLE
Fix missing backticks in configuring.md

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -172,6 +172,7 @@ Supported keys:
                 {%- endif %}
             # Only ask for copyright if project is not in the public domain
             when: "{{ project_license != 'Public domain' }}"
+        ```
 
 !!! example
 


### PR DESCRIPTION
As you can see at the end of the [Advanced promt formatting](https://copier.readthedocs.io/en/stable/configuring/#advanced-prompt-formatting) section in the "Configuration" part of the docs, one of the code blocks is not correctly formated due to missing three backticks (`` ``` ``).