### PR TITLE
chore(pre-commit): use language "system" for local isort hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,7 +48,7 @@ repos:
         require_serial: true
       - id: poetry_isort
         name: isort
-        entry: isort
+        entry: poetry run isort
         require_serial: true
         language: system
         types_or: [cython, pyi, python]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
         name: isort
         entry: isort
         require_serial: true
-        language: python
+        language: system
         types_or: [cython, pyi, python]
         args: ["--filter-files"]
 


### PR DESCRIPTION
I think local pre-commit hooks should use `language: system` because they are installed via Poetry instead of `pre-commit`. The way I read the [`pre-commit` docs on `language: python`](https://pre-commit.com/#python), the `language` tells `pre-commit` how to _install_ a hook. Since `isort` is now installed via Poetry, it's already installed and directly available to `pre-commit`.

Follow-up of #759.