### PR TITLE
chore: bump Black target version to Python 3.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,7 +104,7 @@ vcs = "git"
 
 [tool.black]
 line-length = 88
-target-version = ['py36']
+target-version = ["py37"]
 
 [tool.isort]
 combine_as_imports = true


### PR DESCRIPTION
I've bumped Black's `target-version` setting from Python 3.6 to 3.7 as this is the lowest supported Python version. As a minor cosmetic change, I've replaced the single quotes by double quotes for better consistency.