### PR TITLE
docs: unify shell code blocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,14 +63,14 @@ Ready to contribute? Here's how to set up the project for local development.
 1.  Fork the Copier repo on GitHub.
 2.  Clone your fork locally:
 
-    ```sh
+    ```shell
     git clone git@github.com:my-user/copier.git
     cd copier
     ```
 
 3.  Use Poetry to set up a development environment:
 
-    ```sh
+    ```shell
     # Tell Poetry to create the virtualenv in the project directory
     poetry config virtualenvs.in-project true --local
 
@@ -86,7 +86,7 @@ Ready to contribute? Here's how to set up the project for local development.
 
 4.  Create a branch for local development:
 
-    ```sh
+    ```shell
     git checkout -b name-of-your-bugfix-or-feature
     ```
 
@@ -94,7 +94,7 @@ Ready to contribute? Here's how to set up the project for local development.
 
 5.  When you're done making changes, check that your changes pass all tests:
 
-    ```sh
+    ```shell
     poe test
     poe lint
     ```
@@ -104,7 +104,7 @@ Ready to contribute? Here's how to set up the project for local development.
 
 6.  Commit your changes and push your branch to GitHub:
 
-    ```sh
+    ```shell
     git add .
     cz commit  # use `git commit` if you prefer, but this helps
     git push origin name-of-your-bugfix-or-feature
@@ -123,6 +123,6 @@ Before you submit a pull request, check that it meets these guidelines:
 
 To run a subset of tests:
 
-```sh
+```shell
 poe test tests/the-tests-file.py
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A library and CLI app for rendering project templates.
 
 To create a template:
 
-```bash
+```shell
 📁 my_copier_template ------------------------ # your template project
 ├── 📄 copier.yml ---------------------------- # your template configuration
 ├── 📁 .git ---------------------------------- # your template is a Git repository
@@ -63,7 +63,7 @@ To generate a project from the template:
 
 -   On the command-line:
 
-    ```bash
+    ```shell
     copier path/to/project/template path/to/destination
     ```
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -395,7 +395,7 @@ use_precommit:
 
 And then, you can generate a `.pre-commit-config.yaml` file only if they answered "yes":
 
-```bash
+```shell
 📁 your_template
 ├── 📄 copier.yml
 └── 📄 {% if use_precommit %}.pre-commit-config.yaml{% endif %}.jinja
@@ -420,7 +420,7 @@ ci:
     default: github
 ```
 
-```bash
+```shell
 📁 your_template
 ├── 📄 copier.yml
 ├── 📁 {% if ci == 'github' %}.github{% endif %}
@@ -503,7 +503,7 @@ questions with default answers.
     Example CLI usage to take all default answers from template, except the user name,
     which is overridden, and don't ask user anything else:
 
-    ```sh
+    ```shell
     copier -fd 'user_name=Manuel Calavera' copy template destination
     ```
 
@@ -582,7 +582,7 @@ The CLI option can be passed several times to add several patterns.
 
     !!! example "Example CLI usage to copy only a single file from the template"
 
-        ```sh
+        ```shell
         copier --exclude '*' --exclude '!file-i-want' copy ./template ./destination
         ```
 
@@ -658,7 +658,7 @@ on them, so they are always installed when Copier is installed.
     For example, if your template uses `jinja2_time.TimeExtension`,
     your users must install the `jinja2-time` Python package.
 
-    ```bash
+    ```shell
     # with pip, in the same virtualenv where Copier is installed
     pip install jinja2-time
 
@@ -893,7 +893,7 @@ This allows you to keep separate the template metadata and the template code.
     !!! example "Example project with different `.gitignore` files"
 
 
-        ```bash title="Project layout"
+        ```shell title="Project layout"
         📁 my_copier_template
         ├── 📄 copier.yml       # (1)
         ├── 📄 .gitignore       # (2)
@@ -926,7 +926,7 @@ This allows you to keep separate the template metadata and the template code.
                 - pipenv
         ```
 
-        ```bash title="Project layout"
+        ```shell title="Project layout"
         📁 my_copier_template
         ├── 📄 copier.yaml # (1)
         ├── 📁 poetry
@@ -1133,7 +1133,7 @@ for each one. All of them contain a `{{ _copier_conf.answers_file }}.jinja` file
 [as specified above](#the-copier-answersyml-file). Then you apply all the templates to
 the same project:
 
-```bash
+```shell
 mkdir my-project
 cd my-project
 git init
@@ -1157,7 +1157,7 @@ Done!
 After a while, when templates get new releases, updates are handled separately for each
 template:
 
-```bash
+```shell
 copier -a .copier-answers.main.yml update
 copier -a .copier-answers.pre-commit.yml update
 copier -a .copier-answers.ci.yml update

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -15,7 +15,7 @@ project, the user will be prompted to fill in or confirm the default values.
 
 ## Minimal example
 
-```bash
+```shell
 📁 my_copier_template ------------------------ # your template project
 ├── 📄 copier.yml ---------------------------- # your template configuration
 ├── 📁 .git ---------------------------------- # your template is a Git repository
@@ -48,7 +48,7 @@ Generating a project from this template with `super_project` and `world` as answ
 the `project_name` and `module_name` questions respectively would create in the
 following directory and files:
 
-```bash
+```shell
 📁 generated_project
 ├── 📁 super_project
 │   └── 📄 world.py

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -8,7 +8,7 @@
 As seen in the quick usage section, you can generate a project from a template using the
 `copier` command-line tool:
 
-```bash
+```shell
 copier path/to/project/template path/to/destination
 ```
 
@@ -48,13 +48,13 @@ other reference to use.
 
 For example to use the latest master branch from a public repository:
 
-```bash
+```shell
 copier --vcs-ref master https://github.com/foo/copier-template.git ./path/to/destination
 ```
 
 Or to work from the current checked out revision of a local template:
 
-```bash
+```shell
 copier --vcs-ref HEAD path/to/project/template path/to/destination
 ```
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -11,7 +11,7 @@ true:
 If that's your case, then just enter the destination folder, make sure `git status`
 shows it clean, and run:
 
-```bash
+```shell
 copier update
 ```
 
@@ -64,14 +64,14 @@ repos:
 
 If you want to just reuse all previous answers:
 
-```sh
+```shell
 copier --force update
 ```
 
 If you want to change just one question, and leave all others untouched, and don't want
 to go through the whole questionary again:
 
-```sh
+```shell
 copier --force --data updated_question="my new answer" update
 ```
 


### PR DESCRIPTION
Just a minor (probably a bit subjective and picky :laughing:) change: There was a mix of language identifiers for shell code blocks (`bash` and `sh`). To my understanding, `bash` refers to the [Bash](https://en.wikipedia.org/wiki/Bash_(Unix_shell)) shell and `sh` (unless it's just meant as a short form of "shell") refers to the [Bourne shell](https://en.wikipedia.org/wiki/Bourne_shell). I believe none of the shell code blocks show code specific to one of the shell variants, so I suggest to use `shell` as the generic language identifier for a [Unix shell](https://en.wikipedia.org/wiki/Unix_shell).

There is no difference in syntax highlighting because all three language identifiers map to [`pygments.lexers.shell.BashLexer`](https://pygments.org/docs/lexers/#pygments.lexers.shell.BashLexer), it's rather a matter of conveying the right intent.