### PR TITLE
feat: Preserve symlinks when copying templates

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -447,6 +447,14 @@ class Template:
         return result
 
     @cached_property
+    def preserve_symlinks(self) -> bool:
+        """Know if Copier should preserve symlinks when rendering the template.
+
+        See [preserve_symlinks][].
+        """
+        return bool(self.config_data.get("preserve_symlinks", False))
+
+    @cached_property
     def local_abspath(self) -> Path:
         """Get the absolute path to the template on disk.
 

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -178,3 +178,17 @@ class TemporaryDirectory(tempfile.TemporaryDirectory):
     @staticmethod
     def _robust_cleanup(name):
         shutil.rmtree(name, ignore_errors=False, onerror=handle_remove_readonly)
+
+
+def readlink(link: Path) -> Path:
+    """A custom version of os.readlink/pathlib.Path.readlink.
+
+    pathlib.Path.readlink is what we ideally would want to use, but it is only available on python>=3.9.
+    os.readlink doesn't support Path and bytes on Windows for python<3.8
+    """
+    if sys.version_info >= (3, 9):
+        return link.readlink()
+    elif sys.version_info >= (3, 8) or os.name != "nt":
+        return Path(os.readlink(link))
+    else:
+        return Path(os.readlink(str(link)))

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1022,6 +1022,18 @@ Run but do not make any changes.
 
     Not supported in `copier.yml`.
 
+### `preserve_symlinks`
+
+-   Format: `bool`
+-   CLI flags: N/A
+-   Default value: `False`
+
+Keep symlinks as symlinks. If this is set to `False` symlinks will be replaced with the
+file they point to.
+
+When set to `True` and the symlink ends with the template suffix (`.jinja` by default)
+the target path of the symlink will be rendered as a jinja template.
+
 ### `quiet`
 
 -   Format: `bool`

--- a/tests/demo/symlink.txt
+++ b/tests/demo/symlink.txt
@@ -1,0 +1,1 @@
+aaaa.txt

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -135,6 +135,8 @@ def test_copy(tmp_path: Path) -> None:
     assert not (tmp_path / "py2_folder" / "thing.py").exists()
     assert (tmp_path / "py3_folder" / "thing.py").exists()
 
+    assert (tmp_path / "aaaa.txt").exists()
+
 
 @pytest.mark.impure
 def test_copy_repo(tmp_path: Path) -> None:
@@ -288,22 +290,28 @@ def test_empty_dir(tmp_path_factory: pytest.TempPathFactory, generate: bool) -> 
             ),
             (src / "tpl" / "two.txt"): "[[ do_it ]]",
             (src / "tpl" / "[% if do_it %]three.txt[% endif %].jinja"): "[[ do_it ]]",
-            (src / "tpl" / "four" / "[% if do_it %]five.txt[% endif %].jinja"): (
+            (src / "tpl" / "[% if do_it %]four.txt[% endif %].jinja"): Path(
+                "[% if do_it %]three.txt[% endif %].jinja"
+            ),
+            (src / "tpl" / "five" / "[% if do_it %]six.txt[% endif %].jinja"): (
                 "[[ do_it ]]"
             ),
         },
     )
     copier.run_copy(str(src), dst, {"do_it": generate}, defaults=True, overwrite=True)
-    assert (dst / "four").is_dir()
+    assert (dst / "five").is_dir()
     assert (dst / "two.txt").read_text() == "[[ do_it ]]"
     assert (dst / "one_dir").exists() == generate
     assert (dst / "three.txt").exists() == generate
+    assert (dst / "four.txt").exists() == generate
     assert (dst / "one_dir").is_dir() == generate
     assert (dst / "one_dir" / "one.txt").is_file() == generate
     if generate:
         assert (dst / "one_dir" / "one.txt").read_text() == repr(generate)
         assert (dst / "three.txt").read_text() == repr(generate)
-        assert (dst / "four" / "five.txt").read_text() == repr(generate)
+        assert not (dst / "four.txt").is_symlink()
+        assert (dst / "four.txt").read_text() == repr(generate)
+        assert (dst / "five" / "six.txt").read_text() == repr(generate)
 
 
 @pytest.mark.skipif(

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -66,6 +66,7 @@ def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
                 delete me.
                 """
             ),
