### PR TITLE
build(deps): remove upper bound from Python version specifier

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -925,8 +925,8 @@ docs = ["mkdocs-material", "mkdocstrings"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7,<4.0"
-content-hash = "ec19cf2f5d71ca219961048304c9ae8a583da06f3c0b77c3652ef4c8a5c54773"
+python-versions = ">=3.7"
+content-hash = "15052b3a0682e222bc9190f03e4a4252282e1be88c5f1545a4d7843c35d6d5a0"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ copier = "copier.cli:CopierApp.run"
 "Bug Tracker" = "https://github.com/copier-org/copier/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0"
+python = ">=3.7"
 "backports.cached-property" = { version = ">=1.0.0", python = "<3.8" }
 colorama = ">=0.4.3"
 dunamai = ">=1.7.0"


### PR DESCRIPTION
Capping the Python version (e.g. `<4`) is a bad practice, so I've removed it.

* https://github.com/pypa/packaging.python.org/pull/850
* https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special
* https://discuss.python.org/t/requires-python-upper-limits/12663