### PR TITLE
Disable git GPG commit signatures on temporary commits

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -716,6 +716,7 @@ class Worker:
                 git("add", ".")
                 git("config", "user.name", "Copier")
                 git("config", "user.email", "copier@copier")
+                git("config", "commit.gpgsign", "False")
                 # 1st commit could fail if any pre-commit hook reformats code
                 git("commit", "--allow-empty", "-am", "dumb commit 1", retcode=None)
                 git("commit", "--allow-empty", "-am", "dumb commit 2")

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -152,6 +152,13 @@ def clone(url: str, ref: OptStr = None) -> str:
                 git(
                     "--git-dir=.git",
                     f"--work-tree={url_abspath}",
+                    "config",
+                    "commit.gpgsign",
+                    "False",
+                )
+                git(
+                    "--git-dir=.git",
+                    f"--work-tree={url_abspath}",
                     "commit",
                     "-m",
                     "Copier automated commit for draft changes",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,7 @@ def src_repo(tmp_path_factory) -> Path:
     """Quick helper to avoid creating template repo constantly."""
     result = tmp_path_factory.mktemp("src_repo")
     git("-C", result, "init")
+    git("-C", result, "config", "commit.gpgsign", "False")
     return result
 
 

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -390,6 +390,7 @@ def test_tui_inherited_default(tmp_path_factory, spawn, has_2_owners, owner2):
     )
     _git = git["-C", src]
     _git("init")
+    _git("config", "commit.gpgsign", "False")
     _git("add", "--all")
     _git("commit", "--message", "init template")
     _git("tag", "1")
@@ -417,6 +418,7 @@ def test_tui_inherited_default(tmp_path_factory, spawn, has_2_owners, owner2):
     assert json.load((dst / "answers.json").open()) == result
     _git = git["-C", dst]
     _git("init")
+    _git("config", "commit.gpgsign", "False")
     _git("add", "--all")
     _git("commit", "--message", "init project")
     # After a forced update, answers stay the same
@@ -537,17 +539,20 @@ def test_multi_template_answers(tmp_path_factory):
     # Make them git-tracked
     for tpl in (tpl1, tpl2):
         git("-C", tpl, "init")
+        git("-C", tpl, "config", "commit.gpgsign", "False")
         git("-C", tpl, "add", "-A")
         git("-C", tpl, "commit", "-m1")
     with local.cwd(dst):
         # Apply template 1
         run_auto(str(tpl1), overwrite=True, defaults=True)
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", "-A")
         git("commit", "-m1")
         # Apply template 2
         run_auto(str(tpl2), overwrite=True, defaults=True)
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", "-A")
         git("commit", "-m2")
         # Check contents

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -29,6 +29,7 @@ def git_init(message="hello world"):
     git("init")
     git("config", "user.name", "Copier Test")
     git("config", "user.email", "test@copier")
+    git("config", "commit.gpgsign", "False")
     git("add", ".")
     git("commit", "-m", message)
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -51,6 +51,7 @@ def test_copy_with_non_version_tags(tmp_path_factory):
     )
     with local.cwd(repo):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "test_tag.post23+deadbeef")
@@ -86,6 +87,7 @@ def test_copy_with_non_version_tags_and_vcs_ref(tmp_path_factory):
     )
     with local.cwd(repo):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "test_tag.post23+deadbeef")
@@ -182,6 +184,7 @@ def test_exclude_extends(tmp_path: Path):
     # Convert to git repo
     with local.cwd(src):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "hello world")
     copier.copy(str(src), str(dst), exclude=["*.txt"])
@@ -339,6 +342,7 @@ def test_commit_hash(src_repo, tmp_path):
     )
     src_git = git["-C", src_repo]
     src_git("add", "-A")
+    src_git("config", "commit.gpgsign", "False")
     src_git("commit", "-m1")
     src_git("tag", "1.0")
     commit = src_git("rev-parse", "HEAD").strip()

--- a/tests/test_demo_update_tasks.py
+++ b/tests/test_demo_update_tasks.py
@@ -33,6 +33,7 @@ def test_update_tasks(tmp_path_factory):
     )
     with local.cwd(repo):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "v1")
@@ -49,6 +50,7 @@ def test_update_tasks(tmp_path_factory):
     (repo / "v1.txt").unlink()
     with local.cwd(repo):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m2")
         git("tag", "v2")
