### PR TITLE
refactor: reduce module imports

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -13,9 +13,9 @@ from shutil import rmtree
 from typing import Callable, Iterable, List, Mapping, Optional, Sequence
 from unicodedata import normalize
 
-import pathspec
 from jinja2.loaders import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
+from pathspec import PathSpec
 from plumbum import ProcessExecutionError, colors
 from plumbum.cli.terminal import ask
 from plumbum.cmd import git
@@ -218,7 +218,7 @@ class Worker:
         """Produce a function that matches against specified patterns."""
         # TODO Is normalization really needed?
         normalized_patterns = (normalize("NFD", pattern) for pattern in patterns)
-        spec = pathspec.PathSpec.from_lines("gitwildmatch", normalized_patterns)
+        spec = PathSpec.from_lines("gitwildmatch", normalized_patterns)
         return spec.match_file
 
     def _solve_render_conflict(self, dst_relpath: Path):

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -1,10 +1,10 @@
 """Functions used to load user data."""
-import datetime
 import json
 import sys
 import warnings
 from collections import ChainMap
 from dataclasses import field
+from datetime import datetime
 from hashlib import sha512
 from os import urandom
 from pathlib import Path
@@ -51,7 +51,7 @@ def _now():
         "strftime format reference https://strftime.org/",
         FutureWarning,
     )
-    return datetime.datetime.utcnow()
+    return datetime.utcnow()
 
 
 def _make_secret():

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -2,9 +2,9 @@
 import os
 import re
 import sys
-import tempfile
 from contextlib import suppress
 from pathlib import Path
+from tempfile import mkdtemp
 from warnings import warn
 
 from packaging import version
@@ -130,7 +130,7 @@ def clone(url: str, ref: OptStr = None) -> str:
             Reference to checkout. For Git repos, defaults to `HEAD`.
     """
 
-    location = tempfile.mkdtemp(prefix=f"{__name__}.clone.")
+    location = mkdtemp(prefix=f"{__name__}.clone.")
     _clone = git["clone", "--no-checkout", url, location]
     # Faster clones if possible
     if GIT_VERSION >= Version("2.27"):


### PR DESCRIPTION
Just a minor refactoring that reduces module imports (e.g. `import pathspec`) by preferring imports of specific names from modules (e.g. `from pathspec import PathSpec`).