### PR TITLE
build: use poetry-dynamic-versioning wrapper for build backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,4 +130,4 @@ version = "6.2.0"
 
 [build-system]
 requires = ["poetry_core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry.core.masonry.api"
+build-backend = "poetry_dynamic_versioning.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,4 +130,4 @@ version = "6.2.0"
 
 [build-system]
 requires = ["poetry_core>=1.0.0", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.api"
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
I've updated the `build-backend` config in `pyproject.toml` according to the [`poetry-dynamic-versioning` installation instructions](https://github.com/mtkennerly/poetry-dynamic-versioning#installation).