### PR TITLE
feat: ignore default excludes when using subdirectory

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -300,7 +300,12 @@ class Template:
 
         See [exclude][].
         """
-        return tuple(self.config_data.get("exclude", DEFAULT_EXCLUDE))
+        return tuple(
+            self.config_data.get(
+                "exclude",
+                [] if Path(self.subdirectory) != Path(".") else DEFAULT_EXCLUDE,
+            )
+        )
 
     @cached_property
     def jinja_extensions(self) -> Tuple[str, ...]:

--- a/copier/template.py
+++ b/copier/template.py
@@ -303,7 +303,7 @@ class Template:
         return tuple(
             self.config_data.get(
                 "exclude",
-                [] if Path(self.subdirectory) != Path(".") else DEFAULT_EXCLUDE,
+                DEFAULT_EXCLUDE if Path(self.subdirectory) == Path(".") else [],
             )
         )
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -643,6 +643,12 @@ The CLI option can be passed several times to add several patterns.
 
 !!! info
 
+    When the [`subdirectory`](#subdirectory) parameter is defined and its value is the
+    path of an actual subdirectory (i.e. not `""` or `"."` or `"./"`), then the default
+    value of the `exclude` parameter is `[]`.
+
+!!! info
+
     When you add this parameter from CLI or API, it will **not replace** the values
     defined in `copier.yml` (or the defaults, if missing).
 


### PR DESCRIPTION
I've changed the behavior of the default values of the [`exclude`](https://copier.readthedocs.io/en/latest/configuring/#exclude) list such that the default values are not applied when a subdirectory is specified in `copier.yml`. See https://github.com/copier-org/copier/issues/934#issuecomment-1407444680 for the original discussion.

Note that the default values remain active when the subdirectory is explicitly set to `""` or `"."` because I think this is identical to omitting the `subdirectory` setting and seems like a sensible behavior to me. WDYT, @yajo?

Also, I think it's actually a breaking change because the implicit behavior is changed and Copier template developers might need to add an explicit `exclude` list if they rely on the default values while using a subdirectory. Should this PR be held back until a major release is planned? WDYT, @yajo?