### PR TITLE
chore(pre-commit): add pyupgrade hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,12 @@ repos:
         types_or: [cython, pyi, python]
         args: ["--filter-files"]
 
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.37.3
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus]
+
   # prettier to format our many yaml files
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.5.1


### PR DESCRIPTION
I've added a pre-commit hook that runs [`pyupgrade`](https://github.com/asottile/pyupgrade) which automatically checks and updates Python syntax to newer versions of the language, so we can make sure we don't use unnecessarily old syntax which is often less convenient. I've configured `pyupgrade` to check for and update to Python 3.7 syntax which is Copier's minimum Python version at this point.