### PR TITLE
docs: remove prerequisite "poethepoet" in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,6 @@ We use some tools as part of our development workflow which you'll need to insta
 your host environment:
 
 -   [Poetry](https://python-poetry.org/) for packaging and dependency management
--   [poethepoet](https://github.com/nat-n/poethepoet) for running development tasks
 -   [commitizen](https://commitizen-tools.github.io/commitizen/) for writing Git commits
     easily
 


### PR DESCRIPTION
I've removed the host environment prerequisite `poethepoet` in `CONTRIBUTING.md` because it's installed as a dev dependency via Poetry, and since the Poetry shell is activated in the instructions, the tool is readily available without being installed in the host environment.