### PR TITLE
docs: require Poetry v1.2+

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ Feel free to discuss with our community through
 We use some tools as part of our development workflow which you'll need to install into
 your host environment:
 
--   [Poetry](https://python-poetry.org/) for packaging and dependency management
+-   [Poetry](https://python-poetry.org/) v1.2+ for packaging and dependency management
 
 Or you can use
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/copier-org/copier)


### PR DESCRIPTION
I've documented in the contributing guide that Poetry v1.2+ is required now.

Poetry v1.1 has some interoperability issues with lock files generated by Poetry v1.2 (https://github.com/python-poetry/poetry/issues/6593). Since [@dependabot uses Poetry v1.2](
https://github.com/dependabot/dependabot-core/blob/04741be8510dd4258a3892312b82136eedf8c1ce/python/helpers/requirements.txt#L7) now, I'm afraid we need to follow to avoid issues. Note that it may be necessary to purge the PyPI cache after updating to Poetry v1.2:

```shell
poetry cache clear --all PyPI
```