### PR TITLE
Remove dependency on iteration utilities

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -12,7 +12,6 @@ from warnings import warn
 import dunamai
 import packaging.version
 import yaml
-from iteration_utilities import deepflatten
 from packaging.version import Version, parse
 from plumbum.cmd import git
 from plumbum.machines import local
@@ -26,7 +25,7 @@ from .errors import (
     UnknownCopierVersionWarning,
     UnsupportedVersionError,
 )
-from .tools import copier_version, handle_remove_readonly
+from .tools import copier_version, deepflatten, handle_remove_readonly
 from .types import AnyByStrDict, Env, OptStr, StrSeq, Union, VCSTypes
 from .vcs import checkout_latest_tag, clone, get_repo
 
@@ -96,7 +95,7 @@ def load_template_config(conf_path: Path, quiet: bool = False) -> AnyByStrDict:
         with open(conf_path) as f:
             flattened_result = list(
                 deepflatten(
-                    yaml.load_all(f, Loader=yaml.FullLoader),
+                    list(yaml.load_all(f, Loader=yaml.FullLoader)),
                     depth=2,
                     types=(list,),
                 )

--- a/copier/template.py
+++ b/copier/template.py
@@ -95,7 +95,7 @@ def load_template_config(conf_path: Path, quiet: bool = False) -> AnyByStrDict:
         with open(conf_path) as f:
             flattened_result = list(
                 deepflatten(
-                    list(yaml.load_all(f, Loader=yaml.FullLoader)),
+                    yaml.load_all(f, Loader=yaml.FullLoader),
                     depth=2,
                     types=(list,),
                 )

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -149,6 +149,26 @@ def handle_remove_readonly(
         raise
 
 
+# Replaces https://github.com/MSeifert04/iteration_utilities deepflatten
+# See https://stackoverflow.com/questions/2158395/flatten-an-irregular-arbitrarily-nested-list-of-lists
+def deepflatten(input_list: list, depth: int, types: tuple):
+    """Flatten nested list items in a list
+
+    Params:
+        input_list: The list, including sub lists to be flattened.
+        depth: Maximum level to flatten. Sub lists at a deeper level will remain
+               nested
+        types: Item types to flatten. Items of other types will remain"""
+    if depth <= 0:
+        return input_list
+
+    for item in input_list:
+        if isinstance(item, types) and not isinstance(item, (str, bytes)):
+            yield from deepflatten(item, depth - 1)
+        else:
+            yield item
+
+
 # See https://github.com/copier-org/copier/issues/345
 class TemporaryDirectory(tempfile.TemporaryDirectory):
     """A custom version of `tempfile.TemporaryDirectory` that handles read-only files better.

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -10,7 +10,7 @@ import warnings
 from contextlib import suppress
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Optional, TextIO, Tuple, Union
+from typing import Any, Callable, Iterable, Optional, TextIO, Tuple, Union
 
 import colorama
 from packaging.version import Version
@@ -151,22 +151,22 @@ def handle_remove_readonly(
 
 # Replaces https://github.com/MSeifert04/iteration_utilities deepflatten
 # See https://stackoverflow.com/questions/2158395/flatten-an-irregular-arbitrarily-nested-list-of-lists
-def deepflatten(input_list: list, depth: int, types: tuple):
-    """Flatten nested list items in a list
-
-    Params:
-        input_list: The list, including sub lists to be flattened.
-        depth: Maximum level to flatten. Sub lists at a deeper level will remain
-               nested
-        types: Item types to flatten. Items of other types will remain"""
-    if depth <= 0:
-        return input_list
-
-    for item in input_list:
-        if isinstance(item, types) and not isinstance(item, (str, bytes)):
-            yield from deepflatten(item, depth - 1)
-        else:
-            yield item
+def deepflatten(
+    iterable: Iterable[Any],
+    depth: int,
+    types: Union[type, Tuple[type, ...]],
+) -> Iterable[Any]:
+    """
+    Flatten arbitrarily nested items of selected type(s) up to a maximum depth.
+    """
+    if depth == -1:
+        yield iterable
+    else:
+        for item in iterable:
+            if isinstance(item, types):
+                yield from deepflatten(item, depth - 1, types)
+            else:
+                yield item
 
 
 # See https://github.com/copier-org/copier/issues/345

--- a/poetry.lock
+++ b/poetry.lock
@@ -354,19 +354,6 @@ plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
-name = "iteration-utilities"
-version = "0.11.0"
-description = "Utilities based on Pythons iterators and generators."
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[package.extras]
-all = ["numpydoc", "pytest", "sphinx"]
-doc = ["numpydoc", "sphinx"]
-test = ["pytest"]
-
-[[package]]
 name = "jinja2"
 version = "3.1.2"
 description = "A very fast and expressive template engine."
@@ -1034,8 +1021,8 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.7,<4.0"
-content-hash = "a51cdc39bb23f3b814173ab17dd0de495294ca230d0044b19c7a37a28504c6d6"
+python-versions = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
+content-hash = "ef39a2971160f356e3c3c817df9e912aed661a9f2d53c0288fac0fefdf97b194"
 
 [metadata.files]
 argcomplete = [
@@ -1222,41 +1209,6 @@ iniconfig = [
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
-]
-iteration-utilities = [
-    {file = "iteration_utilities-0.11.0-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:17c9418d967fd8020211ebd5770332fc6cf11800eec446a31fcad4fe96fe4009"},
-    {file = "iteration_utilities-0.11.0-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:243de0d75c54200350fe2f1aa4c08471f95fe4ca77fca741ae50b495ccd7420c"},
-    {file = "iteration_utilities-0.11.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a074f8bbbfd75b9980819a5f342e90069c421dffebc66724bccc84034c9cdcd2"},
-    {file = "iteration_utilities-0.11.0-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:e046738b578a9c7f7ca96a5d7554191d12f22a897ada78ab4d5ac1a92afc47ba"},
-    {file = "iteration_utilities-0.11.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:c4bb9be1d0ac15b13b0c2f4ada6159a32067f6e1af6ce65e3c72fda4deab4478"},
-    {file = "iteration_utilities-0.11.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:37f427f2682aad3b27afab8edcfa8002268d1eab30c4957200a004af3d5f5b0e"},
-    {file = "iteration_utilities-0.11.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0dc2aed43691d38052fe99d94f04886324818d058fb030068e14343008fe856b"},
-    {file = "iteration_utilities-0.11.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f06c4862911aad6c21529ecc0d6744048712303eb37afecc9ee5ffa804ba6614"},
-    {file = "iteration_utilities-0.11.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:e7ad14f9bd0bb6d69b6ac30811decedcb71a16e2d4e528a469fe865ad8d57305"},
-    {file = "iteration_utilities-0.11.0-cp36-cp36m-win32.whl", hash = "sha256:4005c4cbfaacf9897367dc92055e85d4990d5ab43a3234ff5be5b222e42fd511"},
-    {file = "iteration_utilities-0.11.0-cp36-cp36m-win_amd64.whl", hash = "sha256:a9981e55e560389079201b97b10b885050bdfc2cd55d76a830307899a6c475f5"},
-    {file = "iteration_utilities-0.11.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:112b615d596c939a427f08943c0e5594bca672bd67dc7ac928deb4a6a9637df7"},
-    {file = "iteration_utilities-0.11.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:b6541b081a95a1c8b8a0ebb08d2ae49e649b3d8e75bb55e1b4eed7687561bd09"},
-    {file = "iteration_utilities-0.11.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1c9a1d58ca2f5260eed057e1b9d0b08f62a8e42153224476598f2dd079ae765e"},
-    {file = "iteration_utilities-0.11.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ae7cebc811843de5868400a8cc7e401569452e9cbaa09ebfccc4882f2507c36a"},
-    {file = "iteration_utilities-0.11.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:46485bb3c7db9267014a1453009c612fb658d85ba4a41bee01346663b3797de6"},
-    {file = "iteration_utilities-0.11.0-cp37-cp37m-win32.whl", hash = "sha256:3d154511cc177872bb843dcc789591f23214bc9d568db542f95c3cf4cc78b4eb"},
-    {file = "iteration_utilities-0.11.0-cp37-cp37m-win_amd64.whl", hash = "sha256:3f276186d2afc979c86ab4f505e398f9f206a8ad42c510d6000b1ed49748ca74"},
-    {file = "iteration_utilities-0.11.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:07edb8a7553fda1cfb59e4d761f7e03b3607b948cbd3549250bcb489a7bb0f81"},
-    {file = "iteration_utilities-0.11.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:08a00db7beac8647b00c5d9968e14235b33d387f4e2900ae1b1a4cfbf68894bb"},
-    {file = "iteration_utilities-0.11.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:d10a7a6564b32a2266b67994264151e073f77463145b0cac8245cbd1da1b0013"},
-    {file = "iteration_utilities-0.11.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:f586a65e72a1120c9427e1903068268f11f0d73af0f56a247419f33ca0d4c3db"},
-    {file = "iteration_utilities-0.11.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:d2f5e4acce15dbb731b71f9d109c329eee7bcb4d64c1bd9cc2669afca542ede8"},
-    {file = "iteration_utilities-0.11.0-cp38-cp38-win32.whl", hash = "sha256:c37f44ee027d35cb25527260ccd4dcdd23ed6015f957dab4dc1398692e6df7a1"},
-    {file = "iteration_utilities-0.11.0-cp38-cp38-win_amd64.whl", hash = "sha256:47244350489474d25f516286554a3d9df235505e759ce7381ec1c8acf0734ac4"},
-    {file = "iteration_utilities-0.11.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:15f7c88cdaaed2346e086cf993a283a694b74613039aa3d931279e0e40e9dca2"},
-    {file = "iteration_utilities-0.11.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:1666e00a4058620f5d2ca2de12927dc1819e36e1f37c8cfa17050c4db9d6703a"},
-    {file = "iteration_utilities-0.11.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2593385dbe50636c3fec5a9c73a3413c265062608deba37dc54b7be83c23d663"},
-    {file = "iteration_utilities-0.11.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:4805bda63753ad446af8c69035f7b6a1554176147d636a27f8a1f0ad297c405f"},
-    {file = "iteration_utilities-0.11.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:7aecba49b749630f30860535156b50399f23175f91fbb2a9849c3b41d40acac2"},
-    {file = "iteration_utilities-0.11.0-cp39-cp39-win32.whl", hash = "sha256:bd40f6af97e887950377777d7ce69bb47356a3f7d29f65f95687f4aaaf33a783"},
-    {file = "iteration_utilities-0.11.0-cp39-cp39-win_amd64.whl", hash = "sha256:72020ff072f61a05974d82e5850dab3088339907e34c0fe20d8a6bf373e0ddbe"},
-    {file = "iteration_utilities-0.11.0.tar.gz", hash = "sha256:f91f41a2549e9a7e40ff5460fdf9033b6ee5b305d9be77943b63a554534c2a77"},
 ]
 jinja2 = [
     {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ python = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
 colorama = ">=0.4.3"
 dunamai = ">=1.7.0"
 importlib-metadata = { version = ">=3.4,<5.0", python = "<3.8" }
-iteration_utilities = ">=0.11.0"
 jinja2 = ">=3.1.1"
 jinja2-ansible-filters = ">=1.3.1"
 packaging = ">=21.0" # packaging is needed when installing from PyPI

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -44,17 +44,19 @@ def test_temporary_directory_with_git_repo_deletion():
 
 def test_deepflatten():
     """Ensure deepflatten works in simple usage"""
-    result = deepflatten([1, [2, 3], 4], 1, (list,))
+    result = deepflatten([1, [2, 3], 4], depth=1, types=(list,))
     assert list(result) == [1, 2, 3, 4]
 
 
 def test_deepflatten_depth():
     """Ensure deepflatten depth works"""
-    result = deepflatten([1, [2, [3, 4]], 5], 1, (list,))
+    result = deepflatten([1, [2, [3, 4]], 5], depth=1, types=(list,))
     assert list(result) == [1, 2, [3, 4], 5]
 
 
 def test_deepflatten_types():
     """Ensure deepflatten types filter works"""
-    result = deepflatten([1, [2, 3], 4, {"key": ["val1", "val2"]}], 1, (list,))
+    result = deepflatten(
+        [1, [2, 3], 4, {"key": ["val1", "val2"]}], depth=1, types=(list,)
+    )
     assert list(result) == [1, 2, 3, 4, {"key": ["val1", "val2"]}]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,7 +6,7 @@ import pytest
 from plumbum.cmd import git
 from poethepoet.app import PoeThePoet
 
-from copier.tools import TemporaryDirectory
+from copier.tools import TemporaryDirectory, deepflatten
 
 
 @pytest.mark.skipif(
@@ -40,3 +40,21 @@ def test_temporary_directory_with_git_repo_deletion():
     with TemporaryDirectory() as tmp_dir:
         git("clone", "--depth=1", ".", Path(tmp_dir) / "repo")
     assert not Path(tmp_dir).exists()
+
+
+def test_deepflatten():
+    """Ensure deepflatten works in simple usage"""
+    result = deepflatten([1, [2, 3], 4], 1, (list,))
+    assert list(result) == [1, 2, 3, 4]
+
+
+def test_deepflatten_depth():
+    """Ensure deepflatten depth works"""
+    result = deepflatten([1, [2, [3, 4]], 5], 1, (list,))
+    assert list(result) == [1, 2, [3, 4], 5]
+
+
+def test_deepflatten_types():
+    """Ensure deepflatten types filter works"""
+    result = deepflatten([1, [2, 3], 4, {"key": ["val1", "val2"]}], 1, (list,))
+    assert list(result) == [1, 2, 3, 4, {"key": ["val1", "val2"]}]


### PR DESCRIPTION
Solving #889 

Installing copier on Windows with python 3.10 and no c++ compiler fails. This is due to the dependent package iteration_utilities having no python 3.10 wheel file available on pypi.

Solution is to remove the dependency on iteration_utilities. Fortunately the only use of this package is for the `deepflatten` function which I've re-implemented directly in copier.