### PR TITLE
Flexible conflict resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: copier
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -132,12 +132,11 @@ class CopierApp(cli.Application):
     )
     conflict: cli.SwitchAttr = cli.SwitchAttr(
         ["-o", "--conflict"],
-        cli.Set("rej", "inline2", "inline3"),
+        cli.Set("rej", "inline"),
         default="rej",
         help=(
-            "Behavior on conflict: rej=Create .rej file, inline2=2-way merge "
-            "with inline conflict markers, inline3=3-way merge "
-            "with inline conflict markers"
+            "Behavior on conflict: rej=Create .rej file, inline=inline conflict"
+            "markers"
         ),
     )
     exclude: cli.SwitchAttr = cli.SwitchAttr(

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -135,7 +135,7 @@ class CopierApp(cli.Application):
         cli.Set("rej", "inline"),
         default="rej",
         help=(
-            "Behavior on conflict: rej=Create .rej file, inline=inline conflict"
+            "Behavior on conflict: rej=Create .rej file, inline=inline conflict "
             "markers"
         ),
     )

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -130,6 +130,14 @@ class CopierApp(cli.Application):
             "to find the answers file"
         ),
     )
+    conflict: cli.SwitchAttr = cli.SwitchAttr(
+        ["-o", "--conflict"],
+        str,
+        help=(
+            "Behavior on conflict: rej=Create .rej file , inline2=2-way merge "
+            "with inline conflict markers"
+        ),
+    )
     exclude: cli.SwitchAttr = cli.SwitchAttr(
         ["-x", "--exclude"],
         str,
@@ -216,6 +224,7 @@ class CopierApp(cli.Application):
             src_path=src_path,
             vcs_ref=self.vcs_ref,
             use_prereleases=self.prereleases,
+            conflict=self.conflict,
             **kwargs,
         )
 

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -132,9 +132,11 @@ class CopierApp(cli.Application):
     )
     conflict: cli.SwitchAttr = cli.SwitchAttr(
         ["-o", "--conflict"],
-        str,
+        cli.Set("rej", "inline2", "inline3"),
+        default="rej",
         help=(
-            "Behavior on conflict: rej=Create .rej file , inline2=2-way merge "
+            "Behavior on conflict: rej=Create .rej file, inline2=2-way merge "
+            "with inline conflict markers, inline3=3-way merge "
             "with inline conflict markers"
         ),
     )

--- a/copier/main.py
+++ b/copier/main.py
@@ -620,9 +620,14 @@ class Worker:
         return self.template.local_abspath / subdir
 
     def conflict_method(self, method_name: str):
+        """Returns function related to conflict processing.
+
+        This could be replaced by inheritance. Implemented this way temporarily
+        to minimize code changes and likelihood of merge conflicts.
+        """
         class_: Optional[Type] = None
         if self.conflict == "inline":
-            class_ = Merge2Way
+            class_ = InlineConflict
         if class_ is not None:
             return getattr(class_, method_name, None)
         else:
@@ -806,7 +811,9 @@ class Worker:
         )
 
 
-class Merge2Way:
+class InlineConflict:
+    """Overrides "rej" conflict behavior to use inline conflict markers."""
+
     @classmethod
     def _solve_render_conflict(cls, worker: Worker, dst_relpath: Path):
         """Properly solve render conflicts."""

--- a/copier/main.py
+++ b/copier/main.py
@@ -153,7 +153,7 @@ class Worker:
             See [quiet][].
 
         conflict:
-            One of "rej", "inline"
+            One of "rej" (default), "inline" (still experimental).
     """
 
     src_path: Optional[str] = None

--- a/copier/main.py
+++ b/copier/main.py
@@ -152,6 +152,9 @@ class Worker:
             When `True`, disable all output.
 
             See [quiet][].
+
+        conflict:
+            One of "rej", "inline2", "inline3"
     """
 
     src_path: Optional[str] = None
@@ -168,7 +171,7 @@ class Worker:
     overwrite: bool = False
     pretend: bool = False
     quiet: bool = False
-    conflict: Optional[str] = None
+    conflict: str = "rej"
 
     def __enter__(self):
         return self

--- a/copier/main.py
+++ b/copier/main.py
@@ -313,7 +313,6 @@ class Worker:
                 Used to compare existing file contents with them. Allows to know if
                 rendering is needed.
         """
-        # Default implementation
         assert not dst_relpath.is_absolute()
         assert not expected_contents or not is_dir, "Dirs cannot have expected content"
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)

--- a/copier/main.py
+++ b/copier/main.py
@@ -5,6 +5,7 @@ import os
 import platform
 import subprocess
 import sys
+import tempfile
 from contextlib import suppress
 from dataclasses import asdict, field, replace
 from filecmp import dircmp
@@ -12,7 +13,7 @@ from functools import partial
 from itertools import chain
 from pathlib import Path
 from shutil import copyfile, rmtree
-from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Set
+from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Set, Type
 from unicodedata import normalize
 
 from jinja2.loaders import FileSystemLoader
@@ -310,10 +311,13 @@ class Worker:
                 Used to compare existing file contents with them. Allows to know if
                 rendering is needed.
         """
