### PR TITLE
fix: skip tasks in pretend mode

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -651,7 +651,8 @@ class Worker:
             if not self.quiet:
                 # TODO Unify printing tools
                 print("")  # padding space
-            self._execute_tasks(self.template.tasks)
+            if not self.pretend:
+                self._execute_tasks(self.template.tasks)
         except Exception:
             if not was_existing and self.cleanup_on_error:
                 rmtree(self.subproject.local_abspath)
@@ -743,9 +744,10 @@ class Worker:
                     )
                     diff = diff_cmd("--inter-hunk-context=0")
             # Run pre-migration tasks
-            self._execute_tasks(
-                self.template.migration_tasks("before", self.subproject.template)
-            )
+            if not self.pretend:
+                self._execute_tasks(
+                    self.template.migration_tasks("before", self.subproject.template)
+                )
             self._uncached_copy()
             # Try to apply cached diff into final destination
             with local.cwd(self.subproject.local_abspath):
@@ -786,9 +788,10 @@ class Worker:
             _remove_old_files(self.subproject.local_abspath, compared)
 
         # Run post-migration tasks
-        self._execute_tasks(
-            self.template.migration_tasks("after", self.subproject.template)
-        )
+        if not self.pretend:
+            self._execute_tasks(
+                self.template.migration_tasks("after", self.subproject.template)
+            )
 
     def _uncached_copy(self):
         """Copy template to destination without using answer cache."""

--- a/copier/main.py
+++ b/copier/main.py
@@ -218,8 +218,6 @@ class Worker:
         Arguments:
             tasks: The list of tasks to run.
         """
-        if self.pretend:
-            return
         for i, task in enumerate(tasks):
             task_cmd = task.cmd
             if isinstance(task_cmd, str):
@@ -234,6 +232,8 @@ class Worker:
                     | f" > Running task {i + 1} of {len(tasks)}: {task_cmd}",
                     file=sys.stderr,
                 )
+            if self.pretend:
+                continue
             with local.cwd(self.subproject.local_abspath), local.env(**task.extra_env):
                 subprocess.run(task_cmd, shell=use_shell, check=True, env=local.env)
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -218,6 +218,8 @@ class Worker:
         Arguments:
             tasks: The list of tasks to run.
         """
+        if self.pretend:
+            return
         for i, task in enumerate(tasks):
             task_cmd = task.cmd
             if isinstance(task_cmd, str):
@@ -651,8 +653,7 @@ class Worker:
             if not self.quiet:
                 # TODO Unify printing tools
                 print("")  # padding space
-            if not self.pretend:
-                self._execute_tasks(self.template.tasks)
+            self._execute_tasks(self.template.tasks)
         except Exception:
             if not was_existing and self.cleanup_on_error:
                 rmtree(self.subproject.local_abspath)
@@ -744,10 +745,9 @@ class Worker:
                     )
                     diff = diff_cmd("--inter-hunk-context=0")
             # Run pre-migration tasks
-            if not self.pretend:
-                self._execute_tasks(
-                    self.template.migration_tasks("before", self.subproject.template)
-                )
+            self._execute_tasks(
+                self.template.migration_tasks("before", self.subproject.template)
+            )
             self._uncached_copy()
             # Try to apply cached diff into final destination
             with local.cwd(self.subproject.local_abspath):
@@ -788,10 +788,9 @@ class Worker:
             _remove_old_files(self.subproject.local_abspath, compared)
 
         # Run post-migration tasks
-        if not self.pretend:
-            self._execute_tasks(
-                self.template.migration_tasks("after", self.subproject.template)
-            )
+        self._execute_tasks(
+            self.template.migration_tasks("after", self.subproject.template)
+        )
 
     def _uncached_copy(self):
         """Copy template to destination without using answer cache."""

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -226,7 +226,7 @@ def test_prereleases(tmp_path: Path):
 
 
 def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
-    src, dst = tmp_path_factory.mktemp("src"), tmp_path_factory.mktemp("dst")
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
     # Build template in v1
     with local.cwd(src):
@@ -234,16 +234,18 @@ def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
         build_file_tree(
             {
                 "[[ _copier_conf.answers_file ]].jinja": "[[_copier_answers|to_nice_yaml]]",
-                "copier.yml": f"""
+                "copier.yml": (
+                    f"""\
                     _envops: {BRACKET_ENVOPS_JSON}
-                """,
+                    """
+                ),
             }
         )
         git("add", ".")
         git("commit", "-mv1")
         git("tag", "v1")
 
-    copy(str(src), str(dst))
+    copy(str(src), dst)
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["_commit"] == "v1"
 
@@ -257,7 +259,8 @@ def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
         build_file_tree(
             {
                 "[[ _copier_conf.answers_file ]].jinja": "[[_copier_answers|to_nice_yaml]]",
-                "copier.yml": f"""
+                "copier.yml": (
+                    f"""\
                     _envops: {BRACKET_ENVOPS_JSON}
                     _migrations:
                     -   version: v2
@@ -265,7 +268,8 @@ def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
                         -   touch v2-before.txt
                         after:
                         -   touch v2-after.txt
-                """,
+                    """
+                ),
             }
         )
         git("add", ".")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -225,7 +225,7 @@ def test_prereleases(tmp_path: Path):
         copy(dst_path=dst, defaults=True, overwrite=True)
 
 
-def test_pretend_mode(tmp_path_factory):
+def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = tmp_path_factory.mktemp("src"), tmp_path_factory.mktemp("dst")
 
     # Build template in v1

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -45,7 +45,7 @@ def test_copy_tasks(tmp_path, demo_template):
     assert (tmp_path / "pyfile").is_file()
 
 
-def test_pretend_mode(tmp_path_factory):
+def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = tmp_path_factory.mktemp("src"), tmp_path_factory.mktemp("dst")
     build_file_tree(
         {

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -50,7 +50,7 @@ def test_pretend_mode(tmp_path_factory):
     build_file_tree(
         {
             src
-            / "copier.yml": f"""
+            / "copier.yml": """
                 _tasks:
                     - touch created-by-task.txt
             """

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -46,15 +46,16 @@ def test_copy_tasks(tmp_path, demo_template):
 
 
 def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
-    src, dst = tmp_path_factory.mktemp("src"), tmp_path_factory.mktemp("dst")
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yml": """
+            (src / "copier.yml"): (
+                """
                 _tasks:
                     - touch created-by-task.txt
-            """
+                """
+            )
         }
     )
-    copier.copy(str(src), str(dst), pretend=True)
+    copier.copy(str(src), dst, pretend=True)
     assert not (dst / "created-by-task.txt").exists()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -43,3 +43,18 @@ def test_copy_tasks(tmp_path, demo_template):
     assert (tmp_path / "hello" / "world").exists()
     assert (tmp_path / "bye").is_file()
     assert (tmp_path / "pyfile").is_file()
+
+
+def test_pretend_mode(tmp_path_factory):
+    src, dst = tmp_path_factory.mktemp("src"), tmp_path_factory.mktemp("dst")
+    build_file_tree(
+        {
+            src
+            / "copier.yml": f"""
+                _tasks:
+                    - touch created-by-task.txt
+            """
+        }
+    )
+    copier.copy(str(src), str(dst), pretend=True)
+    assert not (dst / "created-by-task.txt").exists()


### PR DESCRIPTION
Copier now skips tasks execution in pretend mode as discussed in #950. I've extended the fix to also skip _migration_ tasks in pretend mode although they weren't explicitly mentioned in #950, but I think that is consistent behavior.

Fixes #950.