### PR TITLE
refactor: remove deprecated code scheduled for removal in Copier v7

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -13,7 +13,6 @@ import dunamai
 import packaging.version
 import yaml
 from iteration_utilities import deepflatten
-from packaging.specifiers import SpecifierSet
 from packaging.version import Version, parse
 from plumbum.cmd import git
 from plumbum.machines import local
@@ -52,9 +51,6 @@ DEFAULT_EXCLUDE: Tuple[str, ...] = (
 )
 
 DEFAULT_TEMPLATES_SUFFIX = ".jinja"
-
-# TODO Remove usage of this on Copier v7
-COPIER_JINJA_BREAK = SpecifierSet("<=6.0.0a5", prereleases=True)
 
 
 def filter_config(data: AnyByStrDict) -> Tuple[AnyByStrDict, AnyByStrDict]:
@@ -286,30 +282,6 @@ class Template:
             #       user will most likely expects as a default.
             #       See https://github.com/copier-org/copier/issues/464
             result["keep_trailing_newline"] = True
-
-        # TODO Copier v7+ will not use any of these altered defaults
-        old_defaults = {
-            "autoescape": False,
-            "block_end_string": "%]",
-            "block_start_string": "[%",
-            "comment_end_string": "#]",
-            "comment_start_string": "[#",
-            "keep_trailing_newline": True,
-            "variable_end_string": "]]",
-            "variable_start_string": "[[",
-        }
-        if self.min_copier_version and self.min_copier_version in COPIER_JINJA_BREAK:
-            warned = False
-            for key, value in old_defaults.items():
-                if key not in result:
-                    if not warned:
-                        warn(
-                            "On future releases, Copier will switch to standard Jinja "
-                            "defaults and this template will not work unless updated.",
-                            FutureWarning,
-                        )
-                        warned = True
-                    result[key] = value
         return result
 
     @cached_property
@@ -450,18 +422,6 @@ class Template:
         """
         result = self.config_data.get("templates_suffix")
         if result is None:
-            # TODO Delete support for .tmpl default in Copier 7
-            if (
-                self.min_copier_version
-                and self.min_copier_version in COPIER_JINJA_BREAK
-            ):
-                warn(
-                    "In future Copier releases, the default value for template suffix "
-                    "will change from .tmpl to .jinja, and this template will "
-                    "fail unless updated.",
-                    FutureWarning,
-                )
-                return ".tmpl"
             return DEFAULT_TEMPLATES_SUFFIX
         return result
 

--- a/tests/test_normal_jinja2.py
+++ b/tests/test_normal_jinja2.py
@@ -1,7 +1,5 @@
 import warnings
 
-import pytest
-
 import copier
 
 from .helpers import build_file_tree
@@ -45,43 +43,6 @@ def test_normal_jinja2(tmp_path_factory):
     todo = (dst / "TODO.txt").read_text()
     expected = "[[ Guybrush TODO LIST]]\n[# GROG #]\n    - Become a pirate\n"
     assert todo == expected
-
-
-def test_future_jinja_defaults_warning(tmp_path_factory):
-    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            src
-            / "copier.yml": """\
-                _min_copier_version: "5"
-                q: a
-            """,
-            src / "result.tmpl": "[[ q ]]",
-        }
-    )
-    # Make sure the future warning is raised
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", FutureWarning)
-        with pytest.raises(FutureWarning):
-            copier.run_copy(str(src), dst, defaults=True, overwrite=True)
-    # Run again without capturing warning, to see how it renders properly
-    copier.run_copy(str(src), dst, defaults=True, overwrite=True)
-    assert (dst / "result").read_text() == "a"
-
-
-def test_jinja_defaults_v6_min_version(tmp_path_factory):
-    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            src / "copier.yml": "{_min_copier_version: '6.0.0a5.post1', q: a}",
-            src / "result.jinja": "{{ q }}",
-        }
-    )
-    # Make sure the future warning is not raised
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        copier.run_copy(str(src), dst, defaults=True, overwrite=True)
-    assert (dst / "result").read_text() == "a"
 
 
 def test_to_not_keep_trailing_newlines_in_jinja2(tmp_path_factory):


### PR DESCRIPTION
Since [Copier v7](https://github.com/copier-org/copier/releases/tag/v7.0.0) was released yesterday :tada:, I've removed some occurrences of deprecated code that were scheduled for removal in v7 according to the inline code comments. Trying to reduce technical debt here. :wink: