### PR TITLE
Make sure the parent directory of the target file exists

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -1,5 +1,6 @@
 """Main functions and classes, used to generate or update projects."""
 
+import os
 import platform
 import subprocess
 import sys
@@ -244,6 +245,7 @@ class Worker:
                 "answers_file": self.answers_relpath,
                 "src_path": self.template.local_abspath,
                 "vcs_ref_hash": self.template.commit_hash,
+                "sep": os.sep,
             }
         )
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -510,6 +510,7 @@ class Worker:
         ):
             return
         if not self.pretend:
+            dst_abspath.parent.mkdir(parents=True, exist_ok=True)
             dst_abspath.write_bytes(new_content)
             dst_abspath.chmod(src_mode)
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -458,6 +458,39 @@ ci:
     On Windows, double-quotes are not valid characters in file and directory paths.
     This is why we used **single-quotes** in the example above.
 
+## Generating a directory structure
+
+You can use answers to generate file names as well as whole directory structures.
+
+```yaml title="copier.yml"
+package:
+    type: str
+    help: Package name
+```
+
+```shell
+📁 your_template
+├── 📄 copier.yml
+└── 📄 {{ package.replace('.', _copier_conf.sep) }}{{ _copier_conf.sep }}__main__.py.jinja
+```
+
+If you answer
+
+> your_package.cli.main
+
+Copier will generate this structure:
+
+```shell
+📁 your_project
+└── 📁 your_package
+    └── 📁 cli
+        └── 📁 main
+            └── 📄 __main__.py
+```
+
+You can either use any separator, like `.`, and replace it with `_copier_conf.sep`, like
+in the example above, or just use `/` in the answer (works on Windows too).
+
 ## Available settings
 
 Template settings alter how the template is rendered.

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -98,3 +98,4 @@ Copier includes:
     -   Modifying it doesn't alter the current rendering configuration.
     -   It contains the current commit hash from the template in
         `{{ _copier_conf.vcs_ref_hash }}`.
+    -   Contains Operating System-specific directory separator under `sep` key.

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -352,15 +352,14 @@ def test_value_with_forward_slash(tmp_path_factory):
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src / "{{ filename.replace('.', sep) }}.txt"
-            : "This is template.",
+            src
+            / "{{ filename.replace('.', _copier_conf.sep) }}.txt": "This is template.",
         }
     )
     copier.run_auto(
         str(src),
         dst,
         data={
-            "sep": "/",
             "filename": "a.b.c",
         },
     )

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -346,3 +346,25 @@ def test_commit_hash(src_repo, tmp_path):
     copier.run_copy(str(src_repo), tmp_path)
     assert tmp_path.joinpath("tag").read_text() == "1.0"
     assert tmp_path.joinpath("commit").read_text() == commit
+
+
+def test_value_with_forward_slash(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "{{ filename.replace('.', sep) }}.txt"
+            : "This is template.",
+        }
+    )
+    copier.run_auto(
+        str(src),
+        dst,
+        data={
+            "sep": "/",
+            "filename": "a.b.c",
+        },
+    )
+
+    file_rendered = (dst / "a" / "b" / "c.txt").read_text()
+    file_expected = "This is template."
+    assert file_rendered == file_expected


### PR DESCRIPTION
When rendering files, the filename template may hold forward slash characters, in which case Copier attempts to write a directory structure. But it doesn't ensure the directory structure exists before writing the file.
This patch fixes it.

Related to #692