### PR TITLE
chore(mypy): remove redundant `--ignore-missing-imports` flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ cmd = "pytest --color=yes"
 help = "run tests"
 
 [tool.poe.tasks.types]
-cmd = "mypy --ignore-missing-imports ."
+cmd = "mypy ."
 help = "run the type (mypy) checker on the codebase"
 
 [tool.poetry-dynamic-versioning]


### PR DESCRIPTION
I've removed the `--ignore-missing-imports` flag from the `mypy` call because this setting is already configured in `pyproject.toml`:

https://github.com/copier-org/copier/blob/682f917b2f02addee997eb82eb38700c143c9de8/pyproject.toml#L115-L116