@@ -64,6 +66,7 @@ def test_update_tasks(tmp_path_factory):
     # Init destination as a new independent git repo
     with local.cwd(dst):
         git("init")
+        git("config", "commit.gpgsign", "False")
         # Configure git in case you're running in CI
         git("config", "user.name", "Copier Test")
         git("config", "user.email", "test@copier")

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -27,6 +27,7 @@ def test_copy(tmp_path_factory):
 
     with local.cwd(src):
         git("init")
+        git("config", "commit.gpgsign", "False")
 
     with pytest.warns(DirtyLocalWarning):
         copier.copy(str(src), str(dst), data=DATA, quiet=True)
@@ -68,6 +69,7 @@ def test_update(tmp_path_factory):
 
     with local.cwd(src):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", "-A")
         git("commit", "-m", "first commit on src")
 
@@ -88,6 +90,7 @@ def test_update(tmp_path_factory):
     # dst must be vcs-tracked to use run_update
     with local.cwd(dst):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", "-A")
         git("commit", "-m", "first commit on dst")
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -36,6 +36,7 @@ def test_migrations_and_tasks(tmp_path: Path):
         git("init")
         git("config", "user.name", "Copier Test")
         git("config", "user.email", "test@copier")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "v1.0.0")
@@ -58,6 +59,7 @@ def test_migrations_and_tasks(tmp_path: Path):
         git("add", ".")
         git("config", "user.name", "Copier Test")
         git("config", "user.email", "test@copier")
+        git("config", "commit.gpgsign", "False")
         git("commit", "-m1")
     # Update it to v2
     copy(dst_path=str(dst), defaults=True, overwrite=True)
@@ -92,6 +94,7 @@ def test_pre_migration_modifies_answers(tmp_path_factory):
             }
         )
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "v1")
@@ -103,6 +106,7 @@ def test_pre_migration_modifies_answers(tmp_path_factory):
         assert answers["best_song"] == "la vie en rose"
         assert json.loads(Path("songs.json").read_text()) == ["la vie en rose"]
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
     with local.cwd(template):
@@ -176,6 +180,7 @@ def test_prereleases(tmp_path: Path):
             }
         )
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-mv1")
         git("tag", "v1.0.0")
@@ -200,6 +205,7 @@ def test_prereleases(tmp_path: Path):
     with local.cwd(dst):
         # Commit subproject
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-mv1")
         # Update it without prereleases; nothing changes

--- a/tests/test_minimum_version.py
+++ b/tests/test_minimum_version.py
@@ -56,6 +56,7 @@ def test_minimum_version_update(template_path, tmp_path, monkeypatch):
         git("init")
         git("config", "user.name", "Copier Test")
         git("config", "user.email", "test@copier")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "hello world")
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -51,6 +51,7 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
     with local.cwd(template):
         build_file_tree(MARIO_TREE)
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "v1")
         git("tag", "v1")
@@ -88,6 +89,7 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
         assert "_commit: v1" in Path(".copier-answers.yml").read_text()
         # Update subproject
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         assert "_commit: v1" in Path(".copier-answers.yml").read_text()
         git("commit", "-m", "v1")
@@ -326,6 +328,7 @@ def test_update_choice(tmp_path_factory, spawn, choices):
     )
     with local.cwd(template):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m one")
         git("tag", "v1")
@@ -338,6 +341,7 @@ def test_update_choice(tmp_path_factory, spawn, choices):
     assert answers["pick_one"] == 2.0
     with local.cwd(subproject):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
     # Update

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -14,6 +14,7 @@ def git_init(message="hello world"):
     git("init")
     git("config", "user.name", "Copier Test")
     git("config", "user.email", "test@copier")
+    git("config", "commit.gpgsign", "False")
     git("add", ".")
     git("commit", "-m", message)
 
@@ -107,6 +108,7 @@ def test_update_subdirectory_from_root_path(tmp_path_factory):
             }
         )
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "1")
@@ -125,6 +127,7 @@ def test_update_subdirectory_from_root_path(tmp_path_factory):
     with local.cwd(dst):
         build_file_tree({"dst_top_file": "one"})
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m0")
     copier.run_copy(

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -49,6 +49,7 @@ def test_updatediff(tmp_path_factory):
     )
     with local.cwd(repo):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "Guybrush wants to be a pirate")
         git("tag", "v0.0.1")
