### PR TITLE
fix: Remove useless is_dir check

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -502,8 +502,6 @@ class Worker:
         else:
             new_content = src_abspath.read_bytes()
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
-        if dst_abspath.is_dir():
-            return
         src_mode = src_abspath.stat().st_mode
         if not self._render_allowed(
             dst_relpath,


### PR DESCRIPTION
This check is no longer needed after 7e0def672998 (fix: don't attempt to render a file if its name is empty) has been added. That commit also made this line no longer be covered by the tests.

This check made copier skip copying a file with an empty name (The path would then point to the directory containing the file).