### PR TITLE
refactor: remove useless code related to not asking a question

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -381,7 +381,6 @@ class Worker:
             questions.append(
                 Question(
                     answers=result,
-                    ask_user=not self.defaults,
                     jinja_env=self.jinja_env,
                     var_name=var_name,
                     **details,

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -197,7 +197,6 @@ class Question:
     choices: Union[Dict[Any, Any], Sequence[Any]] = field(default_factory=list)
     default: Any = None
     help: str = ""
-    ask_user: bool = False
     multiline: Union[str, bool] = False
     placeholder: str = ""
     secret: bool = False
@@ -381,13 +380,6 @@ class Question:
 
     def get_when(self, answers) -> bool:
         """Get skip condition for question."""
-        if (
-            # Skip on --defaults
-            not self.ask_user
-            # Skip on --data=this_question=some_answer
-            or self.var_name in self.answers.init
-        ):
-            return False
         when = self.when
         when = self.render_value(when)
         when = cast_answer_type(when, cast_str_to_bool)


### PR DESCRIPTION
I've removed some useless code related to not asking a question, i.e. not prompting, when (a) defaults are supposed be used (e.g. `--defaults` flag) or (b) the answer is provided via CLI (i.e. `--data` flag) or API (i.e. `data` argument passed to `run_auto(...)`/`copy(...)`). The removed code was about handling this case by setting `when` to `False`, but [it seems one must be careful with using `when` for purposes other than the intended one](https://github.com/copier-org/copier/discussions/678#discussioncomment-2822746), and [using defaults](https://github.com/copier-org/copier/blob/2201d0210a57cc4d88c1d5d2369b70ea4894e2a9/copier/main.py#L394-L395) and [using answers via CLI/API](https://github.com/copier-org/copier/blob/2201d0210a57cc4d88c1d5d2369b70ea4894e2a9/copier/main.py#L378-L380) is already handled elsewhere.