@@ -81,6 +82,7 @@ def test_updatediff(tmp_path_factory):
     )
     with local.cwd(repo):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "Add migrations")
         git("tag", "v0.0.2")
@@ -123,6 +125,7 @@ def test_updatediff(tmp_path_factory):
     )
     with local.cwd(repo):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "Elaine wants to rule")
         git("bundle", "create", bundle, "--all")
@@ -166,6 +169,7 @@ def test_updatediff(tmp_path_factory):
         # Configure git in case you're running in CI
         git("config", "user.name", "Copier Test")
         git("config", "user.email", "test@copier")
+        git("config", "commit.gpgsign", "False")
         # Commit changes
         git("add", ".")
         commit("-m", "hello world")
@@ -327,6 +331,7 @@ def test_commit_hooks_respected(tmp_path_factory):
             }
         )
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "commit 1")
         git("tag", "v1")
@@ -334,6 +339,7 @@ def test_commit_hooks_respected(tmp_path_factory):
     copy(src_path=str(src), dst_path=dst1, defaults=True, overwrite=True)
     with local.cwd(dst1):
         life = Path("life.yml")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         # 1st commit fails because pre-commit reformats life.yml
         git("commit", "-am", "failed commit", retcode=1)
@@ -362,6 +368,7 @@ def test_commit_hooks_respected(tmp_path_factory):
             }
         )
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m", "commit 2")
         git("tag", "v2")
@@ -400,6 +407,7 @@ def test_commit_hooks_respected(tmp_path_factory):
     # Using file:// prefix to allow local shallow clones.
     git("clone", "--depth=1", f"file://{dst1}", dst2)
     with local.cwd(dst2):
+        git("config", "commit.gpgsign", "False")
         # Subproject re-updates just to change some values
         copy(data={"what": "study"}, defaults=True, overwrite=True)
         git("commit", "-am", "re-updated to change values after evolving")
@@ -453,6 +461,7 @@ def test_update_from_tagged_to_head(src_repo, tmp_path):
     # Build repo on copy
     with local.cwd(tmp_path):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", "-A")
         git("commit", "-m3")
     # Update project, it must let us do it
@@ -472,6 +481,7 @@ def test_skip_update(tmp_path_factory):
             }
         )
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "1.0.0")
@@ -484,6 +494,7 @@ def test_skip_update(tmp_path_factory):
     skip_me.write_text("2")
     with local.cwd(dst):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
     with local.cwd(src):
@@ -514,6 +525,7 @@ def test_overwrite_answers_file_always(
             }
         )
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "1")
@@ -524,6 +536,7 @@ def test_overwrite_answers_file_always(
     run_copy(str(src), str(dst), vcs_ref="1", defaults=True, answers_file=answers_file)
     with local.cwd(dst):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", ".")
         git("commit", "-m1")
         # When updating, the only thing to overwrite is the copier answers file,
@@ -556,6 +569,7 @@ def test_file_removed(src_repo, tmp_path):
     # Copy in subproject
     with local.cwd(tmp_path):
         git("init")
+        git("config", "commit.gpgsign", "False")
         run_copy(str(src_repo))
         # Subproject has an extra file
         build_file_tree(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -104,6 +104,7 @@ def test_update_using_local_source_path_with_tilde(tmp_path):
     # assert project update works and correct path again
     with local.cwd(tmp_path):
         git("init")
+        git("config", "commit.gpgsign", "False")
         git("add", "-A")
         git("commit", "-m", "init")
     worker = run_update(


### PR DESCRIPTION
Hi !

First time getting around using the tool, which I'm very excited about the lifecycle management side of things.

My git is globally configured to sign all my commits using GPG by default, as I want committing unsigned code to be an 'opt-out' in my environments.

However, since `copier` creates new temporary commits for internal reasons, it triggers a few GPG signature popups, so I looked into disabling that behaviour, as I have no wish to sign temporary commits and the commit commands fail if I don't.

It's not elegant - *especially* in the tests, where even more `init`s happen - but this patch basically inject a `commit.gpgsign=False` in each copier-created temporary repositories.

I'd welcome any feedback, as this is mostly a quick fix to allow me to continue working on my code template, but I figured it could be helpful to others !