### PR TITLE
fix: do not set git filter for local shallow clones

### DIFF
--- a/copier/errors.py
+++ b/copier/errors.py
@@ -113,3 +113,7 @@ class OldTemplateWarning(UserWarning, CopierWarning):
 
 class DirtyLocalWarning(UserWarning, CopierWarning):
     """Changes and untracked files present in template."""
+
+
+class ShallowCloneWarning(UserWarning, CopierWarning):
+    """The template repository is a shallow clone."""

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -147,7 +147,12 @@ def clone(url: str, ref: OptStr = None) -> str:
     # Faster clones if possible
     if GIT_VERSION >= Version("2.27"):
         file_url = re.match("(file://)?(.*)", url).groups()[-1]
-        if not is_git_shallow_repo(file_url):
+        if is_git_shallow_repo(file_url):
+            warn(
+                f"The repository '{url}' is a shallow clone, this might lead to unexpected "
+                "failure or unusually high resource consumption."
+            )
+        else:
             _clone = _clone["--filter=blob:none"]
     _clone()
 

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -136,7 +136,11 @@ def clone(url: str, ref: OptStr = None) -> str:
     location = mkdtemp(prefix=f"{__name__}.clone.")
     _clone = git["clone", "--no-checkout", url, location]
     # Faster clones if possible
-    if GIT_VERSION >= Version("2.27"):
+    if (
+        GIT_VERSION >= Version("2.27")
+        and not url.startswith("file://")
+        and not Path(url).exists()
+    ):
         _clone = _clone["--filter=blob:none"]
     _clone()
 

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 from plumbum import TF, ProcessExecutionError, colors, local
 from plumbum.cmd import git
 
-from .errors import DirtyLocalWarning
+from .errors import DirtyLocalWarning, ShallowCloneWarning
 from .tools import TemporaryDirectory
 from .types import OptBool, OptStr, StrOrPath
 
@@ -150,7 +150,8 @@ def clone(url: str, ref: OptStr = None) -> str:
         if is_git_shallow_repo(file_url):
             warn(
                 f"The repository '{url}' is a shallow clone, this might lead to unexpected "
-                "failure or unusually high resource consumption."
+                "failure or unusually high resource consumption.",
+                ShallowCloneWarning,
             )
         else:
             _clone = _clone["--filter=blob:none"]

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -146,7 +146,11 @@ def clone(url: str, ref: OptStr = None) -> str:
     _clone = git["clone", "--no-checkout", url, location]
     # Faster clones if possible
     if GIT_VERSION >= Version("2.27"):
-        file_url = re.match("(file://)?(.*)", url).groups()[-1]
+        url_match = re.match("(file://)?(.*)", url)
+        if url_match is not None:
+            file_url = url_match.groups()[-1]
+        else:
+            file_url = url
         if is_git_shallow_repo(file_url):
             warn(
                 f"The repository '{url}' is a shallow clone, this might lead to unexpected "

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -139,7 +139,7 @@ def clone(url: str, ref: OptStr = None) -> str:
     if (
         GIT_VERSION >= Version("2.27")
         and not url.startswith("file://")
-        and not Path(url).exists()
+        and not os.path.exists(url)
     ):
         _clone = _clone["--filter=blob:none"]
     _clone()

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -98,3 +98,9 @@ class ContextUpdater(ContextHook):
 
 Now you can use these added variables in your Jinja templates, and in files and folders
 names!
+
+## Why Copier consumes a lot of resources?
+
+If the repository containing the template is a shallow clone, the git process called by
+Copier might consume unusually high resources. To avoid that, use a fully-cloned
+repository.

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -8,7 +8,7 @@ from packaging.version import Version
 from plumbum import local
 from plumbum.cmd import git
 
-from copier import Worker, run_copy, run_update, vcs
+from copier import Worker, errors, run_copy, run_update, vcs
 
 
 def test_get_repo():
@@ -91,13 +91,7 @@ def test_shallow_clone(tmp_path, recwarn):
     assert exists(join(src_path, "README.md"))
 
     if vcs.GIT_VERSION >= Version("2.27"):
-        with pytest.warns(
-            UserWarning,
-            match=(
-                f"The repository '{src_path}' is a shallow clone, this might lead to unexpected "
-                "failure or unusually high resource consumption."
-            ),
-        ):
+        with pytest.warns(errors.ShallowCloneWarning):
             local_tmp = vcs.clone(str(src_path))
     else:
         assert len(recwarn) == 0

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -70,6 +70,18 @@ def test_clone():
 
 
 @pytest.mark.impure
+def test_local_clone():
+    tmp = vcs.clone("https://github.com/copier-org/copier.git")
+    assert tmp
+    assert exists(join(tmp, "README.md"))
+
+    local_tmp = vcs.clone(str(tmp))
+    assert local_tmp
+    assert exists(join(local_tmp, "README.md"))
+    shutil.rmtree(local_tmp, ignore_errors=True)
+
+
+@pytest.mark.impure
 def test_removes_temporary_clone(tmp_path):
     src_path = "https://github.com/copier-org/autopretty.git"
     with Worker(src_path=src_path, dst_path=tmp_path, defaults=True) as worker:

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -82,6 +82,20 @@ def test_local_clone():
 
 
 @pytest.mark.impure
+def test_shallow_clone(tmp_path):
+    # This test should always work but should be much slower if `is_git_shallow_repo()` is not
+    # checked in `vcs.clone()`.
+    src_path = str(tmp_path / "autopretty")
+    git("clone", "--depth=2", "https://github.com/copier-org/autopretty.git", src_path)
+    assert exists(join(src_path, "README.md"))
+
+    local_tmp = vcs.clone(str(src_path))
+    assert local_tmp
+    assert exists(join(local_tmp, "README.md"))
+    shutil.rmtree(local_tmp, ignore_errors=True)
+
+
+@pytest.mark.impure
 def test_removes_temporary_clone(tmp_path):
     src_path = "https://github.com/copier-org/autopretty.git"
     with Worker(src_path=src_path, dst_path=tmp_path, defaults=True) as worker:

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -92,7 +92,8 @@ def test_removes_temporary_clone(tmp_path):
 
 @pytest.mark.impure
 def test_dont_remove_local_clone(tmp_path):
-    src_path = vcs.clone("https://github.com/copier-org/autopretty.git")
+    src_path = str(tmp_path / "autopretty")
+    git("clone", "https://github.com/copier-org/autopretty.git", src_path)
     with Worker(src_path=src_path, dst_path=tmp_path, defaults=True) as worker:
         worker.run_copy()
     assert exists(src_path)
@@ -101,7 +102,8 @@ def test_dont_remove_local_clone(tmp_path):
 @pytest.mark.impure
 def test_update_using_local_source_path_with_tilde(tmp_path):
     # first, get a local repository clone
-    src_path = vcs.clone("https://github.com/copier-org/autopretty.git")
+    src_path = str(tmp_path / "autopretty")
+    git("clone", "https://github.com/copier-org/autopretty.git", src_path)
 
     # then prepare the user path to this clone (starting with ~)
     if os.name == "nt":


### PR DESCRIPTION
When using `git >= 2.27`, the filter `--filter=blob:none` is used to make the cloning process faster. Nevertheless, this can cause troubles when cloning local repositories.