### PR TITLE
chore: remove Black's default line length setting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,6 @@ style = "pep440"
 vcs = "git"
 
 [tool.black]
-line-length = 88
 target-version = ['py36']
 
 [tool.isort]


### PR DESCRIPTION
I've removed the `line-length` setting for Black because 88 characters is the default value anyway, so it's redundant to set it explicitly.