### PR TITLE
docs: beautify badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 [![codecov](https://codecov.io/gh/copier-org/copier/branch/master/graph/badge.svg)](https://codecov.io/gh/copier-org/copier)
 [![CI](https://github.com/copier-org/copier/workflows/CI/badge.svg)](https://github.com/copier-org/copier/actions?query=branch%3Amaster)
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
-![](https://img.shields.io/pypi/pyversions/copier)
-[![](https://img.shields.io/pypi/v/copier)](https://pypi.org/project/copier/)
+![Python](https://img.shields.io/pypi/pyversions/copier?logo=python&logoColor=%23959DA5)
+[![PyPI](https://img.shields.io/pypi/v/copier?logo=pypi&logoColor=%23959DA5)](https://pypi.org/project/copier/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
-[![Documentation Status](https://readthedocs.org/projects/copier/badge/?version=latest)](https://copier.readthedocs.io/en/latest/?badge=latest)
+[![Documentation Status](https://img.shields.io/readthedocs/copier/latest?logo=readthedocs)](https://copier.readthedocs.io/en/latest)
 
 A library and CLI app for rendering project templates.
 


### PR DESCRIPTION
I've beautified a few badges by adding brand logos. For Python and PyPI, I've adopted the logo color from the CI badge because the original logo color (a shade of blue) doesn't go well with the dark gray background color of the badges. 