### PR TITLE
fix: prevent name collision for question var name "value"

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -15,6 +15,7 @@ from typing import (
     ChainMap as t_ChainMap,
     Dict,
     List,
+    Optional,
     Union,
 )
 
@@ -374,7 +375,7 @@ class Question:
             return False
 
         try:
-            err_msg = self.render_value(self.validator, **{self.var_name: ans}).strip()
+            err_msg = self.render_value(self.validator, {self.var_name: ans}).strip()
         except Exception as error:
             raise ValidationError(message=str(error)) from error
         if err_msg:
@@ -395,7 +396,9 @@ class Question:
         when = cast_answer_type(when, cast_str_to_bool)
         return bool(when)
 
-    def render_value(self, value: Any, **extra_answers: Any) -> str:
+    def render_value(
+        self, value: Any, extra_answers: Optional[AnyByStrDict] = None
+    ) -> str:
         """Render a single templated value using Jinja.
 
         If the value cannot be used as a template, it will be returned as is.
@@ -408,7 +411,7 @@ class Question:
             # value was not a string
             return value
         try:
-            return template.render(**dict(self.answers.combined, **extra_answers))
+            return template.render({**self.answers.combined, **(extra_answers or {})})
         except UndefinedError as error:
             raise UserMessageError(str(error)) from error
 


### PR DESCRIPTION
I've fixed a rare but possible name collision between the var name of a question and the arguments of the method [`Question::render_value(...)`](https://github.com/copier-org/copier/blob/bc80d5fc9bca7fdb901ad85a97e877c443caaf08/copier/user_data.py#L398). `Question::render_value(...)` has a positional argument `value` and before this change, extra answers (a `dict`) were passed to `Question::render_value(...)` as keyword arguments by the [`Question::validate_answer(...)`](https://github.com/copier-org/copier/blob/bc80d5fc9bca7fdb901ad85a97e877c443caaf08/copier/user_data.py#L377) method, so in case a question var name happened to be literally `"value"`, there would be a name collision with the positional argument `value`.

I've verified this bug with a sample `copier.yml` file using https://github.com/copier-org/copier/tree/bc80d5fc9bca7fdb901ad85a97e877c443caaf08:

```yaml
value:
  type: str
  help: A question whose var name is "value"
  default: xyz
```

Running Copier with this `copier.yml` file results in the following error:

```shell-session
$ copier . output/
🎤 A question whose var name is "value"                                                                                                                                                                    
   xyz
render_value() got multiple values for argument 'value'
```

I've also added a test case which fails with the following error when the fix has not been applied:

```text
./tests/test_prompt.py::test_var_name_collision Failed: [undefined]pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x7f233e0dee80>
searcher: searcher_string:
    0: EOF
<pexpect.popen_spawn.PopenSpawn object at 0x7f233e0dee80>
searcher: searcher_string:
    0: EOF
tmp_path_factory = TempPathFactory(_given_basetemp=PosixPath('/tmp/pytest-of-sigurd/pytest-9/popen-gw0'), _trace=<pluggy._tracing.TagTracerSub object at 0x7f233f551d60>, _basetemp=PosixPath('/tmp/pytest-of-sigurd/pytest-9/popen-gw0'))
spawn = <function spawn.<locals>._spawn at 0x7f233e17e790>

    def test_var_name_collision(tmp_path_factory, spawn):
        """Test that a question var name "value" causes no name collision."""
        template, subproject = (
            tmp_path_factory.mktemp("template"),
            tmp_path_factory.mktemp("subproject"),
        )
        # Create template
        build_file_tree(
            {
                template
                / "copier.yaml": """
                    value:
                        type: str
                        default: string
                    """,
                template
                / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
            }
        )
        # Copy
        tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
        expect_prompt(tui, "value", "str")
        tui.expect_exact("string")
        tui.send(Keyboard.Alt + Keyboard.Enter)
>       tui.expect_exact(pexpect.EOF)

tests/test_prompt.py:473: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
.venv/lib/python3.9/site-packages/pexpect/spawnbase.py:421: in expect_exact
    return exp.expect_loop(timeout)
.venv/lib/python3.9/site-packages/pexpect/expect.py:181: in expect_loop
    return self.timeout(e)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <pexpect.expect.Expecter object at 0x7f233e0843a0>
err = TIMEOUT('<pexpect.popen_spawn.PopenSpawn object at 0x7f233e0dee80>\nsearcher: searcher_string:\n    0: EOF')

    def timeout(self, err=None):
        spawn = self.spawn
    
        spawn.before = spawn._before.getvalue()
        spawn.after = TIMEOUT
        index = self.searcher.timeout_index
        if index >= 0:
            spawn.match = TIMEOUT
            spawn.match_index = index
            return index
        else:
            spawn.match = None
            spawn.match_index = None
            msg = str(spawn)
            msg += '\nsearcher: %s' % self.searcher
            if err is not None:
                msg = str(err) + '\n' + msg
    
            exc = TIMEOUT(msg)
            exc.__cause__ = None    # in Python 3.x we can use "raise exc from None"
>           raise exc
E           pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x7f233e0dee80>
E           searcher: searcher_string:
E               0: EOF
E           <pexpect.popen_spawn.PopenSpawn object at 0x7f233e0dee80>
E           searcher: searcher_string:
E               0: EOF

.venv/lib/python3.9/site-packages/pexpect/expect.py:144: TIMEOUT
```