### PR TITLE
refactor(typing): use abstract container types where possible

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -58,7 +58,7 @@ from copier.tools import copier_version
 
 from .errors import UserMessageError
 from .main import Worker
-from .types import AnyByStrDict, List, OptStr
+from .types import AnyByStrDict, OptStr, StrSeq
 
 
 def handle_exceptions(method):
@@ -183,7 +183,7 @@ class CopierApp(cli.Application):
         list=True,
         help="Make VARIABLE available as VALUE when rendering the template",
     )
-    def data_switch(self, values: List[str]) -> None:
+    def data_switch(self, values: StrSeq) -> None:
         """Update [data][] with provided values.
 
         Arguments:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -13,9 +13,9 @@ from typing import (
     Any,
     Callable,
     ChainMap as t_ChainMap,
-    Dict,
-    List,
+    Mapping,
     Optional,
+    Sequence,
     Union,
 )
 
@@ -193,7 +193,7 @@ class Question:
     var_name: str
     answers: AnswersMap
     jinja_env: SandboxedEnvironment
-    choices: Union[Dict[Any, Any], List[Any]] = field(default_factory=list)
+    choices: Union[Mapping[Any, Any], Sequence[Any]] = field(default_factory=list)
     default: Any = None
     help: str = ""
     ask_user: bool = False
@@ -266,7 +266,7 @@ class Question:
         return str(default)
 
     @cached_property
-    def _formatted_choices(self) -> List[Choice]:
+    def _formatted_choices(self) -> Sequence[Choice]:
         """Obtain choices rendered and properly formatted."""
         result = []
         choices = self.choices
@@ -448,7 +448,7 @@ def cast_answer_type(answer: Any, type_fn: Callable) -> Any:
         return answer
 
 
-CAST_STR_TO_NATIVE: Dict[str, Callable] = {
+CAST_STR_TO_NATIVE: Mapping[str, Callable] = {
     "bool": cast_str_to_bool,
     "float": float,
     "int": int,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ import textwrap
 from enum import Enum
 from hashlib import sha1
 from pathlib import Path
-from typing import Dict
+from typing import Mapping
 
 from plumbum import local
 from prompt_toolkit.input.ansi_escape_sequences import REVERSE_ANSI_SEQUENCES
@@ -87,7 +87,7 @@ def assert_file(tmp_path, *path):
     assert filecmp.cmp(p1, p2)
 
 
-def build_file_tree(spec: Dict[StrOrPath, str], dedent: bool = True):
+def build_file_tree(spec: Mapping[StrOrPath, str], dedent: bool = True):
     """Builds a file tree based on the received spec."""
     for path, contents in spec.items():
         path = Path(path)


### PR DESCRIPTION
I've replaced a few occurrences of concrete container types (`Dict` and `List`) by abstract container types (`Mapping` and `Sequence`) which is slightly better practice AFAIK. See, e.g.,

* https://blog.logrocket.com/understanding-type-annotation-python/#adding-type-hints-dictionaries
* https://blog.logrocket.com/understanding-type-annotation-python/#adding-type-hints-lists

for an interesting article on this topic.