### PR TITLE
fix: don't set YAML `!include` constructor globally

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -88,13 +88,16 @@ def load_template_config(conf_path: Path, quiet: bool = False) -> AnyByStrDict:
     Raises:
         InvalidConfigFileError: When the file is formatted badly.
     """
+    class _Loader(yaml.FullLoader):
+        ...
+
     YamlIncludeConstructor.add_to_loader_class(
-        loader_class=yaml.FullLoader, base_dir=conf_path.parent
+        loader_class=_Loader, base_dir=conf_path.parent
     )
 
     try:
         with open(conf_path) as f:
-            flattened_result = lflatten(yaml.load_all(f, Loader=yaml.FullLoader))
+            flattened_result = lflatten(yaml.load_all(f, Loader=_Loader))
             merged_options = defaultdict(list)
             for option in (
                 "_exclude",

--- a/copier/template.py
+++ b/copier/template.py
@@ -88,6 +88,7 @@ def load_template_config(conf_path: Path, quiet: bool = False) -> AnyByStrDict:
     Raises:
         InvalidConfigFileError: When the file is formatted badly.
     """
+
     class _Loader(yaml.FullLoader):
         ...
 

--- a/copier/template.py
+++ b/copier/template.py
@@ -90,7 +90,7 @@ def load_template_config(conf_path: Path, quiet: bool = False) -> AnyByStrDict:
     """
 
     class _Loader(yaml.FullLoader):
-        ...
+        """Intermediate class to avoid monkey-patching main loader."""
 
     YamlIncludeConstructor.add_to_loader_class(
         loader_class=_Loader, base_dir=conf_path.parent


### PR DESCRIPTION
I've fixed a potential race condition bug when using YAML includes in `copier.yml` when projects are generated in parallel in a single process, caused by registering a YAML `!include` constructor globally in the `yaml.FullLoader` class.

I'm not 100% sure whether this could actually cause a problem with CPython because multi-threading only parallelizes I/O-bound tasks, but I think my suggested improvement is safer in any case.

See the different behavior:

```python
from pprint import pprint

from yaml import FullLoader
from yamlinclude import YamlIncludeConstructor


class _Loader(FullLoader):
    ...


pprint(FullLoader.yaml_constructors)
# {...}
pprint(_Loader.yaml_constructors)
# {...}

YamlIncludeConstructor.add_to_loader_class(
    loader_class=_Loader, base_dir="/some/base/dir"
)

pprint(FullLoader.yaml_constructors)
# {...}
pprint(_Loader.yaml_constructors)
# {..., '!include': <yamlinclude.constructor.YamlIncludeConstructor object at 0x7f93ef7adb80>, ...}
```

As you can see, the `!include` constructor is only registered with the ephemeral `_Loader` loader and not with the imported `FullLoader` now.