+            (src / "symlink.txt"): Path("./to_delete.txt"),
         }
     )
 
@@ -84,6 +85,10 @@ def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
         with open("aaaa.txt", "a") as f:
             f.write("dolor sit amet")
 
+        # test updating a symlink
+        Path("symlink.txt").unlink()
+        Path("symlink.txt").symlink_to("test_file.txt")
+
         # test removing a file
         Path("to_delete.txt").unlink()
 
@@ -98,6 +103,10 @@ def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
 
     assert (src / "aaaa.txt").read_text() != (dst / "aaaa.txt").read_text()
 
+    p1 = src / "symlink.txt"
+    p2 = dst / "symlink.txt"
+    assert p1.read_text() != p2.read_text()
+
     assert (dst / "to_delete.txt").exists()
 
     with pytest.warns(DirtyLocalWarning):
@@ -107,6 +116,11 @@ def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert (dst / "test_file.txt").exists()
 
     assert (src / "aaaa.txt").read_text() == (dst / "aaaa.txt").read_text()
+
+    p1 = src / "symlink.txt"
+    p2 = dst / "symlink.txt"
+    assert p1.read_text() == p2.read_text()
+    assert not (dst / "symlink.txt").is_symlink()
 
     # HACK https://github.com/copier-org/copier/issues/461
     # TODO test file deletion on update

