### PR TITLE
docs: update commitizen usage in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,6 @@ your host environment:
 
 -   [Poetry](https://python-poetry.org/) for packaging and dependency management
 -   [poethepoet](https://github.com/nat-n/poethepoet) for running development tasks
--   [commitizen](https://commitizen-tools.github.io/commitizen/) for writing Git commits
-    easily
 
 Or you can use
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/copier-org/copier)
@@ -109,7 +107,7 @@ Ready to contribute? Here's how to set up the project for local development.
 
     ```sh
     git add .
-    cz commit  # use `git commit` if you prefer, but this helps
+    git commit
     git push origin name-of-your-bugfix-or-feature
     ```
 


### PR DESCRIPTION
I've updated the instructions for using `commitizen` in `CONTRIBUTING.md`. Before, `commitizen` was listed as a prerequisite to be installed in the host environment. Also, the `cz commit` command was shown for making a commit. At the same time, `commitizen` is configured as pre-commit hook and the steps for making a contribution include enabling also the `commit-msg` hooks and activating the Poetry shell, so the `commitizen` pre-commit hook is run when executing the `git commit` command.

I think the purely pre-commit-based workflow is smoother than additionally requesting `commitizen` to be installed in the host environment. Also, if the `commitizen` version in the host environment differs from the pre-commit hook version, inconsistent behavior may occur which would be confusing for a developer.

Therefore, I've removed `commitizen` as a prerequisite to be installed in the host environment and replaced the `cz commit` command by `git commit` in `CONTRIBUTING.md`.