### PR TITLE
ci: use codecov token for uploads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,7 @@ jobs:
           file: ./coverage.xml
           flags: unittests
           name: copier
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Let's see if this fixes the constant failures from Codecov uploads.

Inspiration: https://github.com/codecov/codecov-action/issues/557#issuecomment-1224970469