### PR TITLE
Fix bug with pydantic 1.10.2

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -4,7 +4,7 @@ import platform
 import subprocess
 import sys
 from contextlib import suppress
-from dataclasses import asdict, field, replace
+from dataclasses import asdict, replace
 from filecmp import dircmp
 from functools import partial
 from itertools import chain
@@ -20,6 +20,7 @@ from plumbum import ProcessExecutionError, colors
 from plumbum.cli.terminal import ask
 from plumbum.cmd import git
 from plumbum.machines import local
+from pydantic import BaseModel, Extra, Field
 from pydantic.dataclasses import dataclass
 from pydantic.json import pydantic_encoder
 from questionary import unsafe_prompt
@@ -44,9 +45,7 @@ if sys.version_info >= (3, 8):
 else:
     from backports.cached_property import cached_property
 
-
-@dataclass
-class Worker:
+class Worker(BaseModel):
     """Copier process state manager.
 
     This class represents the state of a copier work, and contains methods to
@@ -130,18 +129,21 @@ class Worker:
 
             See [quiet][].
     """
+    class Config:
+        extra = Extra.forbid
+        keep_untouched = (cached_property,)
 
     src_path: Optional[str] = None
-    dst_path: Path = field(default=Path("."))
+    dst_path: Path = Field(default=Path("."))
     answers_file: Optional[RelativePath] = None
     vcs_ref: OptStr = None
-    data: AnyByStrDict = field(default_factory=dict)
+    data: AnyByStrDict = Field(default_factory=dict)
     exclude: StrSeq = ()
     use_prereleases: bool = False
     skip_if_exists: StrSeq = ()
     cleanup_on_error: bool = True
     defaults: bool = False
-    user_defaults: AnyByStrDict = field(default_factory=dict)
+    user_defaults: AnyByStrDict = Field(default_factory=dict)
     overwrite: bool = False
     pretend: bool = False
     quiet: bool = False

--- a/copier/main.py
+++ b/copier/main.py
@@ -670,18 +670,21 @@ class Worker(BaseModel):
         ) as old_copy, TemporaryDirectory(
             prefix=f"{__name__}.recopy_diff."
         ) as new_copy:
-            old_worker = self.copy(
-                update={
+            params = {k: getattr(self, k) for k in self.__fields__}
+            params.update(
+                {
                     "dst_path": old_copy,
-                    "dat": self.subproject.last_answers,
+                    "data": self.subproject.last_answers,
                     "defaults": True,
                     "quiet": True,
                     "src_path": self.subproject.template.url,
                     "vcs_ref": self.subproject.template.commit,
                 }
             )
-            recopy_worker = self.copy(
-                update={
+            old_worker = Worker(**params)
+            params = {k: getattr(self, k) for k in self.__fields__}
+            params.update(
+                {
                     "dst_path": new_copy,
                     "data": self.subproject.last_answers,
                     "defaults": True,
@@ -689,6 +692,7 @@ class Worker(BaseModel):
                     "src_path": self.subproject.template.url,
                 }
             )
+            recopy_worker = Worker(**params)
             old_worker.run_copy()
             recopy_worker.run_copy()
             compared = dircmp(old_copy, new_copy)

--- a/copier/main.py
+++ b/copier/main.py
@@ -4,7 +4,6 @@ import platform
 import subprocess
 import sys
 from contextlib import suppress
-from dataclasses import replace
 from filecmp import dircmp
 from functools import partial
 from itertools import chain
@@ -43,6 +42,7 @@ if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from backports.cached_property import cached_property
+
 
 class Worker(BaseModel):
     """Copier process state manager.
@@ -128,6 +128,7 @@ class Worker(BaseModel):
 
             See [quiet][].
     """
+
     class Config:
         extra = Extra.forbid
         keep_untouched = (cached_property,)
@@ -667,22 +668,24 @@ class Worker(BaseModel):
         ) as old_copy, TemporaryDirectory(
             prefix=f"{__name__}.recopy_diff."
         ) as new_copy:
-            old_worker = replace(
-                self,
-                dst_path=old_copy,
-                data=self.subproject.last_answers,
-                defaults=True,
-                quiet=True,
-                src_path=self.subproject.template.url,
-                vcs_ref=self.subproject.template.commit,
+            old_worker = self.copy(
+                update={
+                    "dst_path": old_copy,
+                    "dat": self.subproject.last_answers,
+                    "defaults": True,
+                    "quiet": True,
+                    "src_path": self.subproject.template.url,
+                    "vcs_ref": self.subproject.template.commit,
+                }
             )
-            recopy_worker = replace(
-                self,
-                dst_path=new_copy,
-                data=self.subproject.last_answers,
-                defaults=True,
-                quiet=True,
-                src_path=self.subproject.template.url,
+            recopy_worker = self.copy(
+                update={
+                    "dst_path": new_copy,
+                    "data": self.subproject.last_answers,
+                    "defaults": True,
+                    "quiet": True,
+                    "src_path": self.subproject.template.url,
+                }
             )
             old_worker.run_copy()
             recopy_worker.run_copy()

--- a/copier/main.py
+++ b/copier/main.py
@@ -198,6 +198,8 @@ class Worker(BaseModel):
         # Backwards compatibility
         # FIXME Remove it?
         conf = dict(self)
+        # Delete this because it's not JSON serializable.
+        del conf["jinja_env"]
         conf.update(
             {
                 "answers_file": self.answers_relpath,

--- a/copier/main.py
+++ b/copier/main.py
@@ -199,7 +199,7 @@ class Worker(BaseModel):
         # FIXME Remove it?
         conf = dict(self)
         # Delete this because it's not JSON serializable.
-        del conf["jinja_env"]
+        conf.pop("jinja_env", None)
         conf.update(
             {
                 "answers_file": self.answers_relpath,

--- a/copier/main.py
+++ b/copier/main.py
@@ -4,7 +4,7 @@ import platform
 import subprocess
 import sys
 from contextlib import suppress
-from dataclasses import asdict, replace
+from dataclasses import replace
 from filecmp import dircmp
 from functools import partial
 from itertools import chain
@@ -21,7 +21,6 @@ from plumbum.cli.terminal import ask
 from plumbum.cmd import git
 from plumbum.machines import local
 from pydantic import BaseModel, Extra, Field
-from pydantic.dataclasses import dataclass
 from pydantic.json import pydantic_encoder
 from questionary import unsafe_prompt
 
@@ -197,7 +196,7 @@ class Worker(BaseModel):
         """Produce render context for Jinja."""
         # Backwards compatibility
         # FIXME Remove it?
-        conf = asdict(self)
+        conf = dict(self)
         conf.update(
             {
                 "answers_file": self.answers_relpath,

--- a/copier/main.py
+++ b/copier/main.py
@@ -9,7 +9,7 @@ from functools import partial
 from itertools import chain
 from pathlib import Path
 from shutil import rmtree
-from typing import Callable, Iterable, List, Mapping, Optional, Sequence
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence
 from unicodedata import normalize
 
 import pathspec
@@ -150,7 +150,7 @@ class Worker(BaseModel):
     pretend: bool = False
     quiet: bool = False
 
-    def _asdict(self, **overrides) -> Mapping:
+    def _asdict(self, **overrides) -> Dict:
         """Return a dictionary with our Pydantic field values."""
         result = {k: getattr(self, k) for k in self.__fields__}
         for k, v in overrides.items():
@@ -206,7 +206,8 @@ class Worker(BaseModel):
         """Produce render context for Jinja."""
         # Backwards compatibility
         # FIXME Remove it?
-        conf = self._asdict(
+        conf = self._asdict()
+        conf.update(
             answers_file=self.answers_relpath,
             src_path=self.template.local_abspath,
             vcs_ref_hash=self.template.commit_hash,

--- a/copier/main.py
+++ b/copier/main.py
@@ -208,9 +208,11 @@ class Worker(BaseModel):
         # FIXME Remove it?
         conf = self._asdict()
         conf.update(
-            answers_file=self.answers_relpath,
-            src_path=self.template.local_abspath,
-            vcs_ref_hash=self.template.commit_hash,
+            {
+                "answers_file": self.answers_relpath,
+                "src_path": self.template.local_abspath,
+                "vcs_ref_hash": self.template.commit_hash,
+            }
         )
         return dict(
             DEFAULT_DATA,

--- a/poetry.lock
+++ b/poetry.lock
@@ -558,6 +558,9 @@ category = "dev"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
 
+[package.dependencies]
+setuptools = "*"
+
 [[package]]
 name = "packaging"
 version = "21.3"
@@ -708,14 +711,14 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "pydantic"
-version = "1.9.2"
+version = "1.10.2"
 description = "Data validation and settings management using python type hints"
 category = "main"
 optional = false
-python-versions = ">=3.6.1"
+python-versions = ">=3.7"
 
 [package.dependencies]
-typing-extensions = ">=3.7.4.3"
+typing-extensions = ">=4.1.0"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
@@ -894,6 +897,19 @@ prompt_toolkit = ">=2.0,<4.0"
 
 [package.extras]
 docs = ["Sphinx (>=3.3,<4.0)", "sphinx-autobuild (>=2020.9.1,<2021.0.0)", "sphinx-autodoc-typehints (>=1.11.1,<2.0.0)", "sphinx-copybutton (>=0.3.1,<0.4.0)", "sphinx-rtd-theme (>=0.5.0,<0.6.0)"]
+
+[[package]]
+name = "setuptools"
+version = "65.3.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "mock", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "six"
@@ -1417,41 +1433,42 @@ pycodestyle = [
     {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
 ]
 pydantic = [
-    {file = "pydantic-1.9.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9c9e04a6cdb7a363d7cb3ccf0efea51e0abb48e180c0d31dca8d247967d85c6e"},
-    {file = "pydantic-1.9.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fafe841be1103f340a24977f61dee76172e4ae5f647ab9e7fd1e1fca51524f08"},
-    {file = "pydantic-1.9.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:afacf6d2a41ed91fc631bade88b1d319c51ab5418870802cedb590b709c5ae3c"},
-    {file = "pydantic-1.9.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ee0d69b2a5b341fc7927e92cae7ddcfd95e624dfc4870b32a85568bd65e6131"},
-    {file = "pydantic-1.9.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:ff68fc85355532ea77559ede81f35fff79a6a5543477e168ab3a381887caea76"},
-    {file = "pydantic-1.9.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c0f5e142ef8217019e3eef6ae1b6b55f09a7a15972958d44fbd228214cede567"},
-    {file = "pydantic-1.9.2-cp310-cp310-win_amd64.whl", hash = "sha256:615661bfc37e82ac677543704437ff737418e4ea04bef9cf11c6d27346606044"},
-    {file = "pydantic-1.9.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:328558c9f2eed77bd8fffad3cef39dbbe3edc7044517f4625a769d45d4cf7555"},
-    {file = "pydantic-1.9.2-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bd446bdb7755c3a94e56d7bdfd3ee92396070efa8ef3a34fab9579fe6aa1d84"},
-    {file = "pydantic-1.9.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e0b214e57623a535936005797567231a12d0da0c29711eb3514bc2b3cd008d0f"},
-    {file = "pydantic-1.9.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:d8ce3fb0841763a89322ea0432f1f59a2d3feae07a63ea2c958b2315e1ae8adb"},
-    {file = "pydantic-1.9.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:b34ba24f3e2d0b39b43f0ca62008f7ba962cff51efa56e64ee25c4af6eed987b"},
-    {file = "pydantic-1.9.2-cp36-cp36m-win_amd64.whl", hash = "sha256:84d76ecc908d917f4684b354a39fd885d69dd0491be175f3465fe4b59811c001"},
-    {file = "pydantic-1.9.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:4de71c718c9756d679420c69f216776c2e977459f77e8f679a4a961dc7304a56"},
-    {file = "pydantic-1.9.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5803ad846cdd1ed0d97eb00292b870c29c1f03732a010e66908ff48a762f20e4"},
-    {file = "pydantic-1.9.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a8c5360a0297a713b4123608a7909e6869e1b56d0e96eb0d792c27585d40757f"},
-    {file = "pydantic-1.9.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:cdb4272678db803ddf94caa4f94f8672e9a46bae4a44f167095e4d06fec12979"},
-    {file = "pydantic-1.9.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:19b5686387ea0d1ea52ecc4cffb71abb21702c5e5b2ac626fd4dbaa0834aa49d"},
-    {file = "pydantic-1.9.2-cp37-cp37m-win_amd64.whl", hash = "sha256:32e0b4fb13ad4db4058a7c3c80e2569adbd810c25e6ca3bbd8b2a9cc2cc871d7"},
-    {file = "pydantic-1.9.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:91089b2e281713f3893cd01d8e576771cd5bfdfbff5d0ed95969f47ef6d676c3"},
-    {file = "pydantic-1.9.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e631c70c9280e3129f071635b81207cad85e6c08e253539467e4ead0e5b219aa"},
-    {file = "pydantic-1.9.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b3946f87e5cef3ba2e7bd3a4eb5a20385fe36521d6cc1ebf3c08a6697c6cfb3"},
-    {file = "pydantic-1.9.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5565a49effe38d51882cb7bac18bda013cdb34d80ac336428e8908f0b72499b0"},
-    {file = "pydantic-1.9.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:bd67cb2c2d9602ad159389c29e4ca964b86fa2f35c2faef54c3eb28b4efd36c8"},
-    {file = "pydantic-1.9.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:4aafd4e55e8ad5bd1b19572ea2df546ccace7945853832bb99422a79c70ce9b8"},
-    {file = "pydantic-1.9.2-cp38-cp38-win_amd64.whl", hash = "sha256:d70916235d478404a3fa8c997b003b5f33aeac4686ac1baa767234a0f8ac2326"},
-    {file = "pydantic-1.9.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f0ca86b525264daa5f6b192f216a0d1e860b7383e3da1c65a1908f9c02f42801"},
-    {file = "pydantic-1.9.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1061c6ee6204f4f5a27133126854948e3b3d51fcc16ead2e5d04378c199b2f44"},
-    {file = "pydantic-1.9.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e78578f0c7481c850d1c969aca9a65405887003484d24f6110458fb02cca7747"},
-    {file = "pydantic-1.9.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5da164119602212a3fe7e3bc08911a89db4710ae51444b4224c2382fd09ad453"},
-    {file = "pydantic-1.9.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:7ead3cd020d526f75b4188e0a8d71c0dbbe1b4b6b5dc0ea775a93aca16256aeb"},
-    {file = "pydantic-1.9.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:7d0f183b305629765910eaad707800d2f47c6ac5bcfb8c6397abdc30b69eeb15"},
-    {file = "pydantic-1.9.2-cp39-cp39-win_amd64.whl", hash = "sha256:f1a68f4f65a9ee64b6ccccb5bf7e17db07caebd2730109cb8a95863cfa9c4e55"},
-    {file = "pydantic-1.9.2-py3-none-any.whl", hash = "sha256:78a4d6bdfd116a559aeec9a4cfe77dda62acc6233f8b56a716edad2651023e5e"},
-    {file = "pydantic-1.9.2.tar.gz", hash = "sha256:8cb0bc509bfb71305d7a59d00163d5f9fc4530f0881ea32c74ff4f74c85f3d3d"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb6ad4489af1bac6955d38ebcb95079a836af31e4c4f74aba1ca05bb9f6027bd"},
+    {file = "pydantic-1.10.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a1f5a63a6dfe19d719b1b6e6106561869d2efaca6167f84f5ab9347887d78b98"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:352aedb1d71b8b0736c6d56ad2bd34c6982720644b0624462059ab29bd6e5912"},
+    {file = "pydantic-1.10.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:19b3b9ccf97af2b7519c42032441a891a5e05c68368f40865a90eb88833c2559"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e9069e1b01525a96e6ff49e25876d90d5a563bc31c658289a8772ae186552236"},
+    {file = "pydantic-1.10.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:355639d9afc76bcb9b0c3000ddcd08472ae75318a6eb67a15866b87e2efa168c"},
+    {file = "pydantic-1.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:ae544c47bec47a86bc7d350f965d8b15540e27e5aa4f55170ac6a75e5f73b644"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a4c805731c33a8db4b6ace45ce440c4ef5336e712508b4d9e1aafa617dc9907f"},
+    {file = "pydantic-1.10.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d49f3db871575e0426b12e2f32fdb25e579dea16486a26e5a0474af87cb1ab0a"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:37c90345ec7dd2f1bcef82ce49b6235b40f282b94d3eec47e801baf864d15525"},
+    {file = "pydantic-1.10.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b5ba54d026c2bd2cb769d3468885f23f43710f651688e91f5fb1edcf0ee9283"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:05e00dbebbe810b33c7a7362f231893183bcc4251f3f2ff991c31d5c08240c42"},
+    {file = "pydantic-1.10.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:2d0567e60eb01bccda3a4df01df677adf6b437958d35c12a3ac3e0f078b0ee52"},
+    {file = "pydantic-1.10.2-cp311-cp311-win_amd64.whl", hash = "sha256:c6f981882aea41e021f72779ce2a4e87267458cc4d39ea990729e21ef18f0f8c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c4aac8e7103bf598373208f6299fa9a5cfd1fc571f2d40bf1dd1955a63d6eeb5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81a7b66c3f499108b448f3f004801fcd7d7165fb4200acb03f1c2402da73ce4c"},
+    {file = "pydantic-1.10.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bedf309630209e78582ffacda64a21f96f3ed2e51fbf3962d4d488e503420254"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:9300fcbebf85f6339a02c6994b2eb3ff1b9c8c14f502058b5bf349d42447dcf5"},
+    {file = "pydantic-1.10.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:216f3bcbf19c726b1cc22b099dd409aa371f55c08800bcea4c44c8f74b73478d"},
+    {file = "pydantic-1.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:dd3f9a40c16daf323cf913593083698caee97df2804aa36c4b3175d5ac1b92a2"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b97890e56a694486f772d36efd2ba31612739bc6f3caeee50e9e7e3ebd2fdd13"},
+    {file = "pydantic-1.10.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:9cabf4a7f05a776e7793e72793cd92cc865ea0e83a819f9ae4ecccb1b8aa6116"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:06094d18dd5e6f2bbf93efa54991c3240964bb663b87729ac340eb5014310624"},
+    {file = "pydantic-1.10.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cc78cc83110d2f275ec1970e7a831f4e371ee92405332ebfe9860a715f8336e1"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1ee433e274268a4b0c8fde7ad9d58ecba12b069a033ecc4645bb6303c062d2e9"},
+    {file = "pydantic-1.10.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:7c2abc4393dea97a4ccbb4ec7d8658d4e22c4765b7b9b9445588f16c71ad9965"},
+    {file = "pydantic-1.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:0b959f4d8211fc964772b595ebb25f7652da3f22322c007b6fed26846a40685e"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c33602f93bfb67779f9c507e4d69451664524389546bacfe1bee13cae6dc7488"},
+    {file = "pydantic-1.10.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5760e164b807a48a8f25f8aa1a6d857e6ce62e7ec83ea5d5c5a802eac81bad41"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6eb843dcc411b6a2237a694f5e1d649fc66c6064d02b204a7e9d194dff81eb4b"},
+    {file = "pydantic-1.10.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4b8795290deaae348c4eba0cebb196e1c6b98bdbe7f50b2d0d9a4a99716342fe"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e0bedafe4bc165ad0a56ac0bd7695df25c50f76961da29c050712596cf092d6d"},
+    {file = "pydantic-1.10.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:2e05aed07fa02231dbf03d0adb1be1d79cabb09025dd45aa094aa8b4e7b9dcda"},
+    {file = "pydantic-1.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1ba1afb396148bbc70e9eaa8c06c1716fdddabaf86e7027c5988bae2a829ab6"},
+    {file = "pydantic-1.10.2-py3-none-any.whl", hash = "sha256:1b6ee725bd6e83ec78b1aa32c5b1fa67a3a65badddde3976bca5fe4568f27709"},
+    {file = "pydantic-1.10.2.tar.gz", hash = "sha256:91b8e218852ef6007c2b98cd861601c6a09f1aa32bbbb74fab5b1c33d4a1e410"},
 ]
 pyflakes = [
     {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
@@ -1551,6 +1568,10 @@ pyyaml-include = [
 questionary = [
     {file = "questionary-1.10.0-py3-none-any.whl", hash = "sha256:fecfcc8cca110fda9d561cb83f1e97ecbb93c613ff857f655818839dac74ce90"},
     {file = "questionary-1.10.0.tar.gz", hash = "sha256:600d3aefecce26d48d97eee936fdb66e4bc27f934c3ab6dd1e292c4f43946d90"},
+]
+setuptools = [
+    {file = "setuptools-65.3.0-py3-none-any.whl", hash = "sha256:2e24e0bec025f035a2e72cdd1961119f557d78ad331bb00ff82efb2ab8da8e82"},
+    {file = "setuptools-65.3.0.tar.gz", hash = "sha256:7732871f4f7fa58fb6bdcaeadb0161b2bd046c85905dbaa066bdcbcc81953b57"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -191,7 +191,7 @@ def test_flags_bad_data(data):
 def test_flags_extra_fails():
     key = "i_am_not_a_member"
     conf_data = {"src_path": "..", "dst_path": ".", key: "and_i_do_not_belong_here"}
-    with pytest.raises(TypeError):
+    with pytest.raises(ValidationError):
         copier.Worker(**conf_data)
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -206,7 +206,7 @@ def is_subdict(small, big):
 
 def test_worker_good_data(tmp_path):
     # This test is probably useless, as it tests the what and not the how
-    conf = copier.Worker("./tests/demo_data", tmp_path)
+    conf = copier.Worker(src_path="./tests/demo_data", dst_path=tmp_path)
     assert conf._render_context()["_folder_name"] == tmp_path.name
     assert conf.all_exclusions == ("exclude1", "exclude2")
     assert conf.template.skip_if_exists == ["skip_if_exists1", "skip_if_exists2"]
@@ -234,7 +234,7 @@ def test_worker_config_precedence(tmp_path, test_input, expected_exclusions):
 
 
 def test_config_data_transclusion():
-    config = copier.Worker("tests/demo_transclude/demo")
+    config = copier.Worker(src_path="tests/demo_transclude/demo")
     assert config.all_exclusions == ("exclude1", "exclude2")
 
 

--- a/tests/test_interrupts.py
+++ b/tests/test_interrupts.py
@@ -38,7 +38,7 @@ def test_keyboard_interrupt(tmp_path_factory, questions, side_effect, raises):
             src / "copier.yml": yaml.safe_dump(questions),
         }
     )
-    worker = Worker(str(src), dst, defaults=False)
+    worker = Worker(src_path=str(src), dst_path=dst, defaults=False)
 
     with patch("copier.main.unsafe_prompt", side_effect=side_effect):
         with pytest.raises(raises):
@@ -75,7 +75,7 @@ def test_multiple_questions_interrupt(
             src / "copier.yml": yaml.safe_dump(questions),
         }
     )
-    worker = Worker(str(src), dst, defaults=False)
+    worker = Worker(src_path=str(src), dst_path=dst, defaults=False)
 
     with patch("copier.main.unsafe_prompt", side_effect=side_effects):
         with pytest.raises(CopierAnswersInterrupt) as err:

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -200,12 +200,16 @@ def test_templated_prompt_custom_envops(tmp_path_factory):
             src / "result.jinja": "<<sentence>>",
         }
     )
-    worker1 = Worker(str(src), dst, defaults=True, overwrite=True)
+    worker1 = Worker(src_path=str(src), dst_path=dst, defaults=True, overwrite=True)
     worker1.run_copy()
     assert (dst / "result").read_text() == "It's over 9000!"
 
     worker2 = Worker(
-        str(src), dst, data={"powerlevel": 1}, defaults=True, overwrite=True
+        src_path=str(src),
+        dst_path=dst,
+        data={"powerlevel": 1},
+        defaults=True,
+        overwrite=True,
     )
     worker2.run_copy()
     assert (dst / "result").read_text() == "It's only 1..."
@@ -228,7 +232,7 @@ def test_templated_prompt_builtins(tmp_path_factory):
             src / "make_secret.tmpl": "[[ question2 ]]",
         }
     )
-    Worker(str(src), dst, defaults=True, overwrite=True).run_copy()
+    Worker(src_path=str(src), dst_path=dst, defaults=True, overwrite=True).run_copy()
     that_now = datetime.fromisoformat((dst / "now").read_text())
     assert that_now <= datetime.utcnow()
     assert len((dst / "make_secret").read_text()) == 128
@@ -251,7 +255,7 @@ def test_templated_prompt_invalid(tmp_path_factory, questions, raises, returns):
             src / "result.jinja": "{{question}}",
         }
     )
-    worker = Worker(str(src), dst, defaults=True, overwrite=True)
+    worker = Worker(src_path=str(src), dst_path=dst, defaults=True, overwrite=True)
     if raises:
         with pytest.raises(raises):
             worker.run_copy()


### PR DESCRIPTION
**NOTE:** All tests are passing locally, except for this one (`tests/test_normal_jinja2.py::test_jinja_defaults_v6_min_version - copier.errors.UnknownCopierVersionWarning: Cannot check Copier version constraint.
`), which I think is because I installed `copier` in editable mode.

This is a fix for the dependabot pydantic 1.10.2 issue surfaced in PR #785. I branched from the dependabot branch in order to see the overall GitHub CI results, but if tests pass, I can create a new PR with _just_ my changes.

The main change I made was to modify `Worker` class to use `pydantic.BaseModel` rather than `pydantic.dataclass`. Rationale:
  * The failing test in the dependabot PR occurred because `pydantic.dataclass` was not raising a `TypeError` when extra fields were passed to the constructor.
  * I attempted to forbid extra fields as described [here](https://stackoverflow.com/questions/71837398/pydantic-validations-for-extra-fields-that-not-defined-in-schema), but I was seeing behavior similar to that described [here](https://github.com/pydantic/pydantic/issues/986), where this does not work correctly for `pydantic.dataclass`.
