### PR TITLE
docs: unify YAML code block indentation

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -773,13 +773,13 @@ Migration processes will receive these environment variables:
 
     ```yaml title="copier.yml"
     _migrations:
-      - version: v1.0.0
-        before:
-          - rm ./old-folder
-        after:
-          # {{ _copier_conf.src_path }} points to the path where the template was
-          # cloned, so it can be helpful to run migration scripts stored there.
-          - invoke -r {{ _copier_conf.src_path }} -c migrations migrate $VERSION_CURRENT
+        - version: v1.0.0
+          before:
+              - rm ./old-folder
+          after:
+              # {{ _copier_conf.src_path }} points to the path where the template was
+              # cloned, so it can be helpful to run migration scripts stored there.
+              - invoke -r {{ _copier_conf.src_path }} -c migrations migrate $VERSION_CURRENT
     ```
 
 ### `min_copier_version`
@@ -846,7 +846,7 @@ exist.
 
     ```yaml title="copier.yml"
     _skip_if_exists:
-      - .secret_password.yml
+        - .secret_password.yml
     ```
 
     ```yaml title=".secret_password.yml.jinja"


### PR DESCRIPTION
I've unified the indentation of YAML code blocks in the docs to 4 spaces per indentation level.

I think most projects use 4 spaces for Python code and 2 spaces for most other languages like YAML. However, Prettier currently cannot be configured accordingly because it doesn't support [config overrides by langauge](https://github.com/prettier/prettier/issues/5378) but only by file (pattern). Markdown indentation was changed to 4 spaces in #249 for good reasons, but as a result also e.g. YAML code blocks are formatted with 4 spaces indentation. I believe the reason why the two occurrences of 2 spaces indentation, that I'm changing to 4 spaces in this PR, weren't caught by Prettier is a result of the non-standard Markdown syntax used for [admonitions](https://python-markdown.github.io/extensions/admonition/) that isn't recognized as such by Prettier (or rather by the [underlying Markdown parser](https://github.com/prettier/prettier/blob/b0d9387b95cdd4e9d50f5999d3be53b0b5d03a97/src/language-markdown/parser-markdown.js#L32-L44)) but instead, as far as I can tell, as [indented code blocks](https://spec.commonmark.org/0.30/#indented-code-blocks), so that a fenced code block inside an admonition is treated as a code block inside a code block, which Prettier won't touch.

This PR also fixes a "regression" introduced in #800.