### PR TITLE
chore: organize deps with Poetry v1.2 groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install poetry poetry-dynamic-versioning
-          poetry install -E docs -v
+          poetry install --with docs -v
       - name: Run pytest
         run: poetry run poe test --cov=./ --cov-report=xml -ra .
       - name: Upload coverage to Codecov

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,10 +3,12 @@
 version: 2
 mkdocs:
   configuration: mkdocs.yml
-python:
-  version: 3.8
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+  jobs:
+    post_install:
+      - pip install poetry
+      - poetry config virtualenvs.create false
+      - poetry install --only docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,7 +75,7 @@ Ready to contribute? Here's how to set up the project for local development.
     poetry config virtualenvs.in-project true --local
 
     # Create a virtualenv with all dependencies from pyproject.toml
-    poetry install -E docs
+    poetry install --with docs
 
     # Install development helper tools
     poetry run pre-commit install -t pre-commit -t commit-msg

--- a/devtasks.py
+++ b/devtasks.py
@@ -36,7 +36,7 @@ def dev_setup():
     """Setup a development environment."""
     # Gitpod sets PIP_USER=yes, which breaks poetry
     env = dict(os.environ, PIP_USER="no")
-    check_call(["poetry", "install", "--extras", "docs"], env=env)
+    check_call(["poetry", "install", "--with", "docs"], env=env)
     check_call(
         [
             "poetry",

--- a/poetry.lock
+++ b/poetry.lock
@@ -81,8 +81,8 @@ uvloop = ["uvloop (>=0.15.2)"]
 name = "cached-property"
 version = "1.5.2"
 description = "A decorator for caching properties in classes."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -108,7 +108,7 @@ unicode_backport = ["unicodedata2"]
 name = "click"
 version = "8.1.3"
 description = "Composable command line interface toolkit"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7"
 
@@ -280,8 +280,8 @@ importlib-metadata = {version = ">=0.9", markers = "python_version < \"3.8\""}
 name = "ghp-import"
 version = "2.1.0"
 description = "Copy your docs directly to the gh-pages branch."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "*"
 
 [package.dependencies]
@@ -294,8 +294,8 @@ dev = ["flake8", "markdown", "twine", "wheel"]
 name = "griffe"
 version = "0.22.1"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -399,8 +399,8 @@ test = ["pytest", "pytest-cov"]
 name = "markdown"
 version = "3.3.5"
 description = "Python implementation of Markdown."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [package.extras]
@@ -426,16 +426,16 @@ python-versions = ">=3.6"
 name = "mergedeep"
 version = "1.3.4"
 description = "A deep merge function for 🐍."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "mkdocs"
 version = "1.2.4"
 description = "Project documentation with Markdown."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -457,8 +457,8 @@ i18n = ["babel (>=2.9.0)"]
 name = "mkdocs-autorefs"
 version = "0.4.1"
 description = "Automatically link across pages in MkDocs."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -469,8 +469,8 @@ mkdocs = ">=1.1"
 name = "mkdocs-material"
 version = "8.2.6"
 description = "A Material Design theme for MkDocs"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -485,16 +485,16 @@ pymdown-extensions = ">=9.0"
 name = "mkdocs-material-extensions"
 version = "1.0.3"
 description = "Extension pack for Python Markdown."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "mkdocstrings"
 version = "0.19.0"
 description = "Automatic documentation from sources, for MkDocs."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -515,8 +515,8 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 name = "mkdocstrings-python"
 version = "0.7.1"
 description = "A Python handler for mkdocstrings."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -747,8 +747,8 @@ plugins = ["importlib-metadata"]
 name = "pymdown-extensions"
 version = "9.5"
 description = "Extension pack for Python Markdown."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -835,8 +835,8 @@ testing = ["filelock"]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 
 [package.dependencies]
@@ -862,8 +862,8 @@ python-versions = ">=3.6"
 name = "pyyaml-env-tag"
 version = "0.1"
 description = "A custom YAML tag for referencing environment variables in YAML files. "
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -915,8 +915,8 @@ testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (
 name = "six"
 version = "1.16.0"
 description = "Python 2 and 3 compatibility utilities"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -1005,8 +1005,8 @@ testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", 
 name = "watchdog"
 version = "2.1.9"
 description = "Filesystem events monitoring"
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=3.6"
 
 [package.extras]
@@ -1032,13 +1032,10 @@ python-versions = ">=3.7"
 docs = ["jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx"]
 testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
-[extras]
-docs = ["mkdocs-material", "mkdocstrings"]
-
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7,<4.0"
-content-hash = "25fa60d0d30c77c5ce0f0a86f6df5bf8e60e8788808586a1b53e32b0c7ff2403"
+python-versions = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
+content-hash = "6606af59c7a66fb0b5cbecf139bc16c4d6499d28bf1384c5e042d1f41c0c8bc6"
 
 [metadata.files]
 argcomplete = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1035,7 +1035,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
-content-hash = "6606af59c7a66fb0b5cbecf139bc16c4d6499d28bf1384c5e042d1f41c0c8bc6"
+content-hash = "a51cdc39bb23f3b814173ab17dd0de495294ca230d0044b19c7a37a28504c6d6"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,6 @@ pyyaml-include = ">=1.2"
 questionary = ">=1.8.1"
 typing-extensions = { version = ">=3.7.4,<5.0.0", python = "<3.8" }
 
-[tool.poetry.group.core.dependencies]
-poethepoet = ">=0.12.3"
-
 [tool.poetry.group.dev.dependencies]
 autoflake = ">=1.4"
 black = ">=22.1"
@@ -58,15 +55,14 @@ flake8-debugger = ">=4.0.0"
 flake8-simplify = ">=0.19.3"
 isort = ">=5.10.1"
 mypy = ">=0.931"
-pre-commit = ">=2.17.0"
-types-backports = ">=0.1.3"
-types-pyyaml = ">=6.0.4"
-
-[tool.poetry.group.test.dependencies]
 pexpect = ">=4.8.0"
+poethepoet = ">=0.12.3"
+pre-commit = ">=2.17.0"
 pytest = ">=7.0.1"
 pytest-cov = ">=3.0.0"
 pytest-xdist = ">=2.5.0"
+types-backports = ">=0.1.3"
+types-pyyaml = ">=6.0.4"
 
 [tool.poetry.group.docs]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,6 @@ importlib-metadata = { version = ">=3.4,<5.0", python = "<3.8" }
 iteration_utilities = ">=0.11.0"
 jinja2 = ">=3.1.1"
 jinja2-ansible-filters = ">=1.3.1"
-mkdocs-material = { version = ">=8.2,<9.0.0", optional = true }
-mkdocstrings = {extras = ["python"], version = ">=0.19.0", optional = true}
 packaging = ">=21.0" # packaging is needed when installing from PyPI
 pathspec = ">=0.9.0"
 plumbum = ">=1.6.9"
@@ -46,13 +44,10 @@ pyyaml-include = ">=1.2"
 questionary = ">=1.8.1"
 typing-extensions = { version = ">=3.7.4,<5.0.0", python = "<3.8" }
 
-[tool.poetry.extras]
-docs = [
-    "mkdocs-material",
-    "mkdocstrings",
-]
+[tool.poetry.group.core.dependencies]
+poethepoet = ">=0.12.3"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 autoflake = ">=1.4"
 black = ">=22.1"
 commitizen = ">=2.32.2"
@@ -63,14 +58,22 @@ flake8-debugger = ">=4.0.0"
 flake8-simplify = ">=0.19.3"
 isort = ">=5.10.1"
 mypy = ">=0.931"
-pexpect = ">=4.8.0"
-poethepoet = ">=0.12.3"
 pre-commit = ">=2.17.0"
+types-backports = ">=0.1.3"
+types-pyyaml = ">=6.0.4"
+
+[tool.poetry.group.test.dependencies]
+pexpect = ">=4.8.0"
 pytest = ">=7.0.1"
 pytest-cov = ">=3.0.0"
 pytest-xdist = ">=2.5.0"
-types-backports = ">=0.1.3"
-types-pyyaml = ">=6.0.4"
+
+[tool.poetry.group.docs]
+optional = true
+
+[tool.poetry.group.docs.dependencies]
+mkdocs-material = ">=8.2,<9.0.0"
+mkdocstrings = { version = ">=0.19.0", extras = ["python"] }
 
 [tool.poe.tasks.clean]
 script = "devtasks:clean"


### PR DESCRIPTION
I've organized dependencies using the new [dependency groups](https://python-poetry.org/docs/managing-dependencies#dependency-groups) feature [released with Poetry v1.2](https://python-poetry.org/blog/announcing-poetry-1.2.0/#dependency-groups). Since [Poetry v1.2 is required now](#816) anyway, I think it's nice to leverage this feature.

Thanks to dependency groups, dependencies can be defined in a more granular fashion and groups can be optional, so that it isn't necessary to always install all of them. Here's what you can do:

```shell
# Install for code dev
poetry install

# Install for code dev + docs
poetry install --with docs

# Install for docs only
poetry install --only docs

# Install for runtime only
poetry install --only main
```

Also, docs dependencies aren't exposed as a runtime extra anymore, which was just a workaround for the missing optional dev dependencies feature.

WDYT?