### PR TITLE
build(deps): fix `funcy` version specifier

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1030,7 +1030,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
-content-hash = "76f033e5473ea6c0ebffd8a3deccf5ca6ffefc864a2a6f2ae7e08e2e5be60fb3"
+content-hash = "eae517c93329374caecdedf4ac78b2568316123b45eba33c9ad0de144db7aa3c"
 
 [metadata.files]
 argcomplete = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ python = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
 "backports.cached-property" = { version = ">=1.0.0", python = "<3.8" }
 colorama = ">=0.4.3"
 dunamai = ">=1.7.0"
+funcy = ">=1.17"
 importlib-metadata = { version = ">=3.4,<5.0", python = "<3.8" }
 jinja2 = ">=3.1.1"
 jinja2-ansible-filters = ">=1.3.1"
@@ -42,7 +43,6 @@ pyyaml = ">=5.3.1"
 pyyaml-include = ">=1.2"
 questionary = ">=1.8.1"
 typing-extensions = { version = ">=3.7.4,<5.0.0", python = "<3.8" }
-funcy = "^1.17"
 
 [tool.poetry.group.dev.dependencies]
 autoflake = ">=1.4"


### PR DESCRIPTION
I've fixed `funcy`'s version specifier to use only a lower bound. Although it's not explicitly mentioned, it looks to me like `funcy` uses SemVer, so only a lower bound should be used.

While at it, I've also placed the `funcy` dependency in alphabetic order with the other dependencies.