### PR TITLE
refactor: model a task to execute using a dataclass

### DIFF
--- a/copier/types.py
+++ b/copier/types.py
@@ -55,6 +55,7 @@ JSONSerializable = (dict, list, str, int, float, bool, type(None))
 Filters = Dict[str, Callable]
 LoaderPaths = Union[str, Iterable[str]]
 VCSTypes = Literal["git"]
+Env = Dict[str, str]
 
 
 class AllowArbitraryTypes:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,7 +8,7 @@ from pydantic import ValidationError
 
 import copier
 from copier.errors import InvalidConfigFileError, MultipleConfigFilesError
-from copier.template import DEFAULT_EXCLUDE, Template, load_template_config
+from copier.template import DEFAULT_EXCLUDE, Task, Template, load_template_config
 
 from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
 
@@ -37,7 +37,10 @@ def test_config_data_is_loaded_from_file():
     tpl = Template("tests/demo_data")
     assert tpl.exclude == ("exclude1", "exclude2")
     assert tpl.skip_if_exists == ["skip_if_exists1", "skip_if_exists2"]
-    assert tpl.tasks == ["touch 1", "touch 2"]
+    assert tpl.tasks == [
+        Task(cmd="touch 1", extra_env={"STAGE": "task"}),
+        Task(cmd="touch 2", extra_env={"STAGE": "task"}),
+    ]
 
 
 @pytest.mark.parametrize("config_suffix", ["yaml", "yml"])
@@ -210,7 +213,10 @@ def test_worker_good_data(tmp_path):
     assert conf._render_context()["_folder_name"] == tmp_path.name
     assert conf.all_exclusions == ("exclude1", "exclude2")
     assert conf.template.skip_if_exists == ["skip_if_exists1", "skip_if_exists2"]
-    assert conf.template.tasks == ["touch 1", "touch 2"]
+    assert conf.template.tasks == [
+        Task(cmd="touch 1", extra_env={"STAGE": "task"}),
+        Task(cmd="touch 2", extra_env={"STAGE": "task"}),
+    ]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I've introduced a Data Class `Task` to model a task to execute (used internally for [tasks](https://copier.readthedocs.io/en/v6.2.0/configuring/#tasks) and [migrations](https://copier.readthedocs.io/en/v6.2.0/configuring/#migrations)).

Before, a task was represented by a dict which is less descriptive and less type-safe. Also, there was some inconsistency between tasks and migrations in terms of where additional environment variables are specified that shall be set while executing a task command. Specifically, migrations had their additional environment variables set in the `Template.migration_tasks` property while tasks had their additional environment variables set in the `Worker.run_copy(...)` method.

The slightly less pretty way of [setting the `use_shell` flag in each branch of the if-else condition](https://github.com/copier-org/copier/pull/812/files#diff-51a5fc56dc37de31d15f74ed1458469179fe72a8b697cbbc83b2a8e8e508f90bL179-R184) in the `Worker._execute_tasks(...)` method cannot be avoided without introducing a type cast

```diff
-task_cmd = self._render_string(task_cmd)
+task_cmd = self._render_string(cast(str, task_cmd))
```

because it seems Mypy doesn't support control flow analysis of aliased conditions unlike, e.g., [TypeScript v4.4+](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-4.html#control-flow-analysis-of-aliased-conditions-and-discriminants).