### PR TITLE
build: easier containerized pre-commit execution for friends without nix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ cmd = "mkdocs serve"
 help = "start local docs server"
 
 [tool.poe.tasks.lint]
-cmd = "pre-commit run --all-files"
+script = "devtasks:lint"
 help = "check (and auto-fix) style with pre-commit"
 
 [tool.poe.tasks.test]


### PR DESCRIPTION
`poe lint` now uses nix if available. Otherwise, it will try to use docker or podman, by downloading the nix image and running pre-commit nix-based from there.

Fixes https://github.com/copier-org/copier/issues/931.