### PR TITLE
add --no-verify to 2nd "dumb commit"

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -866,8 +866,9 @@ class Worker:
         git("config", "user.name", "Copier")
         git("config", "user.email", "copier@copier")
         # 1st commit could fail if any pre-commit hook reformats code
+        # 2nd commit uses --no-verify to disable pre-commit-like checks
         git("commit", "--allow-empty", "-am", "dumb commit 1", retcode=None)
-        git("commit", "--allow-empty", "-am", "dumb commit 2")
+        git("commit", "--allow-empty", "--no-verify", "-am", "dumb commit 2")
         git("config", "--unset", "user.name")
         git("config", "--unset", "user.email")
 


### PR DESCRIPTION
Closes https://github.com/copier-org/copier/issues/871

-> disable pre-commit-like checks to ensure that there won't be any more conflicts concerning this commit.