### PR TITLE
fix: Resolve path before checking Git bundle

### DIFF
--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import tempfile
+from contextlib import suppress
 from pathlib import Path
 from warnings import warn
 
@@ -46,6 +47,8 @@ def is_in_git_repo(path: StrOrPath) -> bool:
 
 def is_git_bundle(path: Path) -> bool:
     """Indicate if a path is a valid git bundle."""
+    with suppress(OSError):
+        path = path.resolve()
     with TemporaryDirectory(prefix=f"{__name__}.is_git_bundle.") as dirname:
         with local.cwd(dirname):
             git("init")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -50,6 +50,10 @@ def test_get_repo():
     assert get("git.myproject.org/MyProject") is None
     assert get("https://google.com") is None
 
+    assert (
+        get("tests/demo_updatediff_repo.bundle") == "tests/demo_updatediff_repo.bundle"
+    )
+
 
 def test_clone():
     tmp = vcs.clone("https://github.com/copier-org/copier.git")


### PR DESCRIPTION
Closes #791.

I won't be able to add a test right now, but can do later this week.