### PR TITLE
chore(pre-commit): add poetry lock file check hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,12 @@ repos:
         language: system
         pass_filenames: false
         require_serial: true
+      - id: poetry-lock-check
+        name: poetry-lock-check
+        entry: poetry lock
+        args: ["--check"]
+        language: system
+        pass_filenames: false
       - id: isort
         name: isort
         entry: poetry run isort


### PR DESCRIPTION
I've added a pre-commit hook that verifies that `poetry.lock` is consistent with `pyproject.toml` using the command:

```sh
poetry lock --check
```