### PR TITLE
chore(pre-commit): remove "poetry run" wrapper for local hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,19 +23,19 @@ repos:
     hooks:
       - id: autoflake
         name: autoflake
-        entry: poetry run autoflake
+        entry: autoflake
         language: system
         types: [python]
         args: ["-i", "--remove-all-unused-imports", "--ignore-init-module-imports"]
       - id: black
         name: black
-        entry: poetry run black
+        entry: black
         language: system
         types: [python]
         require_serial: true
       - id: flake8
         name: flake8
-        entry: poetry run flake8
+        entry: flake8
         language: system
         types: [python]
         require_serial: true


### PR DESCRIPTION
I think wrapping local hook commands with `poetry run <command>` in `.pre-commit-config.yaml` is not necessary because `pre-commit` is run within the context of the Poetry-managed virtual env already:

* Case 1: The Poetry-managed virtual env is activated:
   ```sh
   poetry shell

   git commit
   # or
   pre-commit run ...
   ```

* Case 2: `pre-commit` is run with the `poetry run <command>` wrapper explicitly:
   ```sh
   poetry run git commit
   # or
   poetry run pre-commit run ...
   ```