### PR TITLE
chore: use isort profile "black" and remove default settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,14 +107,9 @@ line-length = 88
 target-version = ['py36']
 
 [tool.isort]
+profile = "black"
 combine_as_imports = true
-default_section = "THIRDPARTY"
-force_grid_wrap = 0
-include_trailing_comma = true
 known_first_party = ["copier"]
-line_length = 88
-multi_line_output = 3 # black interop
-use_parentheses = true
 
 [tool.mypy]
 ignore_missing_imports = true


### PR DESCRIPTION
I've simplified the `isort` config in `pyproject.toml` by using the [profile "black"](https://pycqa.github.io/isort/docs/configuration/profiles.html#black). I've also removed redundant settings that explicitly set `isort`'s default values.