### PR TITLE
Answers file templating

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -417,7 +417,9 @@ class Worker:
         2. Template default.
         3. Copier default.
         """
-        return self.answers_file or self.template.answers_relpath
+        path = self.answers_file or self.template.answers_relpath
+        template = self.jinja_env.from_string(str(path))
+        return Path(template.render())
 
     @cached_property
     def all_exclusions(self) -> StrSeq:

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+import copier
+
+from .helpers import build_file_tree
+
+
+@pytest.fixture(scope="module")
+def template_path(tmp_path_factory) -> str:
+    root = tmp_path_factory.mktemp("template")
+    build_file_tree(
+        {
+            root
+            / ".copier-answers-{{module_name}}.yml": """\
+                # Changes here will be overwritten by Copier
+                [[ _copier_answers|to_nice_yaml ]]
+                """,
+            root
+            / "copier.yml": """\
+                _answers_file: .answers-file-changed-in-template.yml
+
+                module_name:
+                    type: str
+                """,
+        }
+    )
+    return str(root)
+
+
+@pytest.mark.parametrize("answers_file", [None, ".changed-by-user.yaml"])
+def test_answersfile_templating(template_path, tmp_path, answers_file):
+    """Test copier behaves properly when using an answersfile."""
+    copier.copy(
+        template_path,
+        tmp_path,
+        {"module_name": "mymodule"},
+        answers_file=answers_file,
+        defaults=True,
+        overwrite=True,
+    )
+    answers_file = ".copier-answers-mymodule.yml"
+    path = Path(tmp_path) / (answers_file)
+    assert path.exists()
+    copier.copy(
+        template_path,
+        tmp_path,
+        {"module_name": "anothermodule"},
+        defaults=True,
+        overwrite=True,
+    )
+    answers_file = ".copier-answers-anothermodule.yml"
+    path = Path(tmp_path) / (answers_file)
+    assert path.exists()
+    answers_file = ".copier-answers-mymodule.yml"
+    path = Path(tmp_path) / (answers_file)
+    assert path.exists()


### PR DESCRIPTION
Closes #866 

This adds support for templating in the `_answers_file` variable, allowing multiple answers files to be generated depending on answers given in `copier.yml`.

Was unsure whether to put tests in a new file or `tests/test_answersfile.py`. Went ahead and made a new file, but let me know if I should put them elsewhere.