### PR TITLE
refactor(typing): remove unused types

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -49,6 +49,7 @@ from functools import wraps
 from io import StringIO
 from pathlib import Path
 from textwrap import dedent
+from typing import List
 from unittest.mock import patch
 
 import yaml
@@ -58,7 +59,7 @@ from copier.tools import copier_version
 
 from .errors import UserMessageError
 from .main import Worker
-from .types import AnyByStrDict, List, OptStr
+from .types import AnyByStrDict, OptStr
 
 
 def handle_exceptions(method):

--- a/copier/types.py
+++ b/copier/types.py
@@ -2,19 +2,7 @@
 
 import sys
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Dict, Optional, Sequence, TypeVar, Union
 
 from pydantic.validators import path_validator
 
@@ -31,7 +19,6 @@ if TYPE_CHECKING:
 # simple types
 StrOrPath = Union[str, Path]
 AnyByStrDict = Dict[str, Any]
-AnyByStrDictOrTuple = Union[AnyByStrDict, Tuple[str, Any]]
 
 # sequences
 IntSeq = Sequence[int]
@@ -44,16 +31,10 @@ OptBool = Optional[bool]
 OptStrOrPath = Optional[StrOrPath]
 OptStrOrPathSeq = Optional[StrOrPathSeq]
 OptStr = Optional[str]
-OptStrSeq = Optional[StrSeq]
-OptAnyByStrDict = Optional[AnyByStrDict]
 
 # miscellaneous
-CheckPathFunc = Callable[[StrOrPath], bool]
-Choices = Union[List[Any], Dict[Any, Any]]
 T = TypeVar("T")
 JSONSerializable = (dict, list, str, int, float, bool, type(None))
-Filters = Dict[str, Callable]
-LoaderPaths = Union[str, Iterable[str]]
 VCSTypes = Literal["git"]
 Env = Dict[str, str]
 


### PR DESCRIPTION
I've removed a couple of types that were defined in `types.py` but not used anywhere.