### PR TITLE
build: convert package names to lowercase

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -926,7 +926,7 @@ docs = ["mkdocs-material", "mkdocstrings"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0"
-content-hash = "ec19cf2f5d71ca219961048304c9ae8a583da06f3c0b77c3652ef4c8a5c54773"
+content-hash = "d1392257d73dbde79c03990de14be646a24846daccd684c26d1e0a468eb44630"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ colorama = ">=0.4.3"
 dunamai = ">=1.7.0"
 importlib-metadata = { version = ">=3.4,<5.0", python = "<3.8" }
 iteration_utilities = ">=0.11.0"
-Jinja2 = ">=3.1.1"
+jinja2 = ">=3.1.1"
 jinja2-ansible-filters = ">=1.3.1"
 mkdocs-material = { version = ">=8.2,<9.0.0", optional = true }
 mkdocstrings = {extras = ["python"], version = ">=0.19.0", optional = true}
@@ -40,8 +40,8 @@ packaging = ">=21.0" # packaging is needed when installing from PyPI
 pathspec = ">=0.9.0"
 plumbum = ">=1.6.9"
 pydantic = ">=1.9.0"
-Pygments = ">=2.7.1"
-PyYAML = ">=5.3.1"
+pygments = ">=2.7.1"
+pyyaml = ">=5.3.1"
 pyyaml-include = ">=1.2"
 questionary = ">=1.8.1"
 typing-extensions = { version = ">=3.7.4,<5.0.0", python = "<3.8" }
@@ -66,7 +66,7 @@ pre-commit = ">=2.17.0"
 pytest = ">=7.0.1"
 pytest-cov = ">=3.0.0"
 pytest-xdist = ">=2.5.0"
-types-PyYAML = ">=6.0.4"
+types-pyyaml = ">=6.0.4"
 types-backports = ">=0.1.3"
 
 [tool.poe.tasks.clean]


### PR DESCRIPTION
I've converted all package names of dependencies to lowercase because I think it looks nicer and more consistent. Since the dependencies are sorted already, I infer these kinds of details also matter to you. :wink: