### PR TITLE
docs: improve section on including other YAML files

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -342,16 +342,16 @@ cannot use Jinja templating in your answers.
 ### Include other YAML files
 
 The `copier.yml` file supports multiple documents as well as using the `!include` tag to
-include settings and questions from other yaml files. This allows you to split up a
+include settings and questions from other YAML files. This allows you to split up a
 larger `copier.yml` and enables you to reuse common partial sections from your
 templates. When multiple documents are used, care has to be taken with question and
 settings that are defined in more than one document:
 
--   a question with the same name overwrites definitions from an earlier document
--   settings given in multiple documents for `exclude`, `skip_if_exists`,
-    `jinja_extensions` and `secret_questions` are concatenated
--   other settings (such as `tasks` or `migrations`) overwrite previous defintions for
-    these settings
+-   A question with the same name overwrites definitions from an earlier document.
+-   Settings given in multiple documents for `exclude`, `skip_if_exists`,
+    `jinja_extensions` and `secret_questions` are concatenated.
+-   Other settings (such as `tasks` or `migrations`) overwrite previous definitions for
+    these settings.
 
 !!! hint
 
@@ -362,7 +362,7 @@ settings that are defined in more than one document:
 
     This would be a valid `copier.yml` file:
 
-    ```yaml
+    ```yaml title="copier.yml"
     ---
     # Copier will load all these files
     !include shared-conf/common.*.yml
@@ -370,12 +370,12 @@ settings that are defined in more than one document:
     # These 3 lines split the several YAML documents
     ---
     # These two documents include common questions for these kind of projects
-    !include common-questions/web_app.yml
+    !include common-questions/web-app.yml
     ---
     !include common-questions/python-project.yml
     ---
 
-    # Here you can specify any settings or questions specific for your template,
+    # Here you can specify any settings or questions specific for your template
     _skip_if_exists:
         - .password.txt
     custom_question: default answer
@@ -383,13 +383,12 @@ settings that are defined in more than one document:
 
     that includes questions and settings from:
 
-    ```yaml
-    # common-questions/python-project.yml
+    ```yaml title="common-questions/python-project.yml"
     version:
         type: str
-        help: What is the version of your python project?
+        help: What is the version of your Python project?
 
-    # settings like `_skip_if_exists` are merged
+    # Settings like `_skip_if_exists` are merged
     _skip_if_exists:
         - "pyproject.toml"
     ```


### PR DESCRIPTION
I've cleaned up the docs a bit in the section on including other YAML files:
* Some typo and spelling fixes
* Use a code block title instead of inline YAML comment about the file path
* Minor cosmetic/consistency improvements

Follow-up of #846 (specifically, 5d1e9c6c0a07ce86ccbe1e55d13e59f56199c947 respectively 12bd54239cff91140040b8ef592d66aabdc17386).