-        if self.conflict == "inline2":
-            return Merge2Way._render_allowed(
+        conflict_method = self.conflict_method("_render_allowed")
+        if conflict_method:
+            return conflict_method(
                 self, dst_relpath, is_dir, expected_contents, expected_permissions
             )
+
+        # Default implementation
         assert not dst_relpath.is_absolute()
         assert not expected_contents or not is_dir, "Dirs cannot have expected content"
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
@@ -613,6 +617,17 @@ class Worker:
         subdir = self._render_string(self.template.subdirectory) or ""
         return self.template.local_abspath / subdir
 
+    def conflict_method(self, method_name: str):
+        class_: Optional[Type] = None
+        if self.conflict == "inline2":
+            class_ = Merge2Way
+        elif self.conflict == "inline3":
+            class_ = Merge3Way
+        if class_ is not None:
+            return getattr(class_, method_name)
+        else:
+            return None
+
     # Main operations
     def run_auto(self) -> None:
         """Copy or update automatically.
@@ -701,10 +716,12 @@ class Worker:
         self.apply_update()
 
     def apply_update(self):
-        if self.conflict == "inline2":
-            Merge2Way.apply_update(self)
+        conflict_method = self.conflict_method("apply_update")
+        if conflict_method:
+            conflict_method(self)
             return
 
+        # Default implementation.
         # Copy old template into a temporary destination
         with TemporaryDirectory(
             prefix=f"{__name__}.update_diff."
@@ -968,6 +985,92 @@ class Merge2Way:
         worker._execute_tasks(
             worker.template.migration_tasks("after", worker.subproject.template)
         )
+
+
+class Merge3Way:
+    @classmethod
+    def apply_update(cls, worker: Worker):
+        # Copy old template into a temporary destination
+        with tempfile.TemporaryDirectory(
+            prefix=f"{__name__}.update_diff.old."
+        ) as old_temp, tempfile.TemporaryDirectory(
+            prefix=f"{__name__}.update_diff.new."
+        ) as new_temp:
+            assert worker.subproject
+            assert worker.subproject.template
+            old_worker = replace(
+                worker,
+                dst_path=old_temp,
+                data=worker.subproject.last_answers,
+                force=True,
+                quiet=True,
+                skip=False,
+                src_path=worker.subproject.template.url,
+                vcs_ref=worker.subproject.template.commit,
+            )
+            old_worker.run_copy()
+
+            # Run pre-migration tasks
+            worker._execute_tasks(
+                worker.template.migration_tasks("before", worker.subproject.template)
+            )
+            # Clear last answers cache to load possible answers migration
+            with suppress(AttributeError):
+                del worker.answers
+            with suppress(AttributeError):
+                del worker.subproject.last_answers
+            # Do a normal update in final destination
+            worker.run_copy()
+            cls.merge(
+                modified_dir=worker.dst_path,
+                old_upstream_dir=old_temp,
+                new_upstream_dir=new_temp,
+            )
+
+        # Run post-migration tasks
+        worker._execute_tasks(
+            worker.template.migration_tasks("after", worker.subproject.template)
+        )
+
+    @classmethod
+    def merge(cls, modified_dir, old_upstream_dir, new_upstream_dir):
+        participating_files = set()
+        for src_dir in old_upstream_dir, new_upstream_dir:
+            for root, _, files in os.walk(src_dir):
+                root = Path(root).relative_to(src_dir)
+                participating_files.update(Path(root, f) for f in files)
+
+        with tempfile.TemporaryDirectory(
+            prefix=f"{__name__}.update_diff.merge."
+        ) as tmp_dir:
+            for basename in sorted(participating_files):
+                subfile_names = []
+                for subfile_kind, src_dir in [
+                    ("modified", modified_dir),
+                    ("old upstream", old_upstream_dir),
+                    ("new upstream", new_upstream_dir),
+                ]:
+                    path = Path(src_dir, basename)
+                    if path.is_file():
+                        copyfile(path, Path(tmp_dir, subfile_kind))
+                    else:
+                        subfile_kind = os.devnull
+                    subfile_names.append(subfile_kind)
+
+                # TODO: Modify to use git["merge-file", ...] notation
+                output = subprocess.run(
+                    ["git", "merge-file", "--diff3", "-p", *subfile_names],
+                    stdout=subprocess.PIPE,
+                    cwd=tmp_dir,
+                ).stdout
+
+                dest_path = Path(modified_dir, basename)
+                if not output and "new upstream" not in subfile_names:
+                    with contextlib.suppress(FileNotFoundError):
+                        dest_path.unlink()
+                else:
+                    dest_path.parent.mkdir(parents=True, exist_ok=True)
+                    dest_path.write_bytes(output)
 
 
 def run_copy(

--- a/copier/main.py
+++ b/copier/main.py
@@ -1,5 +1,7 @@
 """Main functions and classes, used to generate or update projects."""
 
+import contextlib
+import os
 import platform
 import subprocess
 import sys
@@ -9,8 +11,8 @@ from filecmp import dircmp
 from functools import partial
 from itertools import chain
 from pathlib import Path
-from shutil import rmtree
-from typing import Callable, Iterable, List, Mapping, Optional, Sequence
+from shutil import copyfile, rmtree
+from typing import Callable, Iterable, List, Mapping, Optional, Sequence, Set
 from unicodedata import normalize
 
 from jinja2.loaders import FileSystemLoader
@@ -44,6 +46,19 @@ if sys.version_info >= (3, 8):
     from functools import cached_property
 else:
     from backports.cached_property import cached_property
+
+# Backport of `shutil.copytree` for python 3.7 to accept `dirs_exist_ok` argument
+if sys.version_info >= (3, 8):
+    from shutil import copytree
+else:
+    from distutils.dir_util import copy_tree
+
+    def copytree(src: Path, dst: Path, dirs_exist_ok: bool = False):
+        """Backport of `shutil.copytree` with `dirs_exist_ok` argument.
+
+        Can be remove once python 3.7 dropped.
+        """
+        copy_tree(str(src), str(dst))
 
 
 @dataclass(config=ConfigDict(extra=Extra.forbid))
@@ -152,6 +167,7 @@ class Worker:
     overwrite: bool = False
     pretend: bool = False
     quiet: bool = False
+    conflict: Optional[str] = None
 
     def __enter__(self):
         return self
@@ -294,6 +310,10 @@ class Worker:
                 Used to compare existing file contents with them. Allows to know if
                 rendering is needed.
         """
+        if self.conflict == "inline2":
+            return Merge2Way._render_allowed(
+                self, dst_relpath, is_dir, expected_contents, expected_permissions
+            )
         assert not dst_relpath.is_absolute()
         assert not expected_contents or not is_dir, "Dirs cannot have expected content"
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
@@ -678,6 +698,13 @@ class Worker:
             print(
                 f"Updating to template version {self.template.version}", file=sys.stderr
             )
+        self.apply_update()
+
+    def apply_update(self):
+        if self.conflict == "inline2":
+            Merge2Way.apply_update(self)
+            return
+
         # Copy old template into a temporary destination
         with TemporaryDirectory(
             prefix=f"{__name__}.update_diff."
@@ -759,6 +786,185 @@ class Worker:
         # Run post-migration tasks
         self._execute_tasks(
             self.template.migration_tasks("after", self.subproject.template)
+        )
+
+
+class Merge2Way:
+    @classmethod
+    def _solve_render_conflict(cls, worker: Worker, dst_relpath: Path):
+        """Properly solve render conflicts."""
+        assert not dst_relpath.is_absolute()
+        printf(
+            "conflict",
+            dst_relpath,
+            style=Style.DANGER,
+            quiet=worker.quiet,
+            file_=sys.stderr,
+        )
+        if worker.match_skip(dst_relpath):
+            printf(
+                "skip",
+                dst_relpath,
+                style=Style.OK,
+                quiet=worker.quiet,
+                file_=sys.stderr,
+            )
+            return False
+
+        return True
+
+    @classmethod
+    def _render_allowed(
+        cls,
+        worker: Worker,
+        dst_relpath: Path,
+        is_dir: bool = False,
+        expected_contents: bytes = b"",
+        expected_permissions=None,
+    ) -> bool:
+        """Determine if a file or directory can be rendered.
+
+        Args:
+
+            dst_relpath:
+                Relative path to destination.
+            is_dir:
+                Indicate if the path must be treated as a directory or not.
+            expected_contents:
+                Used to compare existing file contents with them. Allows to know if
+                rendering is needed.
+        """
+        assert not dst_relpath.is_absolute()
+        assert not expected_contents or not is_dir, "Dirs cannot have expected content"
+        dst_abspath = Path(worker.subproject.local_abspath, dst_relpath)
+        if dst_relpath != Path(".") and worker.match_exclude(dst_relpath):
+            return False
+        try:
+            previous_content = dst_abspath.read_bytes()
+        except FileNotFoundError:
+            printf(
+                "create",
+                dst_relpath,
+                style=Style.OK,
+                quiet=worker.quiet,
+                file_=sys.stderr,
+            )
+            return True
+        except (IsADirectoryError, PermissionError) as error:
+            # HACK https://bugs.python.org/issue43095
+            if isinstance(error, PermissionError) and not (
+                error.errno == 13 and platform.system() == "Windows"
+            ):
+                raise
+            if is_dir:
+                printf(
+                    "identical",
+                    dst_relpath,
+                    style=Style.IGNORE,
+                    quiet=worker.quiet,
+                    file_=sys.stderr,
+                )
+                return True
+            return cls._solve_render_conflict(dst_relpath)
+        else:
+            if previous_content == expected_contents:
+                printf(
+                    "identical",
+                    dst_relpath,
+                    style=Style.IGNORE,
+                    quiet=worker.quiet,
+                    file_=sys.stderr,
+                )
+                return True
+            return worker._solve_render_conflict(dst_relpath)
+
+    @classmethod
+    def apply_update(cls, worker: Worker):
+        # Copy old template into a temporary destination
+        with TemporaryDirectory(
+            prefix=f"{__name__}.update_diff.reference."
+        ) as reference_dst_temp, TemporaryDirectory(
+            prefix=f"{__name__}.update_diff.original."
+        ) as original_dst_temp, TemporaryDirectory(
+            prefix=f"{__name__}.update_diff.merge."
+        ) as merge_dst_temp:
+            # Copy reference to be used as base by merge-file
+            copytree(worker.dst_path, reference_dst_temp, dirs_exist_ok=True)
+
+            # Compute modification from the original template to be used as other by merge-file
+            original_worker = replace(
+                worker,
+                dst_path=original_dst_temp,
+                data=worker.subproject.last_answers,
+                defaults=True,
+                quiet=True,
+                src_path=worker.subproject.template.url,
+                vcs_ref=worker.subproject.template.commit,
+            )
+            original_worker.run_copy()
+            # Apply pre-commit hooks if provided by .git
+            with local.cwd(original_dst_temp):
+                git("init", retcode=None)
+                git("add", ".")
+                git("config", "user.name", "Copier")
+                git("config", "user.email", "copier@copier")
+                # 1st commit could fail if any pre-commit hook reformats code
+                git("commit", "--allow-empty", "-am", "dumb commit 1", retcode=None)
+                git("commit", "--allow-empty", "-am", "dumb commit 2")
+                git("config", "--unset", "user.name")
+                git("config", "--unset", "user.email")
+
+            # Run pre-migration tasks
+            worker._execute_tasks(
+                worker.template.migration_tasks("before", worker.subproject.template)
+            )
+            # Clear last answers cache to load possible answers migration
+            with suppress(AttributeError):
+                del worker.answers
+            with suppress(AttributeError):
+                del worker.subproject.last_answers
+            # Do a normal update in final destination
+            worker.run_copy()
+
+            # Extract the list of files to merge
+            participating_files: Set[Path] = set()
+            for src_dir in (original_dst_temp, reference_dst_temp):
+                for root, dirs, files in os.walk(src_dir, topdown=True):
+                    if root == src_dir and ".git" in dirs:
+                        dirs.remove(".git")
+                    root = Path(root).relative_to(src_dir)
+                    participating_files.update(Path(root, f) for f in files)
+
+            # Merging files
+            for basename in sorted(participating_files):
+                subfile_names = []
+                for subfile_kind, src_dir in [
+                    ("modified", reference_dst_temp),
+                    ("old upstream", original_dst_temp),
+                    ("new upstream", worker.dst_path),
+                ]:
+                    path = Path(src_dir, basename)
+                    if path.is_file():
+                        copyfile(path, Path(merge_dst_temp, subfile_kind))
+                    else:
+                        subfile_kind = os.devnull
+                    subfile_names.append(subfile_kind)
+
+                with local.cwd(merge_dst_temp):
+                    output = git("merge-file", "-p", *subfile_names, retcode=None)
+
+                dest_path = Path(worker.dst_path, basename)
+                # Remove the file if it was already removed in the project
+                if not output and "modified" not in subfile_names:
+                    with contextlib.suppress(FileNotFoundError):
+                        dest_path.unlink()
+                else:
+                    dest_path.parent.mkdir(parents=True, exist_ok=True)
+                    dest_path.write_text(output)
+
+        # Run post-migration tasks
+        worker._execute_tasks(
+            worker.template.migration_tasks("after", worker.subproject.template)
         )
 
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -726,15 +726,8 @@ class Worker:
         ) as old_copy, TemporaryDirectory(
             prefix=f"{__name__}.recopy_diff."
         ) as new_copy:
-            old_worker = replace(
-                self,
-                dst_path=old_copy,
-                data=self.subproject.last_answers,
-                defaults=True,
-                quiet=True,
-                src_path=self.subproject.template.url,
-                vcs_ref=self.subproject.template.commit,
-            )
+            old_worker = self._make_old_worker(old_copy)
+            old_worker.run_copy()
             recopy_worker = replace(
                 self,
                 dst_path=new_copy,
@@ -743,7 +736,6 @@ class Worker:
                 quiet=True,
                 src_path=self.subproject.template.url,
             )
-            old_worker.run_copy()
             recopy_worker.run_copy()
             compared = dircmp(old_copy, new_copy)
             # Extract diff between temporary destination and real destination
@@ -754,15 +746,7 @@ class Worker:
                     "rev-parse",
                     "--show-toplevel",
                 ).strip()
-                git("init", retcode=None)
-                git("add", ".")
-                git("config", "user.name", "Copier")
-                git("config", "user.email", "copier@copier")
-                # 1st commit could fail if any pre-commit hook reformats code
-                git("commit", "--allow-empty", "-am", "dumb commit 1", retcode=None)
-                git("commit", "--allow-empty", "-am", "dumb commit 2")
-                git("config", "--unset", "user.name")
-                git("config", "--unset", "user.email")
+                self._git_initialize_repo()
                 git("remote", "add", "real_dst", "file://" + subproject_top)
                 git("fetch", "--depth=1", "real_dst", "HEAD")
                 diff_cmd = git["diff-tree", "--unified=1", "HEAD...FETCH_HEAD"]
@@ -779,13 +763,7 @@ class Worker:
             self._execute_tasks(
                 self.template.migration_tasks("before", self.subproject.template)
             )
-            # Clear last answers cache to load possible answers migration
-            with suppress(AttributeError):
-                del self.answers
-            with suppress(AttributeError):
-                del self.subproject.last_answers
-            # Do a normal update in final destination
-            self.run_copy()
+            self._do_copy()
             # Try to apply cached diff into final destination
             with local.cwd(self.subproject.local_abspath):
                 apply_cmd = git["apply", "--reject", "--exclude", self.answers_relpath]
