### PR TITLE
refactor(typing): use `Mapping` instead of `ChainMap` type

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -12,7 +12,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
-    ChainMap as t_ChainMap,
     Dict,
     Mapping,
     Optional,
@@ -121,7 +120,7 @@ class AnswersMap:
     default: AnyByStrDict = field(default_factory=dict)
 
     @cached_property
-    def combined(self) -> t_ChainMap[str, Any]:
+    def combined(self) -> Mapping[str, Any]:
         """Answers combined from different sources, sorted by priority."""
         return ChainMap(
             self.local,


### PR DESCRIPTION
Just a minor typing change, but I think it's better to use `Mapping[str, Any]` instead of `t_ChainMap[str, Any]` as the return type of `AnswersMap.combined` because

1. the fact that a `ChainMap` is used to combine the answers data is an implementation detail, and
2. the combined answers data is only meant to be read and not updated which is enforced by the `Mapping` type at the type level.

As an esthetic side-effect, the import alias `ChainMap as t_ChainMap` is gone, too. :wink: