### PR TITLE
fix(typing): remove invalid migration task stage "task"

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -321,7 +321,7 @@ class Template:
         return result
 
     def migration_tasks(
-        self, stage: Literal["task", "before", "after"], from_template: "Template"
+        self, stage: Literal["before", "after"], from_template: "Template"
     ) -> Sequence[Task]:
         """Get migration objects that match current version spec.
 


### PR DESCRIPTION
I've fixed a typing error related to the possible stage names of migration tasks. In `template.py`, the method `Template.migration_tasks(...)` declared the `stage` argument to accept three string literals: `Literal["task", "before", "after"]`. The string literal `"task"` is not a valid task stage though. Hence, I've removed it.