--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -1,0 +1,387 @@
+import os
+from pathlib import Path
+
+import pytest
+from plumbum import local
+from plumbum.cmd import git
+
+from copier import copy, readlink, run_copy, run_update
+from copier.errors import DirtyLocalWarning
+
+from .helpers import build_file_tree
+
+
+def test_copy_symlink(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: true
+            """,
+            repo / "target.txt": "Symlink target",
+            repo / "symlink.txt": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert os.path.exists(dst / "target.txt")
+    assert os.path.exists(dst / "symlink.txt")
+    assert os.path.islink(dst / "symlink.txt")
+    assert readlink(dst / "symlink.txt") == Path("target.txt")
+
+
+def test_copy_symlink_templated_name(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: true
+            symlink_name: symlink
+            """,
+            repo / "target.txt": "Symlink target",
+            repo / "{{ symlink_name }}.txt": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert os.path.exists(dst / "target.txt")
+    assert os.path.exists(dst / "symlink.txt")
+    assert os.path.islink(dst / "symlink.txt")
+    assert readlink(dst / "symlink.txt") == Path("target.txt")
+
+
+def test_copy_symlink_templated_target(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: true
+            target_name: target
+            """,
+            repo / "{{ target_name }}.txt": "Symlink target",
+            repo / "symlink1.txt.jinja": Path("{{ target_name }}.txt"),
+            repo / "symlink2.txt": Path("{{ target_name }}.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert os.path.exists(dst / "target.txt")
+
+    assert os.path.exists(dst / "symlink1.txt")
+    assert os.path.islink(dst / "symlink1.txt")
+    assert readlink(dst / "symlink1.txt") == Path("target.txt")
+
+    assert not os.path.exists(dst / "symlink2.txt")
+    assert os.path.islink(dst / "symlink2.txt")
+    assert readlink(dst / "symlink2.txt") == Path("{{ target_name }}.txt")
+
+
+def test_copy_symlink_missing_target(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: true
+            """,
+            repo / "symlink.txt": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert os.path.islink(dst / "symlink.txt")
+    assert readlink(dst / "symlink.txt") == Path("target.txt")
+    assert not os.path.exists(
+        dst / "symlink.txt"
+    )  # exists follows symlinks, It returns False as the target doesn't exist
+
+
+def test_option_preserve_symlinks_false(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: false
+            """,
+            repo / "target.txt": "Symlink target",
+            repo / "symlink.txt": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert os.path.exists(dst / "target.txt")
+    assert os.path.exists(dst / "symlink.txt")
+    assert not os.path.islink(dst / "symlink.txt")
+
+
+def test_option_preserve_symlinks_default(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            """,
+            repo / "target.txt": "Symlink target",
+            repo / "symlink.txt": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert os.path.exists(dst / "target.txt")
+    assert os.path.exists(dst / "symlink.txt")
+    assert not os.path.islink(dst / "symlink.txt")
+
+
+def test_update_symlink(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    build_file_tree(
+        {
+            src
+            / ".copier-answers.yml.jinja": """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+            """,
+            src
+            / "copier.yml": """\
+                _preserve_symlinks: true
+            """,
+            src
+            / "aaaa.txt": """
+                Lorem ipsum
+            """,
+            src
+            / "bbbb.txt": """
+                dolor sit amet
+            """,
+            src / "symlink.txt": Path("./aaaa.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", "-A")
+        git("commit", "-m", "first commit on src")
+
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+
+    with local.cwd(src):
+        # test updating a symlink
+        os.remove("symlink.txt")
+        os.symlink("bbbb.txt", "symlink.txt")
+
+    # dst must be vcs-tracked to use run_update
+    with local.cwd(dst):
+        git("init")
+        git("add", "-A")
+        git("commit", "-m", "first commit on dst")
+
+    # make sure changes have not yet propagated
+    p1 = src / "symlink.txt"
+    p2 = dst / "symlink.txt"
+    assert p1.read_text() != p2.read_text()
+
+    with pytest.warns(DirtyLocalWarning):
+        run_update(dst, defaults=True, overwrite=True)
+
+    # make sure changes propagate after update
+    p1 = src / "symlink.txt"
+    p2 = dst / "symlink.txt"
+    assert p1.read_text() == p2.read_text()
+
+    assert readlink(dst / "symlink.txt") == Path("bbbb.txt")
+
+
+def test_exclude_symlink(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: true
+            """,
+            repo / "target.txt": "Symlink target",
+            repo / "symlink.txt": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        exclude=["symlink.txt"],
+        vcs_ref="HEAD",
+    )
+    assert not (dst / "symlink.txt").exists()
+    assert not (dst / "symlink.txt").is_symlink()
+
+
+def test_pretend_symlink(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: true
+            """,
+            repo / "target.txt": "Symlink target",
+            repo / "symlink.txt": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        pretend=True,
+        vcs_ref="HEAD",
+    )
+    assert not (dst / "symlink.txt").exists()
+    assert not (dst / "symlink.txt").is_symlink()
+
+
+def test_copy_symlink_none_path(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Prepare repo bundle
+    repo = src / "repo"
+    repo.mkdir()
+    build_file_tree(
+        {
+            repo
+            / "copier.yaml": """\
+            _preserve_symlinks: true
+            render: false
+            """,
+            repo / "target.txt": "Symlink target",
+            repo / "{% if render %}symlink.txt{% endif %}": Path("target.txt"),
+        }
+    )
+
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", "hello world")
+
+    copy(
+        str(repo),
+        dst,
+        defaults=True,
+        overwrite=True,
+        vcs_ref="HEAD",
+    )
+
+    assert os.path.exists(dst / "target.txt")
+    assert not os.path.exists(dst / "symlink.txt")
+    assert not os.path.islink(dst / "symlink.txt")


### PR DESCRIPTION
Closes #937.

This PR makes copier preserve symlinks when copying a template instead of copying the file the symlink points to.

The old behavior can be restored by setting `_preserve_symlinks` to false in `copier.yml`.

If the name of a symlink is templated it will be rendered. The targets of symlinks will only be rendered if the symlink name ends with the template suffix (`.jinja` by default).