### PR TITLE
build(deps): add missing dependency "prompt-toolkit"

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -939,8 +939,8 @@ docs = ["mkdocs-material", "mkdocstrings"]
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7,<4.0"
-content-hash = "d66345caa28fcca0f7c4407e43ce674fb633adfc70f70c20e76c8bb45b04a4fc"
+python-versions = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
+content-hash = "c27772c42806af6d81307f237489eb5fb583ac7e597c7469b46fb185600e3f42"
 
 [metadata.files]
 atomicwrites = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.19.0", optional = true}
 packaging = ">=21.0" # packaging is needed when installing from PyPI
 pathspec = ">=0.9.0"
 plumbum = ">=1.6.9"
+prompt-toolkit = ">=3.0.30"
 pydantic = ">=1.9.0"
 pygments = ">=2.7.1"
 pyyaml = ">=5.3.1"


### PR DESCRIPTION
I've added `prompt-toolkit` as a top-level dependency because it's imported in two modules, so Copier directly depends on it. Before, Copier happened to work fine despite this missing top-level dependency because `prompt-toolkit` is a dependency of `questionary`:

```shell-session
$ poetry show -a -t
...
questionary 1.10.0 Python library to build pretty command line user prompts ⭐️
└── prompt-toolkit >=2.0,<4.0
...
```