### PR TITLE
feat: validate answers given via CLI/API

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -375,18 +375,26 @@ class Worker:
         )
         questions: List[Question] = []
         for var_name, details in self.template.questions_data.items():
-            if var_name in result.init:
-                # Do not ask again
-                continue
-            questions.append(
-                Question(
-                    answers=result,
-                    ask_user=not self.defaults,
-                    jinja_env=self.jinja_env,
-                    var_name=var_name,
-                    **details,
-                )
+            question = Question(
+                answers=result,
+                ask_user=not self.defaults,
+                jinja_env=self.jinja_env,
+                var_name=var_name,
+                **details,
             )
+            if var_name in result.init:
+                answer = result.init[var_name]
+                # Try to parse the answer value.
+                question.parse_answer(answer)
+                # Try to validate the answer value if the question has a
+                # validator.
+                question.validate_answer(answer)
+                # At this point, the answer value is valid. Do not ask the
+                # question again.
+                continue
+
+            questions.append(question)
+
         for question in questions:
             # Display TUI and ask user interactively only without --defaults
             try:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -365,9 +365,8 @@ class Question:
 
     def validate_answer(self, answer) -> bool:
         """Validate user answer."""
-        cast_fn = self.get_cast_fn()
         try:
-            ans = cast_fn(answer)
+            ans = self.parse_answer(answer)
         except Exception:
             return False
 
@@ -411,6 +410,17 @@ class Question:
             return template.render({**self.answers.combined, **(extra_answers or {})})
         except UndefinedError as error:
             raise UserMessageError(str(error)) from error
+
+    def parse_answer(self, answer: Any) -> Any:
+        cast_fn = self.get_cast_fn()
+        ans = cast_answer_type(answer, cast_fn)
+        choice_values = {
+            cast_answer_type(choice.value, cast_fn)
+            for choice in self._formatted_choices
+        }
+        if choice_values and ans not in choice_values:
+            raise ValueError("Invalid choice")
+        return ans
 
 
 def parse_yaml_string(string: str) -> Any:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -412,6 +412,7 @@ class Question:
             raise UserMessageError(str(error)) from error
 
     def parse_answer(self, answer: Any) -> Any:
+        """Parse the answer according to the question's type."""
         cast_fn = self.get_cast_fn()
         ans = cast_answer_type(answer, cast_fn)
         choice_values = {


### PR DESCRIPTION
I've added support for validating answers provided via CLI (`--data` flag) and API (via `data` argument to `run_auto(...)`/`copy(...)`).

Closes #814.