@@ -802,6 +780,38 @@ class Worker:
         self._execute_tasks(
             self.template.migration_tasks("after", self.subproject.template)
         )
+
+    def _do_copy(self):
+        # Clear last answers cache to load possible answers migration
+        with suppress(AttributeError):
+            del self.answers
+        with suppress(AttributeError):
+            del self.subproject.last_answers
+        # Do a normal update in final destination
+        self.run_copy()
+
+    def _make_old_worker(self, old_copy):
+        old_worker = replace(
+            self,
+            dst_path=old_copy,
+            data=self.subproject.last_answers,
+            defaults=True,
+            quiet=True,
+            src_path=self.subproject.template.url,
+            vcs_ref=self.subproject.template.commit,
+        )
+        return old_worker
+
+    def _git_initialize_repo(self):
+        git("init", retcode=None)
+        git("add", ".")
+        git("config", "user.name", "Copier")
+        git("config", "user.email", "copier@copier")
+        # 1st commit could fail if any pre-commit hook reformats code
+        git("commit", "--allow-empty", "-am", "dumb commit 1", retcode=None)
+        git("commit", "--allow-empty", "-am", "dumb commit 2")
+        git("config", "--unset", "user.name")
+        git("config", "--unset", "user.email")
 
 
 class InlineConflict:
@@ -837,7 +847,7 @@ class InlineConflict:
             prefix=f"{__name__}.update_diff.reference."
         ) as reference_dst_temp, TemporaryDirectory(
             prefix=f"{__name__}.update_diff.original."
-        ) as original_dst_temp, TemporaryDirectory(
+        ) as old_copy, TemporaryDirectory(
             prefix=f"{__name__}.update_diff.merge."
         ) as merge_dst_temp:
             # Copy reference to be used as base by merge-file
@@ -846,43 +856,20 @@ class InlineConflict:
             # Compute modification from the original template to be used as other by merge-file
             assert worker.subproject
             assert worker.subproject.template
