### PR TITLE
fix: --skip option is ignored

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -221,6 +221,7 @@ class CopierApp(cli.Application):
             defaults=self.force or self.defaults,
             overwrite=self.force or self.overwrite,
             pretend=self.pretend,
+            skip_if_exists=self.skip,
             quiet=self.quiet,
             src_path=src_path,
             vcs_ref=self.vcs_ref,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,3 +46,49 @@ def test_help():
 def test_python_run():
     cmd = [sys.executable, "-m", "copier", "--help-all"]
     assert subprocess.run(cmd, check=True).returncode == 0
+
+
+def test_skip_filenotexists(tmp_path, template_path):
+    run_result = CopierApp.run(
+        [
+            "--quiet",
+            "-a",
+            "altered-answers.yml",
+            "--overwrite",
+            "--skip=a.txt",
+            str(template_path),
+            str(tmp_path),
+        ],
+        exit=False,
+    )
+    a_txt = tmp_path / "a.txt"
+    assert run_result[1] == 0
+    assert a_txt.exists()
+    assert a_txt.is_file()
+    assert a_txt.read_text() == "EXAMPLE_CONTENT"
+    answers = yaml.safe_load((tmp_path / "altered-answers.yml").read_text())
+    assert answers["_src_path"] == str(template_path)
+
+
+def test_skip_fileexists(tmp_path, template_path):
+    a_txt = tmp_path / "a.txt"
+    with open(a_txt, "w") as f_a:
+        f_a.write("PREVIOUS_CONTENT")
+    run_result = CopierApp.run(
+        [
+            "--quiet",
+            "-a",
+            "altered-answers.yml",
+            "--overwrite",
+            "--skip=a.txt",
+            str(template_path),
+            str(tmp_path),
+        ],
+        exit=False,
+    )
+    assert run_result[1] == 0
+    assert a_txt.exists()
+    assert a_txt.is_file()
+    assert a_txt.read_text() == "PREVIOUS_CONTENT"
+    answers = yaml.safe_load((tmp_path / "altered-answers.yml").read_text())
+    assert answers["_src_path"] == str(template_path)


### PR DESCRIPTION
Command line option "--skip" currently does not work and is just ignored, because its value is not passed to Worker class.

