### PR TITLE
refactor: use `dict` constructor as default factory

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -152,7 +152,7 @@ class Task:
     """
 
     cmd: Union[str, Sequence[str]]
-    extra_env: Env = field(default_factory=lambda: {})
+    extra_env: Env = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
Just a minor cosmetic change, it's also more consistent with other similar occurrences.

Follow-up of #812.