-            original_worker = replace(
-                worker,
-                dst_path=original_dst_temp,
-                data=worker.subproject.last_answers,
-                defaults=True,
-                quiet=True,
-                src_path=worker.subproject.template.url,
-                vcs_ref=worker.subproject.template.commit,
-            )
-            original_worker.run_copy()
-            # Apply pre-commit hooks if provided by .git
-            with local.cwd(original_dst_temp):
-                git("init", retcode=None)
-                git("add", ".")
-                git("config", "user.name", "Copier")
-                git("config", "user.email", "copier@copier")
-                # 1st commit could fail if any pre-commit hook reformats code
-                git("commit", "--allow-empty", "-am", "dumb commit 1", retcode=None)
-                git("commit", "--allow-empty", "-am", "dumb commit 2")
-                git("config", "--unset", "user.name")
-                git("config", "--unset", "user.email")
+            old_worker = worker._make_old_worker(old_copy)
+            old_worker.run_copy()
+            with local.cwd(old_copy):
+                worker._git_initialize_repo()
 
             # Run pre-migration tasks
             worker._execute_tasks(
                 worker.template.migration_tasks("before", worker.subproject.template)
             )
-            # Clear last answers cache to load possible answers migration
-            with suppress(AttributeError):
-                del worker.answers
-            with suppress(AttributeError):
-                del worker.subproject.last_answers
-            # Do a normal update in final destination
-            worker.run_copy()
+            worker._do_copy()
 
             # Extract the list of files to merge
             participating_files: Set[Path] = set()
-            for src_dir in (original_dst_temp, reference_dst_temp):
+            for src_dir in (old_copy, reference_dst_temp):
                 for root, dirs, files in os.walk(src_dir, topdown=True):
                     if root == src_dir and ".git" in dirs:
                         dirs.remove(".git")
@@ -894,7 +881,7 @@ class InlineConflict:
                 subfile_names = []
                 for subfile_kind, src_dir in [
                     ("modified", reference_dst_temp),
-                    ("old upstream", original_dst_temp),
+                    ("old upstream", old_copy),
                     ("new upstream", worker.dst_path),
                 ]:
                     path = Path(src_dir, basename)

