### PR TITLE
chore(pytest): move config to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ ignore_missing_imports = true
 plugins = ["pydantic.mypy"]
 warn_no_return = false
 
+[tool.pytest.ini_options]
+addopts = "-n auto -ra"
+
 [build-system]
 requires = ["poetry_core>=1.0.0", "poetry-dynamic-versioning"]
 build-backend = "poetry.core.masonry.api"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts =  -n auto -ra


### PR DESCRIPTION
I've moved `pytest`'s config from `pytest.ini` to `pyproject.toml` as that's where most configs are located these days, and it's also nicer to gather them in a single file instead of having one for each tool in my opinion.