### PR TITLE
fix: require answer for questions without default value

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -31,6 +31,7 @@ from .subproject import Subproject
 from .template import Task, Template
 from .tools import Style, TemporaryDirectory, printf
 from .types import (
+    MISSING,
     AnyByStrDict,
     JSONSerializable,
     OptStr,
@@ -382,13 +383,14 @@ class Worker:
         for question in questions:
             # Display TUI and ask user interactively only without --defaults
             try:
-                new_answer = (
-                    question.get_default()
-                    if self.defaults
-                    else unsafe_prompt(
+                if self.defaults:
+                    new_answer = question.get_default()
+                    if new_answer is MISSING:
+                        raise ValueError(f'Question "{var_name}" is required')
+                else:
+                    new_answer = unsafe_prompt(
                         [question.get_questionary_structure()], answers=result.combined
                     )[question.var_name]
-                )
             except KeyboardInterrupt as err:
                 raise CopierAnswersInterrupt(result, question, self.template) from err
             previous_answer = result.combined.get(question.var_name)

--- a/copier/types.py
+++ b/copier/types.py
@@ -2,7 +2,17 @@
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Mapping, Optional, Sequence, TypeVar, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Mapping,
+    NewType,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 from pydantic.validators import path_validator
 
@@ -37,6 +47,8 @@ T = TypeVar("T")
 JSONSerializable = (dict, list, str, int, float, bool, type(None))
 VCSTypes = Literal["git"]
 Env = Mapping[str, str]
+MissingType = NewType("MissingType", object)
+MISSING = MissingType(object())
 
 
 class AllowArbitraryTypes:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -452,9 +452,6 @@ def load_answersfile_data(
 
 def cast_answer_type(answer: Any, type_fn: Callable) -> Any:
     """Cast answer to expected type."""
-    # Skip casting None into "None"
-    if type_fn is str and answer is None:
-        return answer
     try:
         return type_fn(answer)
     except (TypeError, AttributeError):

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -289,8 +289,6 @@ class Question:
 
     def filter_answer(self, answer) -> Any:
         """Cast the answer to the desired type."""
-        if answer == self.get_default_rendered():
-            return self.get_default()
         return cast_answer_type(answer, self.get_cast_fn())
 
     def get_message(self) -> str:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -31,7 +31,15 @@ from questionary.prompts.common import Choice
 
 from .errors import InvalidTypeError, UserMessageError
 from .tools import cast_str_to_bool, force_str_end
-from .types import AllowArbitraryTypes, AnyByStrDict, OptStr, OptStrOrPath, StrOrPath
+from .types import (
+    MISSING,
+    AllowArbitraryTypes,
+    AnyByStrDict,
+    MissingType,
+    OptStr,
+    OptStrOrPath,
+    StrOrPath,
+)
 
 # HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
 if sys.version_info >= (3, 8):
@@ -195,7 +203,7 @@ class Question:
     answers: AnswersMap
     jinja_env: SandboxedEnvironment
     choices: Union[Dict[Any, Any], Sequence[Any]] = field(default_factory=list)
-    default: Any = None
+    default: Any = MISSING
     help: str = ""
     multiline: Union[str, bool] = False
     placeholder: str = ""
@@ -229,11 +237,13 @@ class Question:
                 try:
                     result = self.answers.user_defaults[self.var_name]
                 except KeyError:
+                    if self.default is MISSING:
+                        return MISSING
                     result = self.render_value(self.default)
         result = cast_answer_type(result, cast_fn)
         return result
 
-    def get_default_rendered(self) -> Union[bool, str, Choice, None]:
+    def get_default_rendered(self) -> Union[bool, str, Choice, None, MissingType]:
         """Get default answer rendered for the questionary lib.
 
         The questionary lib expects some specific data types, and returns
@@ -243,6 +253,8 @@ class Question:
         This helper allows such usages.
         """
         default = self.get_default()
+        if default is MISSING:
+            return MISSING
         # If there are choices, return the one that matches the expressed default
         if self.choices:
             for choice in self._formatted_choices:
@@ -311,7 +323,6 @@ class Question:
         """Get the question in a format that the questionary lib understands."""
         lexer = None
         result: AnyByStrDict = {
-            "default": self.get_default_rendered(),
             "filter": self.filter_answer,
             "message": self.get_message(),
             "mouse_support": True,
@@ -319,10 +330,16 @@ class Question:
             "qmark": "🕵️" if self.secret else "🎤",
             "when": self.get_when,
         }
+        default = self.get_default_rendered()
+        if default is not MISSING:
+            result["default"] = default
         questionary_type = "input"
         type_name = self.get_type_name()
         if type_name == "bool":
             questionary_type = "confirm"
+            # For backwards compatibility
+            if default is MISSING:
+                result["default"] = False
         if self.choices:
             questionary_type = "select"
             result["choices"] = self._formatted_choices

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -681,7 +681,12 @@ Also don't ask questions to the user; just use default values
 -   CLI flags: `--defaults`
 -   Default value: `False`
 
-Use default answers to questions, which might be null if not specified.
+Use default answers to questions.
+
+!!! attention
+
+    Any question that does not have a default value must be answered
+    [via CLI/API](#data). Otherwise, an error is raised.
 
 !!! info
 

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -26,10 +26,6 @@ def template_path(tmp_path_factory) -> str:
 
                 round: 1st
 
-                # A str question without a default should default to None
-                str_question_without_default:
-                    type: str
-
                 # password_1 and password_2 must not appear in answers file
                 _secret_questions:
                     - password_1
@@ -76,7 +72,6 @@ def test_answersfile(template_path, tmp_path, answers_file):
     )
     log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "1st"
-    assert log["str_question_without_default"] is None
     assert "password_1" not in log
     assert "password_2" not in log
 
@@ -101,7 +96,6 @@ def test_answersfile(template_path, tmp_path, answers_file):
     )
     log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "2nd"
-    assert log["str_question_without_default"] is None
     assert "password_1" not in log
     assert "password_2" not in log
 
@@ -125,6 +119,5 @@ def test_answersfile(template_path, tmp_path, answers_file):
     )
     log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "2nd"
-    assert log["str_question_without_default"] is None
     assert "password_1" not in log
     assert "password_2" not in log

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -491,8 +491,7 @@ def test_required_question_without_data(
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yml": yaml.safe_dump(
+            (src / "copier.yml"): yaml.safe_dump(
                 {
                     "question": {
                         "type": type_name,
@@ -502,7 +501,7 @@ def test_required_question_without_data(
         }
     )
     with pytest.raises(ValueError, match='Question "question" is required'):
-        copier.copy(str(src), str(dst), defaults=True)
+        copier.copy(str(src), dst, defaults=True)
 
 
 @pytest.mark.parametrize(
@@ -532,4 +531,4 @@ def test_required_choice_question_without_data(
         }
     )
     with pytest.raises(ValueError, match='Question "question" is required'):
-        copier.copy(str(src), str(dst), defaults=True)
+        copier.copy(str(src), dst, defaults=True)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Dict, List, Mapping, Tuple, Union
+from typing import Any, Dict, List, Mapping, Tuple, Union
 
 import pexpect
 import pytest
@@ -502,7 +502,12 @@ def test_var_name_value_allowed(
         ("yaml", None),
     ],
 )
-def test_required_text_question(tmp_path_factory, spawn, type_name, expected_answer):
+def test_required_text_question(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    type_name: str,
+    expected_answer: Union[str, None, ValueError],
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
@@ -534,7 +539,9 @@ def test_required_text_question(tmp_path_factory, spawn, type_name, expected_ans
         }
 
 
-def test_required_bool_question(tmp_path_factory, spawn):
+def test_required_bool_question(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
@@ -573,8 +580,12 @@ def test_required_bool_question(tmp_path_factory, spawn):
     ],
 )
 def test_required_choice_question(
-    tmp_path_factory, spawn, type_name, choices, expected_answer
-):
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    type_name: str,
+    choices: List[Any],
+    expected_answer: Any,
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -489,9 +489,7 @@ def test_var_name_value_allowed(tmp_path_factory, spawn):
         ("yaml", None),
     ],
 )
-def test_text_question_without_default(
-    tmp_path_factory, spawn, type_name, expected_answer
-):
+def test_required_text_question(tmp_path_factory, spawn, type_name, expected_answer):
     template, subproject = (
         tmp_path_factory.mktemp("template"),
         tmp_path_factory.mktemp("subproject"),
@@ -503,7 +501,7 @@ def test_text_question_without_default(
                 {
                     "_envops": BRACKET_ENVOPS,
                     "_templates_suffix": SUFFIX_TMPL,
-                    "text_question_without_default": {"type": type_name},
+                    "question": {"type": type_name},
                 }
             ),
             template
@@ -511,7 +509,7 @@ def test_text_question_without_default(
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    expect_prompt(tui, "text_question_without_default", type_name)
+    expect_prompt(tui, "question", type_name)
     tui.expect_exact("")
     tui.sendline()
     if isinstance(expected_answer, ValueError):
@@ -522,11 +520,11 @@ def test_text_question_without_default(
         answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
         assert answers == {
             "_src_path": str(template),
-            "text_question_without_default": expected_answer,
+            "question": expected_answer,
         }
 
 
-def test_bool_question_without_default(tmp_path_factory, spawn):
+def test_required_bool_question(tmp_path_factory, spawn):
     template, subproject = (
         tmp_path_factory.mktemp("template"),
         tmp_path_factory.mktemp("subproject"),
@@ -538,7 +536,7 @@ def test_bool_question_without_default(tmp_path_factory, spawn):
                 {
                     "_envops": BRACKET_ENVOPS,
                     "_templates_suffix": SUFFIX_TMPL,
-                    "bool_question_without_default": {"type": "bool"},
+                    "question": {"type": "bool"},
                 }
             ),
             template
@@ -546,14 +544,14 @@ def test_bool_question_without_default(tmp_path_factory, spawn):
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    expect_prompt(tui, "bool_question_without_default", "bool")
+    expect_prompt(tui, "question", "bool")
     tui.expect_exact("(y/N)")
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
     assert answers == {
         "_src_path": str(template),
-        "bool_question_without_default": False,
+        "question": False,
     }
 
 
@@ -567,7 +565,7 @@ def test_bool_question_without_default(tmp_path_factory, spawn):
         ("yaml", ["- 1", "- 2", "- 3"], [1]),
     ],
 )
-def test_choice_question_without_default(
+def test_required_choice_question(
     tmp_path_factory, spawn, type_name, choices, expected_answer
 ):
     template, subproject = (
@@ -581,7 +579,7 @@ def test_choice_question_without_default(
                 {
                     "_envops": BRACKET_ENVOPS,
                     "_templates_suffix": SUFFIX_TMPL,
-                    "choice_question_without_default": {
+                    "question": {
                         "type": type_name,
                         "choices": choices,
                     },
@@ -592,11 +590,11 @@ def test_choice_question_without_default(
         }
     )
     tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
-    expect_prompt(tui, "choice_question_without_default", type_name)
+    expect_prompt(tui, "question", type_name)
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
     assert answers == {
         "_src_path": str(template),
-        "choice_question_without_default": expected_answer,
+        "question": expected_answer,
     }

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -503,67 +503,61 @@ def test_var_name_value_allowed(
     ],
 )
 def test_required_text_question(tmp_path_factory, spawn, type_name, expected_answer):
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yml": yaml.dump(
+            (src / "copier.yml"): yaml.dump(
                 {
                     "_envops": BRACKET_ENVOPS,
                     "_templates_suffix": SUFFIX_TMPL,
                     "question": {"type": type_name},
                 }
             ),
-            template
-            / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                "[[ _copier_answers|to_nice_yaml ]]"
+            ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question", type_name)
     tui.expect_exact("")
     tui.sendline()
     if isinstance(expected_answer, ValueError):
         tui.expect_exact(str(expected_answer))
-        assert not (subproject / ".copier-answers.yml").exists()
+        assert not (dst / ".copier-answers.yml").exists()
     else:
         tui.expect_exact(pexpect.EOF)
-        answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+        answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
         assert answers == {
-            "_src_path": str(template),
+            "_src_path": str(src),
             "question": expected_answer,
         }
 
 
 def test_required_bool_question(tmp_path_factory, spawn):
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yml": yaml.dump(
+            (src / "copier.yml"): yaml.dump(
                 {
                     "_envops": BRACKET_ENVOPS,
                     "_templates_suffix": SUFFIX_TMPL,
                     "question": {"type": "bool"},
                 }
             ),
-            template
-            / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                "[[ _copier_answers|to_nice_yaml ]]"
+            ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question", "bool")
     tui.expect_exact("(y/N)")
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers == {
-        "_src_path": str(template),
+        "_src_path": str(src),
         "question": False,
     }
 
@@ -581,14 +575,10 @@ def test_required_bool_question(tmp_path_factory, spawn):
 def test_required_choice_question(
     tmp_path_factory, spawn, type_name, choices, expected_answer
 ):
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yml": yaml.dump(
+            (src / "copier.yml"): yaml.dump(
                 {
                     "_envops": BRACKET_ENVOPS,
                     "_templates_suffix": SUFFIX_TMPL,
@@ -598,16 +588,17 @@ def test_required_choice_question(
                     },
                 }
             ),
-            template
-            / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                "[[ _copier_answers|to_nice_yaml ]]"
+            ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question", type_name)
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers == {
-        "_src_path": str(template),
+        "_src_path": str(src),
         "question": expected_answer,
     }

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -251,7 +251,7 @@ def test_templated_prompt_invalid(tmp_path_factory, questions, raises, returns):
             src / "result.jinja": "{{question}}",
         }
     )
-    worker = Worker(str(src), dst, defaults=True, overwrite=True)
+    worker = Worker(str(src), dst, data={"question": ""}, overwrite=True)
     if raises:
         with pytest.raises(raises):
             worker.run_copy()


### PR DESCRIPTION
I've fixed the behavior for questions without a default value when no answer is provided in the interactive questionnaire.

The new behavior is:

- `type: str` question: `""`
- `type: yaml` question: `None` (result of `yaml.safe_load("")`)
- `type: int`/`type: float`/`type: json` question: Validation error `Invalid input`
- `type: bool` question: `False` (implicit default)
- `choice: ...` question: The first choice (implicit default).

I think this new behavior is more intuitive and expected than the current one.

Fixes #355 #956.

Note: This PR does not change the behavior when the `--default` flag is passed because it is not yet clear how to deal with questions that lead to a validation error when no default value exists.