### PR TITLE
fix(cli): use `--conflict` flag only in `copier update` subcommand

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -82,7 +82,6 @@ class CopierApp(cli.Application):
 
     Attributes:
         answers_file: Set [answers_file][] option.
-        conflict: Set [conflict][] option.
         exclude: Set [exclude][] option.
         vcs_ref: Set [vcs_ref][] option.
         pretend: Set [pretend][] option.
@@ -128,15 +127,6 @@ class CopierApp(cli.Application):
         help=(
             "Update using this path (relative to `destination_path`) "
             "to find the answers file"
-        ),
-    )
-    conflict: cli.SwitchAttr = cli.SwitchAttr(
-        ["-o", "--conflict"],
-        cli.Set("rej", "inline"),
-        default="rej",
-        help=(
-            "Behavior on conflict: rej=Create .rej file, inline=inline conflict "
-            "markers (inline is still experimental)"
         ),
     )
     exclude: cli.SwitchAttr = cli.SwitchAttr(
@@ -225,7 +215,6 @@ class CopierApp(cli.Application):
             src_path=src_path,
             vcs_ref=self.vcs_ref,
             use_prereleases=self.prereleases,
-            conflict=self.conflict,
             **kwargs,
         )
 
@@ -315,6 +304,9 @@ class CopierUpdateSubApp(cli.Application):
 
     Use this subcommand to update an existing subproject from a template
     that supports updates.
+
+    Attributes:
+        conflict: Set [conflict][] option.
     """
 
     DESCRIPTION = "Update a copy from its original template"
@@ -331,6 +323,16 @@ class CopierUpdateSubApp(cli.Application):
         """
     )
 
+    conflict: cli.SwitchAttr = cli.SwitchAttr(
+        ["-o", "--conflict"],
+        cli.Set("rej", "inline"),
+        default="rej",
+        help=(
+            "Behavior on conflict: rej=Create .rej file, inline=inline conflict "
+            "markers (inline is still experimental)"
+        ),
+    )
+
     @handle_exceptions
     def main(self, destination_path: cli.ExistingDirectory = ".") -> int:
         """Call [run_update][copier.main.Worker.run_update].
@@ -345,6 +347,7 @@ class CopierUpdateSubApp(cli.Application):
         """
         self.parent._worker(
             dst_path=destination_path,
+            conflict=self.conflict,
         ).run_update()
         return 0
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -542,7 +542,7 @@ running `copier update`, this setting has no effect.
 ### `conflict`
 
 -   Format: `Literal["rej", "inline"]`
--   CLI flags: `-o`, `--conflict`
+-   CLI flags: `-o`, `--conflict` (only available in `copier update` subcommand)
 -   Default value: `rej`
 
 When updating a project, sometimes Copier doesn't know what to do with a diff code hunk.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,10 @@ def test_help():
     COPIER_CMD("--help-all")
 
 
+def test_update_help():
+    assert "-o, --conflict" in COPIER_CMD("update", "--help")
+
+
 def test_python_run():
     cmd = [sys.executable, "-m", "copier", "--help-all"]
     assert subprocess.run(cmd, check=True).returncode == 0


### PR DESCRIPTION
I've moved the `--conflict` flag to the `copier update` subcommand as mentioned in #865.

Fixes #865.