### PR TITLE
docs: add `_secret_questions` setting

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -834,7 +834,7 @@ Suppress status output.
 
 -   Format: `List[str]`
 -   CLI flags: N/A
--   Default value: N/A
+-   Default value: `[]`
 
 Question variables to mark as secret questions. This is especially useful when questions
 are provided in the [simplified prompt format](#questions). It's equivalent to

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -830,6 +830,26 @@ Suppress status output.
 
     Not supported in `copier.yml`.
 
+### `secret_questions`
+
+-   Format: `List[str]`
+-   CLI flags: N/A
+-   Default value: N/A
+
+Question variables to mark as secret questions. This is especially useful when questions
+are provided in the [simplified prompt format](#questions). It's equivalent to
+configuring `secret: true` in the [advanced prompt format](#advanced-prompt-formatting).
+
+!!! example
+
+    ```yaml title="copier.yml"
+    _secret_questions:
+        - password
+
+    user: johndoe
+    password: s3cr3t
+    ```
+
 ### `skip_if_exists`
 
 -   Format: `List[str]`


### PR DESCRIPTION
I've added documentation for the `_secret_questions` setting.

Closes #809.