### PR TITLE
docs: always use ordered list marker "1."

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,14 +61,14 @@ to start hacking with one click!
 Ready to contribute? Here's how to set up the project for local development.
 
 1.  Fork the Copier repo on GitHub.
-2.  Clone your fork locally:
+1.  Clone your fork locally:
 
     ```sh
     git clone git@github.com:my-user/copier.git
     cd copier
     ```
 
-3.  Use Poetry to set up a development environment:
+1.  Use Poetry to set up a development environment:
 
     ```sh
     # Tell Poetry to create the virtualenv in the project directory
@@ -84,7 +84,7 @@ Ready to contribute? Here's how to set up the project for local development.
     poetry shell
     ```
 
-4.  Create a branch for local development:
+1.  Create a branch for local development:
 
     ```sh
     git checkout -b name-of-your-bugfix-or-feature
@@ -92,7 +92,7 @@ Ready to contribute? Here's how to set up the project for local development.
 
     Now you can make your changes locally.
 
-5.  When you're done making changes, check that your changes pass all tests:
+1.  When you're done making changes, check that your changes pass all tests:
 
     ```sh
     poe test
@@ -102,7 +102,7 @@ Ready to contribute? Here's how to set up the project for local development.
     To have multiple Python versions on the same machine for running `tox`, I recommend
     using [pyenv](https://github.com/pyenv/pyenv) (_do not_ confuse it with `pipenv`,).
 
-6.  Commit your changes and push your branch to GitHub:
+1.  Commit your changes and push your branch to GitHub:
 
     ```sh
     git add .
@@ -110,14 +110,14 @@ Ready to contribute? Here's how to set up the project for local development.
     git push origin name-of-your-bugfix-or-feature
     ```
 
-7.  Submit a pull request through the GitHub website.
+1.  Submit a pull request through the GitHub website.
 
 ## Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:
 
 1.  The pull request has code, it should include tests.
-2.  Check that all checks pass on GitHub CI.
+1.  Check that all checks pass on GitHub CI.
 
 ## Tips
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -902,9 +902,9 @@ This allows you to keep separate the template metadata and the template code.
         ```
 
         1.  Same contents as the example above.
-        2.  Ignore instructions for the template repo.
-        3.  The configured template subdirectory.
-        4.  Ignore instructions for projects generated with the template.
+        1.  Ignore instructions for the template repo.
+        1.  The configured template subdirectory.
+        1.  Ignore instructions for projects generated with the template.
 
     However, it is true that the value of this option can itself be templated. This would
     let you have different templates that all use the same questionary, and the used
@@ -938,7 +938,7 @@ This allows you to keep separate the template metadata and the template code.
         ```
 
         1.  The configuration from the previous example snippet.
-        2.  See [the answers file docs][the-copier-answersyml-file] to understand.
+        1.  See [the answers file docs][the-copier-answersyml-file] to understand.
 
 ### `tasks`
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -5,8 +5,8 @@ true:
 
 1. The template includes
    [a valid `.copier-answers.yml` file](configuring.md#the-copier-answersyml-file).
-2. The template is versioned with Git (with tags).
-3. The destination folder is versioned with Git.
+1. The template is versioned with Git (with tags).
+1. The destination folder is versioned with Git.
 
 If that's your case, then just enter the destination folder, make sure `git status`
 shows it clean, and run:


### PR DESCRIPTION
I've updated the ordered list markers to `1.`. I think it's common and good practice to always use `1.` as the marker in ordered lists instead of explicitly incrementing the marker because it simplifies changes to an ordered list.