### PR TITLE
docs(faq): convert "choices" items to lowercase

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,10 +38,10 @@ your `copier.yaml` contains a multiple-choice variable like this:
 flavor:
     type: str
     choices:
-        - Docker
-        - Instances
-        - Kubernetes
-        - None
+        - docker
+        - instances
+        - kubernetes
+        - none
 ```
 
 The `context.py` file contains your context hook which could look like:


### PR DESCRIPTION
The `choices` items in the example on the FAQ docs page should be lowercase in order to work with the matching in the context hook example code below. Before this change, the example is inconsistent.