### PR TITLE
chore(pre-commit): rename isort hook ID

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         language: system
         pass_filenames: false
         require_serial: true
-      - id: poetry_isort
+      - id: isort
         name: isort
         entry: poetry run isort
         require_serial: true


### PR DESCRIPTION
I've renamed the `isort` pre-commit hook ID from `poetry_isort` to `isort` for better consistency with the other hook IDs. It's just a minor change, but I like consistency. :wink: