### PR TITLE
ci(codecov): continue on error when uploading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
       - name: Run pytest
         run: poetry run poe test --cov=./ --cov-report=xml -ra .
       - name: Upload coverage to Codecov
+        continue-on-error: true
         uses: codecov/codecov-action@v3
         env:
           OS: ${{ matrix.os }}


### PR DESCRIPTION
This should avoid too many :x: PRs.