### PR TITLE
chore(pre-commit): update hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,14 +54,14 @@ repos:
         stages: [commit-msg]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v3.2.1
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
 
   # prettier to format our many yaml files
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.5.1
+    rev: v2.7.1
     hooks:
       - id: prettier
         exclude: |
@@ -73,7 +73,7 @@ repos:
 
   # miscellaneous hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: check-added-large-files
       - id: check-ast


### PR DESCRIPTION
I've updated the external pre-commit hooks to their latest versions and ran `pre-commit run -a` to check that the project is conformant.