--- a/copier/main.py
+++ b/copier/main.py
@@ -313,12 +313,6 @@ class Worker:
                 Used to compare existing file contents with them. Allows to know if
                 rendering is needed.
         """
-        conflict_method = self.conflict_method("_render_allowed")
-        if conflict_method:
-            return conflict_method(
-                self, dst_relpath, is_dir, expected_contents, expected_permissions
-            )
-
         # Default implementation
         assert not dst_relpath.is_absolute()
         assert not expected_contents or not is_dir, "Dirs cannot have expected content"
@@ -836,71 +830,6 @@ class InlineConflict:
             return False
 
         return True
-
-    @classmethod
-    def _render_allowed(
-        cls,
-        worker: Worker,
-        dst_relpath: Path,
-        is_dir: bool = False,
-        expected_contents: bytes = b"",
-        expected_permissions=None,
-    ) -> bool:
-        """Determine if a file or directory can be rendered.
-
-        Args:
-
-            dst_relpath:
-                Relative path to destination.
-            is_dir:
-                Indicate if the path must be treated as a directory or not.
-            expected_contents:
-                Used to compare existing file contents with them. Allows to know if
-                rendering is needed.
-        """
-        assert not dst_relpath.is_absolute()
-        assert not expected_contents or not is_dir, "Dirs cannot have expected content"
-        dst_abspath = Path(worker.subproject.local_abspath, dst_relpath)
-        if dst_relpath != Path(".") and worker.match_exclude(dst_relpath):
-            return False
-        try:
-            previous_content = dst_abspath.read_bytes()
-        except FileNotFoundError:
-            printf(
-                "create",
-                dst_relpath,
-                style=Style.OK,
-                quiet=worker.quiet,
-                file_=sys.stderr,
-            )
-            return True
-        except (IsADirectoryError, PermissionError) as error:
-            # HACK https://bugs.python.org/issue43095
-            if isinstance(error, PermissionError) and not (
-                error.errno == 13 and platform.system() == "Windows"
-            ):
-                raise
-            if is_dir:
-                printf(
-                    "identical",
-                    dst_relpath,
-                    style=Style.IGNORE,
-                    quiet=worker.quiet,
-                    file_=sys.stderr,
-                )
-                return True
-            return cls._solve_render_conflict(worker, dst_relpath)
-        else:
-            if previous_content == expected_contents:
-                printf(
-                    "identical",
-                    dst_relpath,
-                    style=Style.IGNORE,
-                    quiet=worker.quiet,
-                    file_=sys.stderr,
-                )
-                return True
-            return worker._solve_render_conflict(dst_relpath)
 
     @classmethod
     def apply_update(cls, worker: Worker):

--- a/copier/main.py
+++ b/copier/main.py
@@ -865,7 +865,7 @@ class Merge2Way:
                     file_=sys.stderr,
                 )
                 return True
-            return cls._solve_render_conflict(dst_relpath)
+            return cls._solve_render_conflict(worker, dst_relpath)
         else:
             if previous_content == expected_contents:
                 printf(
@@ -892,6 +892,8 @@ class Merge2Way:
             copytree(worker.dst_path, reference_dst_temp, dirs_exist_ok=True)
 
             # Compute modification from the original template to be used as other by merge-file
+            assert worker.subproject
+            assert worker.subproject.template
             original_worker = replace(
                 worker,
                 dst_path=original_dst_temp,

--- a/copier/main.py
+++ b/copier/main.py
@@ -819,6 +819,7 @@ class Worker:
                     subfile_names.append(subfile_kind)
 
                 with local.cwd(merge_dst_temp):
+                    # https://git-scm.com/docs/git-merge-file
                     output = git("merge-file", "-p", *subfile_names, retcode=None)
 
                 dest_path = Path(self.dst_path, basename)

--- a/copier/main.py
+++ b/copier/main.py
@@ -818,29 +818,6 @@ class InlineConflict:
     """Overrides "rej" conflict behavior to use inline conflict markers."""
 
     @classmethod
-    def _solve_render_conflict(cls, worker: Worker, dst_relpath: Path):
-        """Properly solve render conflicts."""
-        assert not dst_relpath.is_absolute()
-        printf(
-            "conflict",
-            dst_relpath,
-            style=Style.DANGER,
-            quiet=worker.quiet,
-            file_=sys.stderr,
-        )
-        if worker.match_skip(dst_relpath):
-            printf(
-                "skip",
-                dst_relpath,
-                style=Style.OK,
-                quiet=worker.quiet,
-                file_=sys.stderr,
-            )
-            return False
-
-        return True
-
-    @classmethod
     def apply_update(cls, worker: Worker):
         # Copy old template into a temporary destination
         with TemporaryDirectory(

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -502,6 +502,21 @@ running `copier update`, this setting has no effect.
 
     Not supported in `copier.yml`.
 
+### `conflict`
+
+-   Format: `Literal["rej", "inline"]`
+-   CLI flags: `-o`, `--conflict`
+-   Default value: `rej`
+
+When updating a project, sometimes Copier doesn't know what to do with a diff code hunk.
+This option controls the output format if this happens. The default, `rej`, creates
+`*.rej` files that contain the unresolved diffs. The `inline` option includes the diff
+code hunk in the file itself, similar to the behavior of `git merge`.
+
+!!! info
+
+    Not supported in `copier.yml`.
+
 ### `data`
 
 -   Format: `dict|List[str=str]`

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1060,7 +1060,7 @@ the `v2.0.0a1` tag unless this flag is enabled.
 ### `vcs_ref`
 
 -   Format: `str`
--   CLI flags: `-r`, `-vcs-ref`
+-   CLI flags: `-r`, `--vcs-ref`
 -   Default value: N/A (use latest release)
 
 When copying or updating from a Git-versioned template, indicate which template version

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -25,11 +25,11 @@ answers you provided when copied last time. However, sometimes it's impossible f
 Copier to know what to do with a diff code hunk. In those cases, copier handles the
 conflict one of two ways, controlled with the `--conflict` option:
 
--   `--conflict rej` (default): Creates a separate `.rej` file for each file with conflicts. These
-    files contain the unresolved diffs.
--   `--conflict inline`: Updates the file with conflict markers. This is quite similar
-    to the conflict markers created when a `git merge` command encounters a conflict.
-    For more information, see the "Checking Out Conflicts" section of the
+-   `--conflict rej` (default): Creates a separate `.rej` file for each file with
+    conflicts. These files contain the unresolved diffs.
+-   `--conflict inline` (experimental): Updates the file with conflict markers. This is
+    quite similar to the conflict markers created when a `git merge` command encounters
+    a conflict. For more information, see the "Checking Out Conflicts" section of the
     [`git` documentation](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging).
 
 If the update results in conflicts, _you should review those manually_ before
@@ -43,7 +43,7 @@ That's why the recommended way to prevent these mistakes is to add a
 conflict files or markers. The recommended hook configuration depends on the `conflict`
 setting you use.
 
-## Preventing Commit of `.rej` Files
+## Preventing Commit of Merge Conflicts
 
 If you use `--conflict rej` (the default):
 
@@ -51,22 +51,16 @@ If you use `--conflict rej` (the default):
 repos:
     - repo: local
       hooks:
+          # Prevent committing .rej files
           - id: forbidden-files
             name: forbidden files
             entry: found Copier update rejection files; review them and remove them
             language: fail
             files: "\\.rej$"
-```
-
-## Preventing Commit of Files with Inline Conflicts
-
-If you use `--conflict inline`:
-
-```yaml title=".pre-commit-config.yaml"
-repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.3.0
       hooks:
+          # Prevent committing inline conflict markers
           - id: check-merge-conflict
             args: [--assume-in-merge]
 ```

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -25,7 +25,7 @@ answers you provided when copied last time. However, sometimes it's impossible f
 Copier to know what to do with a diff code hunk. In those cases, copier handles the
 conflict one of two ways, controlled with the `--conflict` option:
 
--   `--conflict rej`: Creates a separate `.rej` file for each file with conflicts. These
+-   `--conflict rej` (default): Creates a separate `.rej` file for each file with conflicts. These
     files contain the unresolved diffs.
 -   `--conflict inline`: Updates the file with conflict markers. This is quite similar
     to the conflict markers created when a `git merge` command encounters a conflict.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -22,15 +22,30 @@ other Git ref you want.
 
 When updating, Copier will do its best to respect your project evolution by using the
 answers you provided when copied last time. However, sometimes it's impossible for
-Copier to know what to do with a diff code hunk. In those cases, you will find `*.rej`
-files that contain the unresolved diffs. _You should review those manually_ before
+Copier to know what to do with a diff code hunk. In those cases, copier handles the
+conflict one of two ways, controlled with the `--conflict` option:
+
+-   `--conflict rej`: Creates a separate `.rej` file for each file with conflicts. These
+    files contain the unresolved diffs.
+-   `--conflict inline`: Updates the file with conflict markers. This is quite similar
+    to the conflict markers created when a `git merge` command encounters a conflict.
+    For more information, see the "Checking Out Conflicts" section of the
+    [`git` documentation](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging).
+
+If the update results in conflicts, _you should review those manually_ before
 committing.
 
-You probably don't want `*.rej` files in your Git history, but if you add them to
-`.gitignore`, some important changes could pass unnoticed to you. That's why the
-recommended way to deal with them is to _not_ add them to add a
-[pre-commit](https://pre-commit.com/) (or equivalent) hook that forbids them, just like
-this:
+You probably don't want to lose important changes or to include merge conflicts in your
+Git history, but if you aren't careful, it's easy to make mistakes.
+
+That's why the recommended way to prevent these mistakes is to add a
+[pre-commit](https://pre-commit.com/) (or equivalent) hook that forbids committing
+conflict files or markers. The recommended hook configuration depends on the `conflict`
+setting you use.
+
+## Preventing Commit of `.rej` Files
+
+If you use `--conflict rej` (the default):
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
@@ -41,6 +56,19 @@ repos:
             entry: found Copier update rejection files; review them and remove them
             language: fail
             files: "\\.rej$"
+```
+
+## Preventing Commit of Files with Inline Conflicts
+
+If you use `--conflict inline`:
+
+```yaml title=".pre-commit-config.yaml"
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.3.0
+      hooks:
+          - id: check-merge-conflict
+            args: [--assume-in-merge]
 ```
 
 ## Never change the answers file manually

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import pytest
 import yaml
@@ -160,16 +159,7 @@ def _normalize_line_endings(text):
 @pytest.mark.parametrize(
     "conflict, readme, expect_reject",
     [
-        pytest.param(
-            "rej",
-            "upstream version 2\n",
-            True,
-            marks=pytest.mark.xfail(
-                condition=platform.system() == "Windows",
-                reason="Windows line-ending issue with README.md",
-                strict=True,
-            ),
-        ),
+        ("rej", "upstream version 2\n", True),
         (
             "inline",
             "<<<<<<< modified\ndownstream version 1\n"
@@ -245,6 +235,14 @@ def test_new_version_uses_subdirectory(
     assert (project_path / "README.md").exists()
 
     # On Windows, skip checking the inline conflicts due to line ending issues.
+    if conflict == "rej" or os.name != "nt":
+        with (project_path / "README.md").open() as fd:
+            file_content = fd.read()
+            print(repr(file_content))
+            assert (
+                _normalize_line_endings(file_content).splitlines()
+                == _normalize_line_endings(readme).splitlines()
+            )
     reject_path = project_path / "README.md.rej"
     assert reject_path.exists() == expect_reject
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -234,7 +234,12 @@ def test_new_version_uses_subdirectory(
     # correctly.
     assert (project_path / "README.md").exists()
     with (project_path / "README.md").open() as fd:
-        assert _normalize_line_endings(fd.read()) == _normalize_line_endings(readme)
+        file_content = fd.read()
+        print(repr(file_content))
+        assert (
+            _normalize_line_endings(file_content).splitlines()
+            == _normalize_line_endings(readme).splitlines()
+        )
     reject_path = project_path / "README.md.rej"
     assert reject_path.exists() == expect_reject
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -233,13 +233,16 @@ def test_new_version_uses_subdirectory(
     # Assert that the README still exists, and the conflicts were handled
     # correctly.
     assert (project_path / "README.md").exists()
-    with (project_path / "README.md").open() as fd:
-        file_content = fd.read()
-        print(repr(file_content))
-        assert (
-            _normalize_line_endings(file_content).splitlines()
-            == _normalize_line_endings(readme).splitlines()
-        )
+
+    # On Windows, skip checking the inline conflicts due to line ending issues.
+    if conflict == "rej" or os.name != "nt":
+        with (project_path / "README.md").open() as fd:
+            file_content = fd.read()
+            print(repr(file_content))
+            assert (
+                _normalize_line_endings(file_content).splitlines()
+                == _normalize_line_endings(readme).splitlines()
+            )
     reject_path = project_path / "README.md.rej"
     assert reject_path.exists() == expect_reject
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -243,7 +243,13 @@ def test_new_version_uses_subdirectory(
     # correctly.
     assert (project_path / "README.md").exists()
 
-    # On Windows, skip checking the inline conflicts due to line ending issues.
+    with (project_path / "README.md").open() as fd:
+        file_content = fd.read()
+        print(repr(file_content))
+        assert (
+            _normalize_line_endings(file_content).splitlines()
+            == _normalize_line_endings(readme).splitlines()
+        )
     reject_path = project_path / "README.md.rej"
     assert reject_path.exists() == expect_reject
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -170,8 +170,8 @@ def _normalize_line_endings(text):
             "<<<<<<< modified\ndownstream version 1\n"
             "=======\nupstream version 2\n>>>>>>> new upstream\n",
             False,
-            marks=pytest.mark.skipif(
-                platform.system() == "Windows",
+            marks=pytest.mark.xfail(
+                condition=platform.system() == "Windows",
                 reason="Windows line-ending issue with README.md"
             ),
         ),

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -158,7 +158,7 @@ def test_update_subdirectory_from_root_path(tmp_path_factory):
         ("rej", "upstream version 2\n", True),
         (
             "inline",
-            f"<<<<<<< modified\ndownstream version 1{os.linesep}"
+            "<<<<<<< modified\ndownstream version 1\n"
             "=======\nupstream version 2\n>>>>>>> new upstream\n",
             False,
         ),
@@ -229,8 +229,8 @@ def test_new_version_uses_subdirectory(
     # Assert that the README still exists, and the conflicts were handled
     # correctly.
     assert (project_path / "README.md").exists()
-    with (project_path / "README.md").open() as fd:
-        assert fd.read() == readme
+    # Verify file contents match readme, ignoring line endings.
+    assert (project_path / "README.md").read_text().splitlines() == readme.splitlines()
     reject_path = project_path / "README.md.rej"
     assert reject_path.exists() == expect_reject
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -158,7 +158,7 @@ def test_update_subdirectory_from_root_path(tmp_path_factory):
         ("rej", "upstream version 2\n", True),
         (
             "inline",
-            "<<<<<<< modified\ndownstream version 1\n"
+            f"<<<<<<< modified\ndownstream version 1{os.linesep}"
             "=======\nupstream version 2\n>>>>>>> new upstream\n",
             False,
         ),

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -152,6 +152,10 @@ def test_update_subdirectory_from_root_path(tmp_path_factory):
     assert (dst / "subfolder" / "file1").read_text() == "version 2\nhello\na1\nbye\n"
 
 
+def _normalize_line_endings(text):
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
 @pytest.mark.parametrize(
     "conflict, readme, expect_reject",
     [
@@ -229,8 +233,8 @@ def test_new_version_uses_subdirectory(
     # Assert that the README still exists, and the conflicts were handled
     # correctly.
     assert (project_path / "README.md").exists()
-    # Verify file contents match readme, ignoring line endings.
-    assert (project_path / "README.md").read_text().splitlines() == readme.splitlines()
+    with (project_path / "README.md").open() as fd:
+        assert _normalize_line_endings(fd.read()) == _normalize_line_endings(readme)
     reject_path = project_path / "README.md.rej"
     assert reject_path.exists() == expect_reject
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -170,10 +170,9 @@ def _normalize_line_endings(text):
             "<<<<<<< modified\ndownstream version 1\n"
             "=======\nupstream version 2\n>>>>>>> new upstream\n",
             False,
-            marks=pytest.mark.xfail(
-                condition=platform.system() == "Windows",
-                reason="Windows line-ending issue with README.md",
-                strict=True,
+            marks=pytest.mark.skipif(
+                platform.system() == "Windows",
+                reason="Windows line-ending issue with README.md"
             ),
         ),
     ],

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -164,17 +164,17 @@ def _normalize_line_endings(text):
             "rej",
             "upstream version 2\n",
             True,
+        ),
+        pytest.param(
+            "inline",
+            "<<<<<<< modified\ndownstream version 1\n"
+            "=======\nupstream version 2\n>>>>>>> new upstream\n",
+            False,
             marks=pytest.mark.xfail(
                 condition=platform.system() == "Windows",
                 reason="Windows line-ending issue with README.md",
                 strict=True,
             ),
-        ),
-        (
-            "inline",
-            "<<<<<<< modified\ndownstream version 1\n"
-            "=======\nupstream version 2\n>>>>>>> new upstream\n",
-            False,
         ),
     ],
 )

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -243,7 +243,9 @@ def test_new_version_uses_subdirectory(
 
     with (project_path / "README.md").open("rb") as fd:
         file_content = fd.read()
-        assert [s.decode("utf-8") for s in file_content.splitlines()] == readme.splitlines()
+        assert [
+            s.decode("utf-8") for s in file_content.splitlines()
+        ] == readme.splitlines()
     reject_path = project_path / "README.md.rej"
     assert reject_path.exists() == expect_reject
 

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -153,17 +153,20 @@ def test_update_subdirectory_from_root_path(tmp_path_factory):
 
 
 @pytest.mark.parametrize(
-    "conflict, readme",
+    "conflict, readme, expect_reject",
     [
-        ("rej", "upstream version 2\n"),
+        ("rej", "upstream version 2\n", True),
         (
             "inline",
             "<<<<<<< modified\ndownstream version 1\n"
             "=======\nupstream version 2\n>>>>>>> new upstream\n",
+            False,
         ),
     ],
 )
-def test_new_version_uses_subdirectory(conflict, tmp_path_factory, readme):
+def test_new_version_uses_subdirectory(
+    conflict, tmp_path_factory, readme, expect_reject
+):
     # Template in v1 doesn't have a _subdirectory;
     # in v2 it moves all things into a subdir and adds that key to copier.yml.
     # Some files change. Downstream project has evolved too. Does that work as expected?
@@ -228,6 +231,8 @@ def test_new_version_uses_subdirectory(conflict, tmp_path_factory, readme):
     assert (project_path / "README.md").exists()
     with (project_path / "README.md").open() as fd:
         assert fd.read() == readme
+    reject_path = project_path / "README.md.rej"
+    assert reject_path.exists() == expect_reject
 
     # Also assert the subdirectory itself was not rendered
     assert not (project_path / "subdir").exists()

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -366,7 +366,7 @@ def test_commit_hooks_respected(tmp_path_factory):
         git("commit", "-m", "commit 2")
         git("tag", "v2")
     # Update subproject to v2
-    copy(dst_path=dst1, defaults=True, overwrite=True)
+    copy(dst_path=dst1, defaults=True, overwrite=True, conflict="rej")
     with local.cwd(dst1):
         git("commit", "-am", "copied v2")
         assert life.read_text() == dedent(
@@ -401,7 +401,7 @@ def test_commit_hooks_respected(tmp_path_factory):
     git("clone", "--depth=1", f"file://{dst1}", dst2)
     with local.cwd(dst2):
         # Subproject re-updates just to change some values
-        copy(data={"what": "study"}, defaults=True, overwrite=True)
+        copy(data={"what": "study"}, defaults=True, overwrite=True, conflict="rej")
         git("commit", "-am", "re-updated to change values after evolving")
         # Subproject evolution was respected up to sane possibilities.
         # In an ideal world, this file would be exactly the same as what's written
@@ -592,7 +592,7 @@ def test_file_removed(src_repo, tmp_path):
         git("tag", "2")
     # Subproject updates
     with local.cwd(tmp_path):
-        run_update()
+        run_update(conflict="rej")
     # Check what must still exist
     assert tmp_path.joinpath(".copier-answers.yml").is_file()
     assert tmp_path.joinpath("I.txt").is_file()


### PR DESCRIPTION
Fixes #613 

Based on #627, but:
- Supports both old (`.rej` files) and new (inline markers) conflict behavior
- Organizes the code to reduce likelihood of merge conflicts (while this PR is in development/review)