### PR TITLE
Merge answerfile options

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -341,14 +341,17 @@ cannot use Jinja templating in your answers.
 
 ### Include other YAML files
 
-The `copier.yml` file supports multiple documents. When found, they are merged (**not**
-deeply merged; just merged) and the latest one defined has priority.
+The `copier.yml` file supports multiple documents as well as using the `!include` tag to
+include settings and questions from other yaml files. This allows you to split up a
+larger `copier.yml` and enables you to reuse common partial sections from your
+templates. When multiple documents are used, care has to be taken with question and
+settings that are defined in more than one document:
 
-It also supports using the `!include` tag to include other configurations from
-elsewhere.
-
-These two features, combined, allow you to reuse common partial sections from your
-templates.
+-   a question with the same name overwrites definitions from an earlier document
+-   settings given in multiple documents for `exclude`, `skip_if_exists`,
+    `jinja_extensions` and `secret_questions` are concatenated
+-   other settings (such as `tasks` or `migrations`) overwrite previous defintions for
+    these settings
 
 !!! hint
 
@@ -376,6 +379,19 @@ templates.
     _skip_if_exists:
         - .password.txt
     custom_question: default answer
+    ```
+
+    that includes questions and settings from:
+
+    ```yaml
+    # common-questions/python-project.yml
+    version:
+        type: str
+        help: What is the version of your python project?
+
+    # settings like `_skip_if_exists` are merged
+    _skip_if_exists:
+        - "pyproject.toml"
     ```
 
 ## Conditional files and directories

--- a/tests/demo_merge_options_from_answerfiles/copier.yml
+++ b/tests/demo_merge_options_from_answerfiles/copier.yml
@@ -1,0 +1,10 @@
+_skip_if_exists:
+  - skip_if_exists0
+
+_jinja_extensions:
+  - jinja2.ext.0
+
+---
+!include ./include1.yml
+---
+!include ./include2.yml

--- a/tests/demo_merge_options_from_answerfiles/include1.yml
+++ b/tests/demo_merge_options_from_answerfiles/include1.yml
@@ -1,0 +1,8 @@
+_skip_if_exists:
+  - skip_if_exists1
+
+_secret_questions:
+  - question1
+
+_exclude:
+  - exclude1

--- a/tests/demo_merge_options_from_answerfiles/include2.yml
+++ b/tests/demo_merge_options_from_answerfiles/include2.yml
@@ -1,0 +1,9 @@
+_skip_if_exists:
+  - skip_if_exists2
+
+_jinja_extensions:
+  - jinja2.ext.2
+
+_exclude:
+  - exclude21
+  - exclude22

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -43,6 +43,18 @@ def test_config_data_is_loaded_from_file():
     ]
 
 
+def test_config_data_is_merged_from_files():
+    tpl = Template("tests/demo_merge_options_from_answerfiles")
+    assert list(tpl.skip_if_exists) == [
+        "skip_if_exists0",
+        "skip_if_exists1",
+        "skip_if_exists2",
+    ]
+    assert list(tpl.exclude) == ["exclude1", "exclude21", "exclude22"]
+    assert list(tpl.jinja_extensions) == ["jinja2.ext.0", "jinja2.ext.2"]
+    assert list(tpl.secret_questions) == ["question1"]
+
+
 @pytest.mark.parametrize("config_suffix", ["yaml", "yml"])
 def test_read_data(tmp_path_factory, config_suffix):
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))


### PR DESCRIPTION
Hi there 👋 
This is my first PR here and it adds code, tests and docs for merging copier settings from multiple yaml documents included into `copier.yml`.

# Example

Given the following project layout
```

|-- copier.yml
|-- foo.txt
|-- component
     |-- component.yml
     |-- bar.txt
```

and the files 
```yaml
# copier.yml
...
_skip_if_exists:
  - foo.txt
---
!include ./component/component.yml
```

```yaml
# component.yml
...
_skip_if_exists:
  - component/bar.txt
...
```

the resulting value for `_skip_if_exists` will be the concatenated values from both documents i.e. `["foo.txt", "/component/bar.txt"]` instead the latest document overwriting the previous value i.e. `["/component/bar.txt"]`. 

# Details
This PR only adds logic for merging settings that are not order dependent i.e. `skip_if_exists`, `jinja_extensions`, `secret_questions` and `exclude`. For order dependent settings (such as  `tasks` or `migrations`) it would have to be decided what the order of execution should be. Do tasks from multiple document run in the order the documents are defined or in reverse? In any case this should probably go in another PR and I'd be happy to work on this. 