### PR TITLE
docs: No redundant empty lines for `_copier_answers`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ print("Hello from {{module_name}}!")
 
 ```yaml+jinja title="{{_copier_conf.answers_file}}.jinja"
 # Changes here will be overwritten by Copier
-{{_copier_answers|to_nice_yaml}}
+{{ _copier_answers|to_nice_yaml -}}
 ```
 
 To generate a project from the template:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1135,9 +1135,9 @@ The default name will be `.copier-answers.yml`, but
 
 The file must have this content:
 
-```yaml
+```yaml+jinja
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-{{_copier_answers|to_nice_yaml}}
+{{ _copier_answers|to_nice_yaml -}}
 ```
 
 !!! important

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -41,7 +41,7 @@ print("Hello from {{module_name}}!")
 
 ```yaml+jinja title="{{_copier_conf.answers_file}}.jinja"
 # Changes here will be overwritten by Copier
-{{_copier_answers|to_nice_yaml}}
+{{ _copier_answers|to_nice_yaml -}}
 ```
 
 Generating a project from this template with `super_project` and `world` as answers for


### PR DESCRIPTION
Fix #894

Signed-off-by: Xuan Hu <i@huxuan.org>