### PR TITLE
refactor(tests): add type hints and clean up

### DIFF
--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ import textwrap
 from enum import Enum
 from hashlib import sha1
 from pathlib import Path
-from typing import Mapping, Optional, Protocol, Tuple, Union, cast
+from typing import Mapping, Optional, Tuple, Union, cast
 
 from pexpect.popen_spawn import PopenSpawn
 from plumbum import local
@@ -15,6 +15,12 @@ from prompt_toolkit.keys import Keys
 
 import copier
 from copier.types import OptStr, StrOrPath
+
+# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
+if sys.version_info >= (3, 8):
+    from typing import Protocol
+else:
+    from typing_extensions import Protocol
 
 PROJECT_TEMPLATE = Path(__file__).parent / "demo"
 

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -69,12 +69,15 @@ def test_answersfile(template_path: str, tmp_path: Path, answers_file: OptStr) -
         overwrite=True,
     )
     answers_file = answers_file or ".answers-file-changed-in-template.yml"
-    assert round_file.read_text() == dedent(
-        """\
-        It's the 1st round.
-        password_1=password one
-        password_2=password two
-        """
+    assert (
+        round_file.read_text()
+        == dedent(
+            """
+            It's the 1st round.
+            password_1=password one
+            password_2=password two
+            """
+        ).lstrip()
     )
     log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "1st"
@@ -91,12 +94,15 @@ def test_answersfile(template_path: str, tmp_path: Path, answers_file: OptStr) -
         defaults=True,
         overwrite=True,
     )
-    assert round_file.read_text() == dedent(
-        """\
-        It's the 2nd round.
-        password_1=password one
-        password_2=password two
-        """
+    assert (
+        round_file.read_text()
+        == dedent(
+            """
+            It's the 2nd round.
+            password_1=password one
+            password_2=password two
+            """
+        ).lstrip()
     )
     log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "2nd"
@@ -112,12 +118,15 @@ def test_answersfile(template_path: str, tmp_path: Path, answers_file: OptStr) -
         defaults=True,
         overwrite=True,
     )
-    assert round_file.read_text() == dedent(
-        """\
-        It's the 2nd round.
-        password_1=password one
-        password_2=password two
-        """
+    assert (
+        round_file.read_text()
+        == dedent(
+            """
+            It's the 2nd round.
+            password_1=password one
+            password_2=password two
+            """
+        ).lstrip()
     )
     log = load_answersfile_data(tmp_path, answers_file)
     assert log["round"] == "2nd"

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -10,7 +10,7 @@ def test_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and removes it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", dst, quiet=True)
+        copier.copy(str(Path("tests", "demo_cleanup")), dst, quiet=True)
     assert not dst.exists()
 
 
@@ -18,7 +18,9 @@ def test_do_not_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and keeps it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False)
+        copier.copy(
+            str(Path("tests", "demo_cleanup")), dst, quiet=True, cleanup_on_error=False
+        )
     assert dst.exists()
 
 
@@ -27,6 +29,11 @@ def test_no_cleanup_when_folder_existed(tmp_path: Path) -> None:
     preexisting_file = tmp_path / "something"
     preexisting_file.touch()
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=True)
+        copier.copy(
+            str(Path("tests", "demo_cleanup")),
+            tmp_path,
+            quiet=True,
+            cleanup_on_error=True,
+        )
     assert tmp_path.exists()
     assert preexisting_file.exists()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -10,7 +10,7 @@ def test_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and removes it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.copy(str(Path("tests", "demo_cleanup")), dst, quiet=True)
+        copier.copy("./tests/demo_cleanup", dst, quiet=True)
     assert not dst.exists()
 
 
@@ -18,9 +18,7 @@ def test_do_not_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and keeps it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.copy(
-            str(Path("tests", "demo_cleanup")), dst, quiet=True, cleanup_on_error=False
-        )
+        copier.copy("./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False)
     assert dst.exists()
 
 
@@ -29,11 +27,6 @@ def test_no_cleanup_when_folder_existed(tmp_path: Path) -> None:
     preexisting_file = tmp_path / "something"
     preexisting_file.touch()
     with pytest.raises(CalledProcessError):
-        copier.copy(
-            str(Path("tests", "demo_cleanup")),
-            tmp_path,
-            quiet=True,
-            cleanup_on_error=True,
-        )
+        copier.copy("./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=True)
     assert tmp_path.exists()
     assert preexisting_file.exists()

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from subprocess import CalledProcessError
 
 import pytest
@@ -5,28 +6,23 @@ import pytest
 import copier
 
 
-def test_cleanup(tmp_path):
+def test_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and removes it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
         copier.copy("./tests/demo_cleanup", dst, quiet=True)
-    assert not (dst).exists()
+    assert not dst.exists()
 
 
-def test_do_not_cleanup(tmp_path):
+def test_do_not_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and keeps it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.copy(
-            "./tests/demo_cleanup",
-            dst,
-            quiet=True,
-            cleanup_on_error=False,
-        )
-    assert (dst).exists()
+        copier.copy("./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False)
+    assert dst.exists()
 
 
-def test_no_cleanup_when_folder_existed(tmp_path):
+def test_no_cleanup_when_folder_existed(tmp_path: Path) -> None:
     """Copier will not delete a folder if it didn't create it."""
     preexisting_file = tmp_path / "something"
     preexisting_file.touch()

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -1,4 +1,5 @@
 import json
+from collections import deque
 from pathlib import Path
 from textwrap import dedent
 
@@ -191,9 +192,16 @@ def test_cli_interactive(template_path: str, tmp_path: Path, spawn: Spawn) -> No
     tui.sendline("- I'd love it")
     tui.send(Keyboard.Esc + Keyboard.Enter)
     expect_prompt(tui, "choose_list", "str", help="You see the value of the list items")
-    tui.expect_exact("first")
-    tui.expect_exact("second")
-    tui.expect_exact("third")
+    deque(
+        map(
+            tui.expect_exact,
+            [
+                "first",
+                "second",
+                "third",
+            ],
+        )
+    )
     tui.sendline()
     expect_prompt(
         tui,
@@ -201,21 +209,38 @@ def test_cli_interactive(template_path: str, tmp_path: Path, spawn: Spawn) -> No
         "str",
         help="You see the 1st tuple item, but I get the 2nd item as a result",
     )
-    tui.expect_exact("one")
-    tui.expect_exact("two")
-    tui.expect_exact("three")
+    deque(
+        map(
+            tui.expect_exact,
+            [
+                "one",
+                "two",
+                "three",
+            ],
+        )
+    )
     tui.sendline()
     expect_prompt(
         tui, "choose_dict", "str", help="You see the dict key, but I get the dict value"
     )
-    tui.expect_exact("one")
-    tui.expect_exact("two")
-    tui.expect_exact("three")
+    deque(
+        map(
+            tui.expect_exact,
+            [
+                "one",
+                "two",
+                "three",
+            ],
+        )
+    )
     tui.sendline()
     expect_prompt(tui, "choose_number", "float", help="This must be a number")
-    tui.expect_exact("-1.1")
-    tui.expect_exact("0")
-    tui.expect_exact("1")
+    deque(
+        map(
+            tui.expect_exact,
+            ["-1.1", "0", "1"],
+        )
+    )
     tui.sendline()
     expect_prompt(tui, "minutes_under_water", "int")
     tui.expect_exact("10")
@@ -397,14 +422,14 @@ def test_tui_inherited_default(
         "owner1": "example",
         "owner2": owner2,
     }
-    assert json.loads((dst / "answers.json").read_bytes()) == result
+    assert json.loads((dst / "answers.json").read_text()) == result
     with local.cwd(dst):
         git("init")
         git("add", "--all")
         git("commit", "--message", "init project")
     # After a forced update, answers stay the same
     run_update(dst, defaults=True, overwrite=True)
-    assert json.loads((dst / "answers.json").read_bytes()) == result
+    assert json.loads((dst / "answers.json").read_text()) == result
 
 
 def test_tui_typed_default(
@@ -434,7 +459,7 @@ def test_tui_typed_default(
     )
     tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     tui.expect_exact(pexpect.EOF)
-    assert json.loads((dst / "answers.json").read_bytes()) == {
+    assert json.loads((dst / "answers.json").read_text()) == {
         "_src_path": str(src),
         "test1": False,
         "test2": False,

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -1,15 +1,16 @@
 import json
-from collections import deque
 from pathlib import Path
 from textwrap import dedent
 
 import pexpect
 import pytest
 import yaml
+from pexpect.popen_spawn import PopenSpawn
 from plumbum import local
 from plumbum.cmd import git
 
 from copier import copy, run_auto, run_update
+from copier.types import OptStr
 
 from .helpers import (
     BRACKET_ENVOPS,
@@ -17,6 +18,7 @@ from .helpers import (
     COPIER_PATH,
     SUFFIX_TMPL,
     Keyboard,
+    Spawn,
     build_file_tree,
     expect_prompt,
 )
@@ -26,12 +28,12 @@ BLK_END = BRACKET_ENVOPS["block_end_string"]
 
 
 @pytest.fixture(scope="module")
-def template_path(tmp_path_factory) -> str:
+def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
     root = tmp_path_factory.mktemp("template")
     build_file_tree(
         {
-            root
-            / "copier.yml": f"""\
+            (root / "copier.yml"): (
+                f"""\
                 _templates_suffix: {SUFFIX_TMPL}
                 _envops: {BRACKET_ENVOPS_JSON}
                 love_me:
@@ -91,9 +93,10 @@ def template_path(tmp_path_factory) -> str:
                 # Simplified format is still supported
                 minutes_under_water: 10
                 optional_value: null
-            """,
-            root
-            / "results.txt.tmpl": """\
+                """
+            ),
+            (root / "results.txt.tmpl"): (
+                """\
                 love_me: [[love_me|tojson]]
                 your_name: [[your_name|tojson]]
                 your_age: [[your_age|tojson]]
@@ -106,13 +109,29 @@ def template_path(tmp_path_factory) -> str:
                 choose_number: [[choose_number|tojson]]
                 minutes_under_water: [[minutes_under_water|tojson]]
                 optional_value: [[optional_value|tojson]]
-            """,
+            """
+            ),
         }
     )
     return str(root)
 
 
-def test_api(tmp_path, template_path):
+def check_invalid(
+    tui: PopenSpawn,
+    name: str,
+    format: str,
+    invalid_value: str,
+    help: OptStr = None,
+    err: str = "Invalid input",
+):
+    """Check that invalid input is reported correctly"""
+    expect_prompt(tui, name, format, help)
+    tui.sendline(invalid_value)
+    tui.expect_exact(invalid_value)
+    tui.expect_exact(err)
+
+
+def test_api(template_path: str, tmp_path: Path) -> None:
     """Test copier correctly processes advanced questions and answers through API."""
     copy(
         template_path,
@@ -128,8 +147,7 @@ def test_api(tmp_path, template_path):
         defaults=True,
         overwrite=True,
     )
-    results_file = tmp_path / "results.txt"
-    assert results_file.read_text() == dedent(
+    assert (tmp_path / "results.txt").read_text() == dedent(
         """\
             love_me: false
             your_name: "LeChuck"
@@ -147,16 +165,8 @@ def test_api(tmp_path, template_path):
     )
 
 
-def test_cli_interactive(tmp_path, spawn, template_path):
+def test_cli_interactive(template_path: str, tmp_path: Path, spawn: Spawn) -> None:
     """Test copier correctly processes advanced questions and answers through CLI."""
-
-    def check_invalid(tui, name, format, invalid_value, help=None, err="Invalid input"):
-        """Check that invalid input is reported correctly"""
-        expect_prompt(tui, name, format, help)
-        tui.sendline(invalid_value)
-        tui.expect_exact(invalid_value)
-        tui.expect_exact(err)
-
     tui = spawn(COPIER_PATH + ("copy", template_path, str(tmp_path)), timeout=10)
     expect_prompt(tui, "love_me", "bool", help="I need to know it. Do you love me?")
     tui.send("y")
@@ -181,16 +191,9 @@ def test_cli_interactive(tmp_path, spawn, template_path):
     tui.sendline("- I'd love it")
     tui.send(Keyboard.Esc + Keyboard.Enter)
     expect_prompt(tui, "choose_list", "str", help="You see the value of the list items")
-    deque(
-        map(
-            tui.expect_exact,
-            [
-                "first",
-                "second",
-                "third",
-            ],
-        )
-    )
+    tui.expect_exact("first")
+    tui.expect_exact("second")
+    tui.expect_exact("third")
     tui.sendline()
     expect_prompt(
         tui,
@@ -198,38 +201,21 @@ def test_cli_interactive(tmp_path, spawn, template_path):
         "str",
         help="You see the 1st tuple item, but I get the 2nd item as a result",
     )
-    deque(
-        map(
-            tui.expect_exact,
-            [
-                "one",
-                "two",
-                "three",
-            ],
-        )
-    )
+    tui.expect_exact("one")
+    tui.expect_exact("two")
+    tui.expect_exact("three")
     tui.sendline()
     expect_prompt(
         tui, "choose_dict", "str", help="You see the dict key, but I get the dict value"
     )
-    deque(
-        map(
-            tui.expect_exact,
-            [
-                "one",
-                "two",
-                "three",
-            ],
-        )
-    )
+    tui.expect_exact("one")
+    tui.expect_exact("two")
+    tui.expect_exact("three")
     tui.sendline()
     expect_prompt(tui, "choose_number", "float", help="This must be a number")
-    deque(
-        map(
-            tui.expect_exact,
-            ["-1.1", "0", "1"],
-        )
-    )
+    tui.expect_exact("-1.1")
+    tui.expect_exact("0")
+    tui.expect_exact("1")
     tui.sendline()
     expect_prompt(tui, "minutes_under_water", "int")
     tui.expect_exact("10")
@@ -238,8 +224,7 @@ def test_cli_interactive(tmp_path, spawn, template_path):
     expect_prompt(tui, "optional_value", "yaml")
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
-    results_file = tmp_path / "results.txt"
-    assert results_file.read_text() == dedent(
+    assert (tmp_path / "results.txt").read_text() == dedent(
         """\
             love_me: true
             your_name: "Guybrush Threpwood"
@@ -257,7 +242,7 @@ def test_cli_interactive(tmp_path, spawn, template_path):
     )
 
 
-def test_api_str_data(tmp_path, template_path):
+def test_api_str_data(template_path: str, tmp_path: Path) -> None:
     """Test copier when all data comes as a string.
 
     This happens i.e. when using the --data CLI argument.
@@ -277,8 +262,7 @@ def test_api_str_data(tmp_path, template_path):
         defaults=True,
         overwrite=True,
     )
-    results_file = tmp_path / "results.txt"
-    assert results_file.read_text() == dedent(
+    assert (tmp_path / "results.txt").read_text() == dedent(
         """\
             love_me: "false"
             your_name: "LeChuck"
@@ -297,10 +281,9 @@ def test_api_str_data(tmp_path, template_path):
 
 
 def test_cli_interatively_with_flag_data_and_type_casts(
-    tmp_path: Path, spawn, template_path
+    template_path: str, tmp_path: Path, spawn: Spawn
 ):
     """Assert how choices work when copier is invoked with --data interactively."""
-    invalid = "Invalid input"
     tui = spawn(
         COPIER_PATH
         + (
@@ -318,20 +301,16 @@ def test_cli_interatively_with_flag_data_and_type_casts(
     tui.send("y")
     expect_prompt(tui, "your_name", "str", help="Please tell me your name.")
     tui.sendline("Guybrush Threpwood")
-    expect_prompt(tui, "your_age", "int", help="How old are you?")
-    tui.send("wrong your_age")
-    tui.expect_exact(invalid)
+    check_invalid(tui, "your_age", "int", "wrong your_age", help="How old are you?")
     tui.sendline()  # Does nothing, "wrong your_age still on screen"
     tui.send((Keyboard.Alt + Keyboard.Backspace) * 2)
     tui.sendline("22")
-    expect_prompt(tui, "your_height", "float", help="What's your height?")
-    tui.send("wrong your_height")
-    tui.expect_exact(invalid)
+    check_invalid(
+        tui, "your_height", "float", "wrong your_height", help="What's your height?"
+    )
     tui.send((Keyboard.Alt + Keyboard.Backspace) * 2)
     tui.sendline("1.56")
-    expect_prompt(tui, "more_json_info", "json")
-    tui.sendline('{"objective":')
-    tui.expect_exact(invalid)
+    check_invalid(tui, "more_json_info", "json", '{"objective":')
     tui.sendline('"be a pirate"}')
     tui.send(Keyboard.Esc + Keyboard.Enter)
     expect_prompt(tui, "anything_else", "yaml", help="Wanna give me any more info?")
@@ -364,15 +343,20 @@ def test_cli_interatively_with_flag_data_and_type_casts(
 
 
 @pytest.mark.parametrize(
-    "has_2_owners, owner2", ((True, "example2"), (False, "example"))
+    "has_2_owners, owner2", [(True, "example2"), (False, "example")]
 )
-def test_tui_inherited_default(tmp_path_factory, spawn, has_2_owners, owner2):
+def test_tui_inherited_default(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    has_2_owners: bool,
+    owner2: str,
+) -> None:
     """Make sure a template inherits default as expected."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yaml": """\
+            (src / "copier.yaml"): (
+                """\
                 owner1:
                     type: str
                 has_2_owners:
@@ -382,21 +366,20 @@ def test_tui_inherited_default(tmp_path_factory, spawn, has_2_owners, owner2):
                     type: str
                     default: "{{ owner1 }}"
                     when: "{{ has_2_owners }}"
-            """,
-            src
-            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
-            src / "answers.json.jinja": "{{ _copier_answers|to_nice_json }}",
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
+            (src / "answers.json.jinja"): "{{ _copier_answers|to_nice_json }}",
         }
     )
-    _git = git["-C", src]
-    _git("init")
-    _git("add", "--all")
-    _git("commit", "--message", "init template")
-    _git("tag", "1")
-    tui = spawn(
-        COPIER_PATH + ("copy", str(src), str(dst)),
-        timeout=10,
-    )
+    with local.cwd(src):
+        git("init")
+        git("add", "--all")
+        git("commit", "--message", "init template")
+        git("tag", "1")
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "owner1", "str")
     tui.sendline("example")
     expect_prompt(tui, "has_2_owners", "bool")
@@ -414,23 +397,25 @@ def test_tui_inherited_default(tmp_path_factory, spawn, has_2_owners, owner2):
         "owner1": "example",
         "owner2": owner2,
     }
-    assert json.load((dst / "answers.json").open()) == result
-    _git = git["-C", dst]
-    _git("init")
-    _git("add", "--all")
-    _git("commit", "--message", "init project")
+    assert json.loads((dst / "answers.json").read_bytes()) == result
+    with local.cwd(dst):
+        git("init")
+        git("add", "--all")
+        git("commit", "--message", "init project")
     # After a forced update, answers stay the same
     run_update(dst, defaults=True, overwrite=True)
-    assert json.load((dst / "answers.json").open()) == result
+    assert json.loads((dst / "answers.json").read_bytes()) == result
 
 
-def test_tui_typed_default(tmp_path_factory, spawn):
+def test_tui_typed_default(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+) -> None:
     """Make sure a template defaults are typed as expected."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yaml": """\
+            (src / "copier.yaml"): (
+                """\
                 test1:
                     type: bool
                     default: false
@@ -439,32 +424,32 @@ def test_tui_typed_default(tmp_path_factory, spawn):
                     type: bool
                     default: "{{ 'a' == 'b' }}"
                     when: false
-            """,
-            src
-            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
-            src / "answers.json.jinja": "{{ _copier_answers|to_nice_json }}",
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
+            (src / "answers.json.jinja"): "{{ _copier_answers|to_nice_json }}",
         }
     )
-    tui = spawn(
-        COPIER_PATH + ("copy", str(src), str(dst)),
-        timeout=10,
-    )
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     tui.expect_exact(pexpect.EOF)
-    result = {
+    assert json.loads((dst / "answers.json").read_bytes()) == {
         "_src_path": str(src),
         "test1": False,
         "test2": False,
     }
-    assert json.load((dst / "answers.json").open()) == result
 
 
-def test_selection_type_cast(tmp_path_factory, spawn):
+def test_selection_type_cast(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+) -> None:
     """Selection question with different types, properly casted."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yaml": """\
+            (src / "copier.yaml"): (
+                """\
                 postgres1: &pg
                     type: yaml
                     default: 10
@@ -483,14 +468,12 @@ def test_selection_type_cast(tmp_path_factory, spawn):
                         - [becomes array, "[one, 2, -3.0]"]
                 nulls2: *nulls
                 nulls3: *nulls
-            """,
-            src / "answers.json.jinja": "{{ _copier_answers|to_json }}",
+                """
+            ),
+            (src / "answers.json.jinja"): "{{ _copier_answers|to_json }}",
         }
     )
-    tui = spawn(
-        COPIER_PATH + ("copy", str(src), str(dst)),
-        timeout=10,
-    )
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(
         tui, "postgres1", "yaml", help="Which PostgreSQL version do you want to deploy?"
     )
@@ -521,24 +504,32 @@ def test_selection_type_cast(tmp_path_factory, spawn):
     }
 
 
-def test_multi_template_answers(tmp_path_factory):
+def test_multi_template_answers(tmp_path_factory: pytest.TempPathFactory) -> None:
     tpl1, tpl2, dst = map(tmp_path_factory.mktemp, map(str, range(3)))
     # Build 2 templates with different questions and answers file defaults
     build_file_tree(
         {
-            tpl1 / "copier.yml": "q1: a1",
-            tpl1
-            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
-            tpl2 / "copier.yml": "{_answers_file: two.yml, q2: a2}",
-            tpl2
-            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+            (tpl1 / "copier.yml"): "q1: a1",
+            (tpl1 / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
+            (tpl2 / "copier.yml"): (
+                """\
+                _answers_file: two.yml
+                q2: a2
+                """
+            ),
+            (tpl2 / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
         }
     )
     # Make them git-tracked
     for tpl in (tpl1, tpl2):
-        git("-C", tpl, "init")
-        git("-C", tpl, "add", "-A")
-        git("-C", tpl, "commit", "-m1")
+        with local.cwd(tpl):
+            git("init")
+            git("add", "-A")
+            git("commit", "-m1")
     with local.cwd(dst):
         # Apply template 1
         run_auto(str(tpl1), overwrite=True, defaults=True)
@@ -551,11 +542,11 @@ def test_multi_template_answers(tmp_path_factory):
         git("add", "-A")
         git("commit", "-m2")
         # Check contents
-        answers1 = yaml.safe_load(Path(".copier-answers.yml").open())
+        answers1 = yaml.safe_load(Path(".copier-answers.yml").read_bytes())
         assert answers1["_src_path"] == str(tpl1)
         assert answers1["q1"] == "a1"
         assert "q2" not in answers1
-        answers2 = yaml.safe_load(Path("two.yml").open())
+        answers2 = yaml.safe_load(Path("two.yml").read_bytes())
         assert answers2["_src_path"] == str(tpl2)
         assert answers2["q2"] == "a2"
         assert "q1" not in answers2

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -513,12 +513,7 @@ def test_multi_template_answers(tmp_path_factory: pytest.TempPathFactory) -> Non
             (tpl1 / "{{ _copier_conf.answers_file }}.jinja"): (
                 "{{ _copier_answers|to_nice_yaml }}"
             ),
-            (tpl2 / "copier.yml"): (
-                """\
-                _answers_file: two.yml
-                q2: a2
-                """
-            ),
+            (tpl2 / "copier.yml"): "{_answers_file: two.yml, q2: a2}",
             (tpl2 / "{{ _copier_conf.answers_file }}.jinja"): (
                 "{{ _copier_answers|to_nice_yaml }}"
             ),
@@ -542,11 +537,11 @@ def test_multi_template_answers(tmp_path_factory: pytest.TempPathFactory) -> Non
         git("add", "-A")
         git("commit", "-m2")
         # Check contents
-        answers1 = yaml.safe_load(Path(".copier-answers.yml").read_bytes())
+        answers1 = yaml.safe_load(Path(".copier-answers.yml").read_text())
         assert answers1["_src_path"] == str(tpl1)
         assert answers1["q1"] == "a1"
         assert "q2" not in answers1
-        answers2 = yaml.safe_load(Path("two.yml").read_bytes())
+        answers2 = yaml.safe_load(Path("two.yml").read_text())
         assert answers2["_src_path"] == str(tpl2)
         assert answers2["q2"] == "a2"
         assert "q1" not in answers2

--- a/tests/test_conditional_file_name.py
+++ b/tests/test_conditional_file_name.py
@@ -1,78 +1,57 @@
 from pytest import TempPathFactory
 
 import copier
-from tests.helpers import build_file_tree
+
+from .helpers import build_file_tree
 
 
-def test_render_conditional(tmp_path_factory: TempPathFactory):
+def test_render_conditional(tmp_path_factory: TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "{% if conditional %}file.txt{% endif %}.jinja": "This is {{ conditional.variable }}.",
+            (src / "{% if conditional %}file.txt{% endif %}.jinja"): (
+                "This is {{ conditional.variable }}."
+            ),
         }
     )
-    copier.run_auto(
-        str(src),
-        dst,
-        data={"conditional": {"variable": True}},
-    )
-
-    file_rendered = (dst / "file.txt").read_text()
-    file_expected = "This is True."
-    assert file_rendered == file_expected
+    copier.run_auto(str(src), dst, data={"conditional": {"variable": True}})
+    assert (dst / "file.txt").read_text() == "This is True."
 
 
-def test_dont_render_conditional(tmp_path_factory: TempPathFactory):
+def test_dont_render_conditional(tmp_path_factory: TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "{% if conditional %}file.txt{% endif %}.jinja": "This is {{ conditional.variable }}.",
+            (src / "{% if conditional %}file.txt{% endif %}.jinja"): (
+                "This is {{ conditional.variable }}."
+            ),
         }
     )
-    copier.run_auto(
-        str(src),
-        dst,
-    )
-
-    file_rendered = dst / "file.txt"
-    assert not file_rendered.exists()
+    copier.run_auto(str(src), dst)
+    assert not (dst / "file.txt").exists()
 
 
 def test_render_conditional_subdir(tmp_path_factory: TempPathFactory):
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "subdir"
-            / "{% if conditional %}file.txt{% endif %}.jinja": "This is {{ conditional.variable }}.",
+            (src / "subdir" / "{% if conditional %}file.txt{% endif %}.jinja"): (
+                "This is {{ conditional.variable }}."
+            ),
         }
     )
-    copier.run_auto(
-        str(src),
-        dst,
-        data={"conditional": {"variable": True}},
-    )
-
-    file_rendered = (dst / "subdir" / "file.txt").read_text()
-    file_expected = "This is True."
-    assert file_rendered == file_expected
+    copier.run_auto(str(src), dst, data={"conditional": {"variable": True}})
+    assert (dst / "subdir" / "file.txt").read_text() == "This is True."
 
 
 def test_dont_render_conditional_subdir(tmp_path_factory: TempPathFactory):
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "subdir"
-            / "{% if conditional %}file.txt{% endif %}.jinja": "This is a {{ conditional.variable }}.",
+            (src / "subdir" / "{% if conditional %}file.txt{% endif %}.jinja"): (
+                "This is a {{ conditional.variable }}."
+            ),
         }
     )
-    copier.run_auto(
-        str(src),
-        dst,
-    )
-
-    file_rendered = dst / "subdir" / "file.txt"
-    assert not file_rendered.exists()
+    copier.run_auto(str(src), dst)
+    assert not (dst / "subdir" / "file.txt").exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -256,7 +256,7 @@ def test_worker_good_data(tmp_path: Path) -> None:
         ),
         # func_args > user_data
         (
-            {"src_path": "tests/demo_data", "exclude": ["aaa"]},
+            {"src_path": str(Path("tests", "demo_data")), "exclude": ["aaa"]},
             ("exclude1", "exclude2", "aaa"),
         ),
     ],

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -221,7 +221,7 @@ def test_exclude_replaces(tmp_path_factory: pytest.TempPathFactory) -> None:
 
 
 def test_skip_if_exists(tmp_path: Path) -> None:
-    copier.copy("tests/demo_skip_dst", tmp_path)
+    copier.copy(str(Path("tests/demo_skip_dst")), tmp_path)
     copier.copy(
         str(Path("tests", "demo_skip_src")),
         tmp_path,

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -103,7 +103,7 @@ def test_copy_with_non_version_tags_and_vcs_ref(
     )
 
 
-def test_copy(tmp_path):
+def test_copy(tmp_path: Path) -> None:
     render(tmp_path)
 
     generated = (tmp_path / "pyproject.toml").read_text()

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -221,7 +221,7 @@ def test_exclude_replaces(tmp_path_factory: pytest.TempPathFactory) -> None:
 
 
 def test_skip_if_exists(tmp_path: Path) -> None:
-    copier.copy(str(Path("tests/demo_skip_dst")), tmp_path)
+    copier.copy(str(Path("tests", "demo_skip_dst")), tmp_path)
     copier.copy(
         str(Path("tests", "demo_skip_src")),
         tmp_path,

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,21 +1,21 @@
-import os
+import json
 import platform
 import stat
 import sys
 from contextlib import nullcontext as does_not_raise
 from pathlib import Path
+from typing import ContextManager
 
 import pytest
-import yaml
 from plumbum import local
 from plumbum.cmd import git
 from prompt_toolkit.validation import ValidationError
 
 import copier
 from copier import copy
+from copier.types import AnyByStrDict
 
 from .helpers import (
-    BRACKET_ENVOPS,
     BRACKET_ENVOPS_JSON,
     PROJECT_TEMPLATE,
     assert_file,
@@ -25,7 +25,7 @@ from .helpers import (
 )
 
 
-def test_project_not_found(tmp_path):
+def test_project_not_found(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
         copier.copy("foobar", tmp_path)
 
@@ -33,34 +33,33 @@ def test_project_not_found(tmp_path):
         copier.copy(__file__, tmp_path)
 
 
-def test_copy_with_non_version_tags(tmp_path_factory):
+def test_copy_with_non_version_tags(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    # Prepare repo bundle
-    repo = src / "repo"
-    repo.mkdir()
     build_file_tree(
         {
-            repo
-            / ".copier-answers.yml.jinja": """\
+            (src / ".copier-answers.yml.jinja"): (
+                """\
                 # Changes here will be overwritten by Copier
                 {{ _copier_answers|to_nice_yaml }}
-            """,
-            repo
-            / "copier.yaml": """\
+                """
+            ),
+            (src / "copier.yaml"): (
+                """\
                 _tasks:
                     - cat v1.txt
-            """,
-            repo / "v1.txt": "file only in v1",
+                """
+            ),
+            (src / "v1.txt"): "file only in v1",
         }
     )
-    with local.cwd(repo):
+    with local.cwd(src):
         git("init")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "test_tag.post23+deadbeef")
 
     copy(
-        str(repo),
+        str(src),
         dst,
         defaults=True,
         overwrite=True,
@@ -68,34 +67,35 @@ def test_copy_with_non_version_tags(tmp_path_factory):
     )
 
 
-def test_copy_with_non_version_tags_and_vcs_ref(tmp_path_factory):
+def test_copy_with_non_version_tags_and_vcs_ref(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    # Prepare repo bundle
-    repo = src / "repo"
-    repo.mkdir()
     build_file_tree(
         {
-            repo
-            / ".copier-answers.yml.jinja": """\
+            (src / ".copier-answers.yml.jinja"): (
+                """\
                 # Changes here will be overwritten by Copier
                 {{ _copier_answers|to_nice_yaml }}
-            """,
-            repo
-            / "copier.yaml": """\
+                """
+            ),
+            (src / "copier.yaml"): (
+                """\
                 _tasks:
                     - cat v1.txt
-            """,
-            repo / "v1.txt": "file only in v1",
+                """
+            ),
+            (src / "v1.txt"): "file only in v1",
         }
     )
-    with local.cwd(repo):
+    with local.cwd(src):
         git("init")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "test_tag.post23+deadbeef")
 
     copy(
-        str(repo),
+        str(src),
         dst,
         defaults=True,
         overwrite=True,
@@ -107,39 +107,38 @@ def test_copy(tmp_path):
     render(tmp_path)
 
     generated = (tmp_path / "pyproject.toml").read_text()
-    control = (Path(__file__).parent / "reference_files/pyproject.toml").read_text()
-    assert generated == control
+    expected = (
+        Path(__file__).parent / "reference_files" / "pyproject.toml"
+    ).read_text()
+    assert generated == expected
 
     assert_file(tmp_path, "doc", "mañana.txt")
     assert_file(tmp_path, "doc", "images", "nslogo.gif")
 
-    p1 = str(tmp_path / "awesome" / "hello.txt")
-    p2 = str(PROJECT_TEMPLATE / "[[ myvar ]]" / "hello.txt")
+    p1 = tmp_path / "awesome" / "hello.txt"
+    p2 = PROJECT_TEMPLATE / "[[ myvar ]]" / "hello.txt"
     assert filecmp.cmp(p1, p2)
 
-    with open(tmp_path / "README.txt") as readme:
-        assert readme.read() == "This is the README for Copier.\n"
+    assert (tmp_path / "README.txt").read_text() == "This is the README for Copier.\n"
 
-    p1 = str(tmp_path / "awesome.txt")
-    p2 = str(PROJECT_TEMPLATE / "[[ myvar ]].txt")
+    p1 = tmp_path / "awesome.txt"
+    p2 = PROJECT_TEMPLATE / "[[ myvar ]].txt"
     assert filecmp.cmp(p1, p2)
 
-    assert not os.path.exists(tmp_path / "[% if not py3 %]py2_only.py[% endif %]")
-    assert not os.path.exists(tmp_path / "[% if py3 %]py3_only.py[% endif %]")
-    assert not os.path.exists(tmp_path / "py2_only.py")
-    assert os.path.exists(tmp_path / "py3_only.py")
-    assert not os.path.exists(
+    assert not (tmp_path / "[% if not py3 %]py2_only.py[% endif %]").exists()
+    assert not (tmp_path / "[% if py3 %]py3_only.py[% endif %]").exists()
+    assert not (tmp_path / "py2_only.py").exists()
+    assert (tmp_path / "py3_only.py").exists()
+    assert not (
         tmp_path / "[% if not py3 %]py2_folder[% endif %]" / "thing.py"
-    )
-    assert not os.path.exists(
-        tmp_path / "[% if py3 %]py3_folder[% endif %]" / "thing.py"
-    )
-    assert not os.path.exists(tmp_path / "py2_folder" / "thing.py")
-    assert os.path.exists(tmp_path / "py3_folder" / "thing.py")
+    ).exists()
+    assert not (tmp_path / "[% if py3 %]py3_folder[% endif %]" / "thing.py").exists()
+    assert not (tmp_path / "py2_folder" / "thing.py").exists()
+    assert (tmp_path / "py3_folder" / "thing.py").exists()
 
 
 @pytest.mark.impure
-def test_copy_repo(tmp_path):
+def test_copy_repo(tmp_path: Path) -> None:
     copier.copy(
         "gh:copier-org/copier.git",
         tmp_path,
@@ -150,17 +149,17 @@ def test_copy_repo(tmp_path):
     assert (tmp_path / "README.md").exists()
 
 
-def test_default_exclude(tmp_path):
+def test_default_exclude(tmp_path: Path) -> None:
     render(tmp_path)
     assert not (tmp_path / ".svn").exists()
 
 
-def test_include_file(tmp_path):
+def test_include_file(tmp_path: Path) -> None:
     render(tmp_path, exclude=["!.svn"])
     assert_file(tmp_path, ".svn")
 
 
-def test_include_pattern(tmp_path):
+def test_include_pattern(tmp_path: Path) -> None:
     render(tmp_path, exclude=["!.*"])
     assert (tmp_path / ".svn").exists()
 
@@ -170,7 +169,7 @@ def test_include_pattern(tmp_path):
     reason="Mac claims to use UTF-8 filesystem, but behaves differently.",
     strict=True,
 )
-def test_exclude_file(tmp_path):
+def test_exclude_file(tmp_path: Path) -> None:
     print(f"Filesystem encoding is {sys.getfilesystemencoding()}")
     # This file name is b"man\xcc\x83ana.txt".decode()
     render(tmp_path, exclude=["mañana.txt"])
@@ -180,25 +179,30 @@ def test_exclude_file(tmp_path):
     assert (tmp_path / "doc" / "manana.txt").exists()
 
 
-def test_exclude_extends(tmp_path: Path):
+def test_exclude_extends(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Exclude argument extends the original exclusions instead of replacing them."""
-    src, dst = tmp_path / "src", tmp_path / "dst"
-    build_file_tree({src / "test.txt": "Test text", src / "test.json": '"test json"'})
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "test.txt": "Test text",
+            src / "test.json": '"test json"',
+        }
+    )
     # Convert to git repo
     with local.cwd(src):
         git("init")
         git("add", ".")
         git("commit", "-m", "hello world")
-    copier.copy(str(src), str(dst), exclude=["*.txt"])
+    copier.copy(str(src), dst, exclude=["*.txt"])
     assert (dst / "test.json").is_file()
     assert not (dst / "test.txt").exists()
     # .git exists in src, but not in dst because it is excluded by default
     assert not (dst / ".git").exists()
 
 
-def test_exclude_replaces(tmp_path: Path):
+def test_exclude_replaces(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Exclude in copier.yml replaces default values."""
-    src, dst = tmp_path / "src", tmp_path / "dst"
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
             src / "test.txt": "Test text",
@@ -208,7 +212,7 @@ def test_exclude_replaces(tmp_path: Path):
             src / "copier.yml": "_exclude: ['*.json']",
         }
     )
-    copier.copy(str(src), str(dst), exclude=["*.txt"])
+    copier.copy(str(src), dst, exclude=["*.txt"])
     assert (dst / "test.yaml").is_file()
     assert not (dst / "test.txt").exists()
     assert not (dst / "test.json").exists()
@@ -216,12 +220,12 @@ def test_exclude_replaces(tmp_path: Path):
     assert (dst / "copier.yaml").is_file()
 
 
-def test_skip_if_exists(tmp_path):
+def test_skip_if_exists(tmp_path: Path) -> None:
     copier.copy("tests/demo_skip_dst", tmp_path)
     copier.copy(
-        "tests/demo_skip_src",
+        str(Path("tests", "demo_skip_src")),
         tmp_path,
-        skip_if_exists=["b.noeof.txt", "meh/c.noeof.txt"],
+        skip_if_exists=["b.noeof.txt", str(Path("meh", "c.noeof.txt"))],
         defaults=True,
         overwrite=True,
     )
@@ -231,13 +235,13 @@ def test_skip_if_exists(tmp_path):
     assert (tmp_path / "meh" / "c.noeof.txt").read_text() == "SKIPPED"
 
 
-def test_skip_if_exists_rendered_patterns(tmp_path):
-    copier.copy("tests/demo_skip_dst", tmp_path)
+def test_skip_if_exists_rendered_patterns(tmp_path: Path) -> None:
+    copier.copy(str(Path("tests", "demo_skip_dst")), tmp_path)
     copier.copy(
-        "tests/demo_skip_src",
+        str(Path("tests", "demo_skip_src")),
         tmp_path,
         data={"name": "meh"},
-        skip_if_exists=["{{ name }}/c.noeof.txt"],
+        skip_if_exists=[str(Path("{{ name }}", "c.noeof.txt"))],
         defaults=True,
         overwrite=True,
     )
@@ -246,7 +250,7 @@ def test_skip_if_exists_rendered_patterns(tmp_path):
     assert (tmp_path / "meh" / "c.noeof.txt").read_text() == "SKIPPED"
 
 
-def test_skip_option(tmp_path):
+def test_skip_option(tmp_path: Path) -> None:
     render(tmp_path)
     path = tmp_path / "pyproject.toml"
     content = "lorem ipsum"
@@ -255,7 +259,7 @@ def test_skip_option(tmp_path):
     assert path.read_text() == content
 
 
-def test_force_option(tmp_path):
+def test_force_option(tmp_path: Path) -> None:
     render(tmp_path)
     path = tmp_path / "pyproject.toml"
     content = "lorem ipsum"
@@ -264,36 +268,35 @@ def test_force_option(tmp_path):
     assert path.read_text() != content
 
 
-def test_pretend_option(tmp_path):
+def test_pretend_option(tmp_path: Path) -> None:
     render(tmp_path, pretend=True)
     assert not (tmp_path / "doc").exists()
     assert not (tmp_path / "config.py").exists()
     assert not (tmp_path / "pyproject.toml").exists()
 
 
-@pytest.mark.parametrize("generate", (True, False))
-def test_empty_dir(tmp_path_factory, generate):
+@pytest.mark.parametrize("generate", [True, False])
+def test_empty_dir(tmp_path_factory: pytest.TempPathFactory, generate: bool) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yaml": f"""
+            (src / "copier.yaml"): (
+                f"""\
                 _subdirectory: tpl
                 _templates_suffix: .jinja
                 _envops: {BRACKET_ENVOPS_JSON}
                 do_it:
                     type: bool
-            """,
-            src
-            / "tpl"
-            / "[% if do_it %]one_dir[% endif %]"
-            / "one.txt.jinja": "[[ do_it ]]",
-            src / "tpl" / "two.txt": "[[ do_it ]]",
-            src / "tpl" / "[% if do_it %]three.txt[% endif %].jinja": "[[ do_it ]]",
-            src
-            / "tpl"
-            / "four"
-            / "[% if do_it %]five.txt[% endif %].jinja": "[[ do_it ]]",
+                """
+            ),
+            (src / "tpl" / "[% if do_it %]one_dir[% endif %]" / "one.txt.jinja"): (
+                "[[ do_it ]]"
+            ),
+            (src / "tpl" / "two.txt"): "[[ do_it ]]",
+            (src / "tpl" / "[% if do_it %]three.txt[% endif %].jinja"): "[[ do_it ]]",
+            (src / "tpl" / "four" / "[% if do_it %]five.txt[% endif %].jinja"): (
+                "[[ do_it ]]"
+            ),
         },
     )
     copier.run_copy(str(src), dst, {"do_it": generate}, defaults=True, overwrite=True)
@@ -315,62 +318,55 @@ def test_empty_dir(tmp_path_factory, generate):
 )
 @pytest.mark.parametrize(
     "permissions",
-    (
+    [
         stat.S_IRUSR,
         stat.S_IRWXU,
         stat.S_IRWXU | stat.S_IRWXG,
         stat.S_IRWXU | stat.S_IRWXO,
         stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO,
-    ),
+    ],
 )
 def test_preserved_permissions(
     tmp_path_factory: pytest.TempPathFactory, permissions: int
-):
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     src_file = src / "the_file"
     src_file.write_text("content")
     src_file.chmod(permissions)
     copier.run_copy(str(src), dst, defaults=True, overwrite=True)
-    dst_file = dst / "the_file"
-    assert (dst_file.stat().st_mode & permissions) == permissions
+    assert ((dst / "the_file").stat().st_mode & permissions) == permissions
 
 
-def test_commit_hash(src_repo, tmp_path):
-    build_file_tree(
-        {
-            src_repo / "commit.jinja": "{{_copier_conf.vcs_ref_hash}}",
-            src_repo / "tag.jinja": "{{_copier_answers._commit}}",
-        }
-    )
-    src_git = git["-C", src_repo]
-    src_git("add", "-A")
-    src_git("commit", "-m1")
-    src_git("tag", "1.0")
-    commit = src_git("rev-parse", "HEAD").strip()
-    copier.run_copy(str(src_repo), tmp_path)
-    assert tmp_path.joinpath("tag").read_text() == "1.0"
-    assert tmp_path.joinpath("commit").read_text() == commit
-
-
-def test_value_with_forward_slash(tmp_path_factory):
+def test_commit_hash(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "{{ filename.replace('.', _copier_conf.sep) }}.txt": "This is template.",
+            src / "commit.jinja": "{{_copier_conf.vcs_ref_hash}}",
+            src / "tag.jinja": "{{_copier_answers._commit}}",
         }
     )
-    copier.run_auto(
-        str(src),
-        dst,
-        data={
-            "filename": "a.b.c",
-        },
-    )
+    with local.cwd(src):
+        git("init")
+        git("add", "-A")
+        git("commit", "-m1")
+        git("tag", "1.0")
+        commit = git("rev-parse", "HEAD").strip()
+    copier.run_copy(str(src), dst)
+    assert (dst / "tag").read_text() == "1.0"
+    assert (dst / "commit").read_text() == commit
 
-    file_rendered = (dst / "a" / "b" / "c.txt").read_text()
-    file_expected = "This is template."
-    assert file_rendered == file_expected
+
+def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "{{ filename.replace('.', _copier_conf.sep) }}.txt"): (
+                "This is template."
+            ),
+        }
+    )
+    copier.run_auto(str(src), dst, data={"filename": "a.b.c"})
+    assert (dst / "a" / "b" / "c.txt").read_text() == "This is template."
 
 
 @pytest.mark.parametrize(
@@ -469,19 +465,23 @@ def test_value_with_forward_slash(tmp_path_factory):
         ),
     ],
 )
-def test_validate_init_data(tmp_path_factory, spec, value, expected):
+def test_validate_init_data(
+    tmp_path_factory: pytest.TempPathFactory,
+    spec: AnyByStrDict,
+    value: str,
+    expected: ContextManager[None],
+):
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yml": yaml.dump(
-                {
-                    "_envops": BRACKET_ENVOPS,
-                    "_templates_suffix": ".jinja",
-                    "q": spec,
-                }
+            (src / "copier.yml"): (
+                f"""\
+                _envops: {BRACKET_ENVOPS_JSON}
+                _templates_suffix: .jinja
+                q: {json.dumps(spec)}
+                """
             ),
         }
     )
     with expected:
-        copier.copy(str(src), str(dst), data={"q": value})
+        copier.copy(str(src), dst, data={"q": value})

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,4 +1,3 @@
-import json
 import platform
 import stat
 import sys
@@ -7,6 +6,7 @@ from pathlib import Path
 from typing import ContextManager
 
 import pytest
+import yaml
 from plumbum import local
 from plumbum.cmd import git
 from prompt_toolkit.validation import ValidationError
@@ -16,6 +16,7 @@ from copier import copy
 from copier.types import AnyByStrDict
 
 from .helpers import (
+    BRACKET_ENVOPS,
     BRACKET_ENVOPS_JSON,
     PROJECT_TEMPLATE,
     assert_file,
@@ -107,10 +108,8 @@ def test_copy(tmp_path: Path) -> None:
     render(tmp_path)
 
     generated = (tmp_path / "pyproject.toml").read_text()
-    expected = (
-        Path(__file__).parent / "reference_files" / "pyproject.toml"
-    ).read_text()
-    assert generated == expected
+    control = (Path(__file__).parent / "reference_files" / "pyproject.toml").read_text()
+    assert generated == control
 
     assert_file(tmp_path, "doc", "mañana.txt")
     assert_file(tmp_path, "doc", "images", "nslogo.gif")
@@ -474,12 +473,12 @@ def test_validate_init_data(
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            (src / "copier.yml"): (
-                f"""\
-                _envops: {BRACKET_ENVOPS_JSON}
-                _templates_suffix: .jinja
-                q: {json.dumps(spec)}
-                """
+            (src / "copier.yml"): yaml.dump(
+                {
+                    "_envops": BRACKET_ENVOPS,
+                    "_templates_suffix": ".jinja",
+                    "q": spec,
+                }
             ),
         }
     )

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -181,12 +181,7 @@ def test_exclude_file(tmp_path: Path) -> None:
 def test_exclude_extends(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Exclude argument extends the original exclusions instead of replacing them."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            src / "test.txt": "Test text",
-            src / "test.json": '"test json"',
-        }
-    )
+    build_file_tree({src / "test.txt": "Test text", src / "test.json": '"test json"'})
     # Convert to git repo
     with local.cwd(src):
         git("init")
@@ -222,7 +217,7 @@ def test_exclude_replaces(tmp_path_factory: pytest.TempPathFactory) -> None:
 def test_skip_if_exists(tmp_path: Path) -> None:
     copier.copy(str(Path("tests", "demo_skip_dst")), tmp_path)
     copier.copy(
-        str(Path("tests", "demo_skip_src")),
+        "tests/demo_skip_src",
         tmp_path,
         skip_if_exists=["b.noeof.txt", "meh/c.noeof.txt"],
         defaults=True,
@@ -235,9 +230,9 @@ def test_skip_if_exists(tmp_path: Path) -> None:
 
 
 def test_skip_if_exists_rendered_patterns(tmp_path: Path) -> None:
-    copier.copy(str(Path("tests", "demo_skip_dst")), tmp_path)
+    copier.copy("tests/demo_skip_dst", tmp_path)
     copier.copy(
-        str(Path("tests", "demo_skip_src")),
+        "tests/demo_skip_src",
         tmp_path,
         data={"name": "meh"},
         skip_if_exists=["{{ name }}/c.noeof.txt"],
@@ -317,13 +312,13 @@ def test_empty_dir(tmp_path_factory: pytest.TempPathFactory, generate: bool) -> 
 )
 @pytest.mark.parametrize(
     "permissions",
-    [
+    (
         stat.S_IRUSR,
         stat.S_IRWXU,
         stat.S_IRWXU | stat.S_IRWXG,
         stat.S_IRWXU | stat.S_IRWXO,
         stat.S_IRWXU | stat.S_IRWXG | stat.S_IRWXO,
-    ],
+    ),
 )
 def test_preserved_permissions(
     tmp_path_factory: pytest.TempPathFactory, permissions: int

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -225,7 +225,7 @@ def test_skip_if_exists(tmp_path: Path) -> None:
     copier.copy(
         str(Path("tests", "demo_skip_src")),
         tmp_path,
-        skip_if_exists=["b.noeof.txt", str(Path("meh", "c.noeof.txt"))],
+        skip_if_exists=["b.noeof.txt", "meh/c.noeof.txt"],
         defaults=True,
         overwrite=True,
     )
@@ -241,7 +241,7 @@ def test_skip_if_exists_rendered_patterns(tmp_path: Path) -> None:
         str(Path("tests", "demo_skip_src")),
         tmp_path,
         data={"name": "meh"},
-        skip_if_exists=[str(Path("{{ name }}", "c.noeof.txt"))],
+        skip_if_exists=["{{ name }}/c.noeof.txt"],
         defaults=True,
         overwrite=True,
     )

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 from shutil import copy2, copytree
 
@@ -13,14 +12,14 @@ from copier.main import run_copy, run_update
 from .helpers import DATA, PROJECT_TEMPLATE, build_file_tree
 
 
-def test_copy(tmp_path_factory):
-    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+def test_copy(tmp_path: Path) -> None:
+    src, dst = tmp_path / "src", tmp_path / "dst"
 
     # dirs_exist_ok not available in Python 3.7
-    for item in os.listdir(PROJECT_TEMPLATE):
-        item_src_path = os.path.join(PROJECT_TEMPLATE, item)
-        item_dst_path = os.path.join(src, item)
-        if os.path.isdir(item_src_path):
+    for item in PROJECT_TEMPLATE.iterdir():
+        item_src_path = item
+        item_dst_path = src / item.name
+        if item_src_path.is_dir():
             copytree(item_src_path, item_dst_path)
         else:
             copy2(item_src_path, item_dst_path)
@@ -29,40 +28,38 @@ def test_copy(tmp_path_factory):
         git("init")
 
     with pytest.warns(DirtyLocalWarning):
-        copier.copy(str(src), str(dst), data=DATA, quiet=True)
+        copier.copy(str(src), dst, data=DATA, quiet=True)
 
     generated = (dst / "pyproject.toml").read_text()
-    control = (Path(__file__).parent / "reference_files" / "pyproject.toml").read_text()
-    assert generated == control
+    expected = (
+        Path(__file__).parent / "reference_files" / "pyproject.toml"
+    ).read_text()
+    assert generated == expected
 
     # assert template still dirty
     with local.cwd(src):
         assert bool(git("status", "--porcelain").strip())
 
 
-def test_update(tmp_path_factory):
+def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
     build_file_tree(
         {
-            src
-            / ".copier-answers.yml.jinja": """\
+            (src / ".copier-answers.yml.jinja"): (
+                """\
                 # Changes here will be overwritten by Copier
                 {{ _copier_answers|to_nice_yaml }}
-            """,
-            src
-            / "copier.yml": """\
+                """
+            ),
+            (src / "copier.yml"): (
+                """\
                 _envops:
                     "keep_trailing_newline": True
-            """,
-            src
-            / "aaaa.txt": """
-                Lorem ipsum
-            """,
-            src
-            / "to_delete.txt": """
-                delete me.
-            """,
+                """
+            ),
+            (src / "aaaa.txt"): "Lorem ipsum",
+            (src / "to_delete.txt"): "delete me.",
         }
     )
 
@@ -75,15 +72,14 @@ def test_update(tmp_path_factory):
 
     with local.cwd(src):
         # test adding a file
-        with open("test_file.txt", "w") as f:
-            f.write("Test content")
+        Path("test_file.txt").write_text("Test content")
 
         # test updating a file
         with open("aaaa.txt", "a") as f:
             f.write("dolor sit amet")
 
         # test removing a file
-        os.remove("to_delete.txt")
+        Path("to_delete.txt").unlink()
 
     # dst must be vcs-tracked to use run_update
     with local.cwd(dst):
@@ -92,24 +88,20 @@ def test_update(tmp_path_factory):
         git("commit", "-m", "first commit on dst")
 
     # make sure changes have not yet propagated
-    assert not os.path.exists(dst / "test_file.txt")
+    assert not (dst / "test_file.txt").exists()
 
-    p1 = src / "aaaa.txt"
-    p2 = dst / "aaaa.txt"
-    assert p1.read_text() != p2.read_text()
+    assert (src / "aaaa.txt").read_text() != (dst / "aaaa.txt").read_text()
 
-    assert os.path.exists(dst / "to_delete.txt")
+    assert (dst / "to_delete.txt").exists()
 
     with pytest.warns(DirtyLocalWarning):
         run_update(dst, defaults=True, overwrite=True)
 
     # make sure changes propagate after update
-    assert os.path.exists(dst / "test_file.txt")
+    assert (dst / "test_file.txt").exists()
 
-    p1 = src / "aaaa.txt"
-    p2 = dst / "aaaa.txt"
-    assert p1.read_text() == p2.read_text()
+    assert (src / "aaaa.txt").read_text() == (dst / "aaaa.txt").read_text()
 
     # HACK https://github.com/copier-org/copier/issues/461
     # TODO test file deletion on update
-    # assert not os.path.exists(dst / "to_delete.txt")
+    # assert not (dst / "to_delete.txt").exists()

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -31,10 +31,8 @@ def test_copy(tmp_path_factory: pytest.TempPathFactory) -> None:
         copier.copy(str(src), dst, data=DATA, quiet=True)
 
     generated = (dst / "pyproject.toml").read_text()
-    expected = (
-        Path(__file__).parent / "reference_files" / "pyproject.toml"
-    ).read_text()
-    assert generated == expected
+    control = (Path(__file__).parent / "reference_files" / "pyproject.toml").read_text()
+    assert generated == control
 
     # assert template still dirty
     with local.cwd(src):
@@ -58,8 +56,16 @@ def test_update(tmp_path_factory: pytest.TempPathFactory) -> None:
                     "keep_trailing_newline": True
                 """
             ),
-            (src / "aaaa.txt"): "Lorem ipsum",
-            (src / "to_delete.txt"): "delete me.",
+            (src / "aaaa.txt"): (
+                """
+                Lorem ipsum
+                """
+            ),
+            (src / "to_delete.txt"): (
+                """
+                delete me.
+                """
+            ),
         }
     )
 

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -12,8 +12,8 @@ from copier.main import run_copy, run_update
 from .helpers import DATA, PROJECT_TEMPLATE, build_file_tree
 
 
-def test_copy(tmp_path: Path) -> None:
-    src, dst = tmp_path / "src", tmp_path / "dst"
+def test_copy(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
     # dirs_exist_ok not available in Python 3.7
     for item in PROJECT_TEMPLATE.iterdir():

--- a/tests/test_empty_suffix.py
+++ b/tests/test_empty_suffix.py
@@ -6,10 +6,10 @@ from .helpers import build_file_tree
 
 
 def test_empty_suffix(tmp_path_factory: pytest.TempPathFactory) -> None:
-    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    root, dest = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            (src / "copier.yaml"): (
+            (root / "copier.yaml"): (
                 """\
                 _templates_suffix: ""
                 name:
@@ -17,30 +17,30 @@ def test_empty_suffix(tmp_path_factory: pytest.TempPathFactory) -> None:
                     default: pingu
                 """
             ),
-            (src / "render_me"): "Hello {{name}}!",
-            (src / "{{name}}.txt"): "Hello {{name}}!",
-            (src / "{{name}}" / "render_me.txt"): "Hello {{name}}!",
+            (root / "render_me"): "Hello {{name}}!",
+            (root / "{{name}}.txt"): "Hello {{name}}!",
+            (root / "{{name}}" / "render_me.txt"): "Hello {{name}}!",
         }
     )
-    copier.copy(str(src), dst, defaults=True, overwrite=True)
+    copier.copy(str(root), dest, defaults=True, overwrite=True)
 
-    assert not (dst / "copier.yaml").exists()
+    assert not (dest / "copier.yaml").exists()
 
-    assert (dst / "render_me").exists()
-    assert (dst / "pingu.txt").exists()
-    assert (dst / "pingu" / "render_me.txt").exists()
+    assert (dest / "render_me").exists()
+    assert (dest / "pingu.txt").exists()
+    assert (dest / "pingu" / "render_me.txt").exists()
 
     expected = "Hello pingu!"
-    assert (dst / "render_me").read_text() == expected
-    assert (dst / "pingu.txt").read_text() == expected
-    assert (dst / "pingu" / "render_me.txt").read_text() == expected
+    assert (dest / "render_me").read_text() == expected
+    assert (dest / "pingu.txt").read_text() == expected
+    assert (dest / "pingu" / "render_me.txt").read_text() == expected
 
 
 def test_binary_file_fallback_to_copy(tmp_path_factory: pytest.TempPathFactory) -> None:
-    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    root, dest = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            (src / "copier.yaml"): (
+            (root / "copier.yaml"): (
                 """\
                 _templates_suffix: ""
                 name:
@@ -48,13 +48,13 @@ def test_binary_file_fallback_to_copy(tmp_path_factory: pytest.TempPathFactory) 
                     default: pingu
                 """
             ),
-            (src / "logo.png"): (
+            (root / "logo.png"): (
                 b"\x89PNG\r\n\x1a\n\x00\rIHDR\x00\xec\n{{name}}\n\x00\xec"
             ),
         }
     )
-    copier.copy(str(src), dst, defaults=True, overwrite=True)
-    logo = dst / "logo.png"
+    copier.copy(str(root), dest, defaults=True, overwrite=True)
+    logo = dest / "logo.png"
     assert logo.exists()
     logo_bytes = logo.read_bytes()
     assert b"{{name}}" in logo_bytes

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -30,12 +30,7 @@ def test_exclude_recursive_negate(tmp_path: Path) -> None:
 
 def test_config_exclude(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            src / "copier.yml": "_exclude: ['*.txt']",
-            src / "aaaa.txt": "",
-        }
-    )
+    build_file_tree({src / "copier.yml": "_exclude: ['*.txt']", src / "aaaa.txt": ""})
     run_auto(str(src), dst, quiet=True)
     assert not (dst / "aaaa.txt").exists()
     assert (dst / "copier.yml").exists()
@@ -43,12 +38,7 @@ def test_config_exclude(tmp_path_factory: pytest.TempPathFactory) -> None:
 
 def test_config_exclude_extended(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            src / "copier.yml": "_exclude: ['*.txt']",
-            src / "aaaa.txt": "",
-        }
-    )
+    build_file_tree({src / "copier.yml": "_exclude: ['*.txt']", src / "aaaa.txt": ""})
     run_auto(str(src), dst, quiet=True, exclude=["*.yml"])
     assert not (dst / "aaaa.txt").exists()
     assert not (dst / "copier.yml").exists()
@@ -57,10 +47,7 @@ def test_config_exclude_extended(tmp_path_factory: pytest.TempPathFactory) -> No
 def test_config_include(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
-        {
-            src / "copier.yml": "_exclude: ['!.svn']",
-            src / ".svn" / "hello": "",
-        }
+        {src / "copier.yml": "_exclude: ['!.svn']", src / ".svn" / "hello": ""}
     )
     run_auto(str(src), dst, quiet=True)
     assert (dst / ".svn" / "hello").exists()
@@ -129,30 +116,19 @@ def test_config_exclude_with_subdirectory(
 
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
-        {
-            src / "copier.yml": "_subdirectory: '.'",
-            src / "template" / "copier.yml": "",
-        }
+        {src / "copier.yml": "_subdirectory: '.'", src / "template" / "copier.yml": ""}
     )
     run_auto(str(src), dst, quiet=True)
     assert not (dst / "template" / "copier.yml").exists()
 
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
-        {
-            src / "copier.yml": "_subdirectory: ''",
-            src / "template" / "copier.yml": "",
-        }
+        {src / "copier.yml": "_subdirectory: ''", src / "template" / "copier.yml": ""}
     )
     run_auto(str(src), dst, quiet=True)
     assert not (dst / "template" / "copier.yml").exists()
 
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            src / "copier.yml": "",
-            src / "template" / "copier.yml": "",
-        }
-    )
+    build_file_tree({src / "copier.yml": "", src / "template" / "copier.yml": ""})
     run_auto(str(src), dst, quiet=True)
     assert not (dst / "template" / "copier.yml").exists()

--- a/tests/test_interrupts.py
+++ b/tests/test_interrupts.py
@@ -67,8 +67,8 @@ def test_multiple_questions_interrupt(tmp_path_factory: pytest.TempPathFactory) 
     ):
         with pytest.raises(CopierAnswersInterrupt) as err:
             worker.run_copy()
-            assert err.value.answers.user == {
-                "question1": "foobar",
-                "question2": "yosemite",
-            }
-            assert err.value.template == worker.template
+        assert err.value.answers.user == {
+            "question1": "foobar",
+            "question2": "yosemite",
+        }
+        assert err.value.template == worker.template

--- a/tests/test_interrupts.py
+++ b/tests/test_interrupts.py
@@ -1,7 +1,6 @@
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 import pytest
-import yaml
 
 from copier import Worker
 from copier.errors import CopierAnswersInterrupt
@@ -10,75 +9,66 @@ from .helpers import build_file_tree
 
 
 @pytest.mark.parametrize(
-    "questions, side_effect, raises",
-    (
-        (
-            {
-                "question": {"type": "str"},
-            },
-            # We override the prompt method from questionary to raise this
-            # exception and expect our surrounding machinery to re-raise
-            # it as a CopierAnswersInterrupt.
-            KeyboardInterrupt,
-            CopierAnswersInterrupt,
-        ),
-        (
-            {
-                "question": {"type": "str"},
-            },
-            KeyboardInterrupt,
-            KeyboardInterrupt,
-        ),
-    ),
+    "side_effect",
+    [
+        # We override the prompt method from questionary to raise this
+        # exception and expect our surrounding machinery to re-raise
+        # it as a CopierAnswersInterrupt.
+        CopierAnswersInterrupt(Mock(), Mock(), Mock()),
+        KeyboardInterrupt,
+    ],
 )
-def test_keyboard_interrupt(tmp_path_factory, questions, side_effect, raises):
+def test_keyboard_interrupt(
+    tmp_path_factory: pytest.TempPathFactory, side_effect: KeyboardInterrupt
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src / "copier.yml": yaml.safe_dump(questions),
+            (src / "copier.yml"): (
+                """\
+                question:
+                    type: str
+                """
+            ),
         }
     )
     worker = Worker(str(src), dst, defaults=False)
 
     with patch("copier.main.unsafe_prompt", side_effect=side_effect):
-        with pytest.raises(raises):
+        with pytest.raises(KeyboardInterrupt):
             worker.run_copy()
 
 
-@pytest.mark.parametrize(
-    "questions, side_effects, answers",
-    (
-        (
-            {
-                "question1": {"type": "str"},
-                "question2": {"type": "str"},
-                "question3": {"type": "str"},
-            },
-            [
-                {"question1": "foobar"},
-                {"question2": "yosemite"},
-                KeyboardInterrupt,
-            ],
-            {
-                "question1": "foobar",
-                "question2": "yosemite",
-            },
-        ),
-    ),
-)
-def test_multiple_questions_interrupt(
-    tmp_path_factory, questions, side_effects, answers
-):
+def test_multiple_questions_interrupt(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src / "copier.yml": yaml.safe_dump(questions),
+            (src / "copier.yml"): (
+                """\
+                question1:
+                    type: str
+                question2:
+                    type: str
+                question3:
+                    type: str
+                """
+            ),
         }
     )
     worker = Worker(str(src), dst, defaults=False)
 
-    with patch("copier.main.unsafe_prompt", side_effect=side_effects):
+    with patch(
+        "copier.main.unsafe_prompt",
+        side_effect=[
+            {"question1": "foobar"},
+            {"question2": "yosemite"},
+            KeyboardInterrupt,
+        ],
+    ):
         with pytest.raises(CopierAnswersInterrupt) as err:
             worker.run_copy()
-        assert err.value.answers.user == answers
-        assert err.value.template == worker.template
+            assert err.value.answers.user == {
+                "question1": "foobar",
+                "question2": "yosemite",
+            }
+            assert err.value.template == worker.template

--- a/tests/test_jinja2_extensions.py
+++ b/tests/test_jinja2_extensions.py
@@ -1,6 +1,9 @@
 import json
+from pathlib import Path
+from typing import Any
 
-from jinja2.ext import Extension
+import pytest
+from jinja2.ext import Environment, Extension
 
 import copier
 
@@ -10,10 +13,10 @@ from .helpers import PROJECT_TEMPLATE, build_file_tree
 class FilterExtension(Extension):
     """Jinja2 extension to add a filter to the Jinja2 environment."""
 
-    def __init__(self, environment):
+    def __init__(self, environment: Environment) -> None:
         super().__init__(environment)
 
-        def super_filter(obj):
+        def super_filter(obj: Any) -> str:
             return str(obj) + " super filter!"
 
         environment.filters["super_filter"] = super_filter
@@ -22,51 +25,39 @@ class FilterExtension(Extension):
 class GlobalsExtension(Extension):
     """Jinja2 extension to add global variables to the Jinja2 environment."""
 
-    def __init__(self, environment):
+    def __init__(self, environment: Environment) -> None:
         super().__init__(environment)
 
-        def super_func(argument):
+        def super_func(argument: Any) -> str:
             return str(argument) + " super func!"
 
         environment.globals.update(super_func=super_func)
         environment.globals.update(super_var="super var!")
 
 
-def test_default_jinja2_extensions(tmp_path):
-    copier.copy(
-        str(PROJECT_TEMPLATE) + "_extensions_default",
-        tmp_path,
-    )
+def test_default_jinja2_extensions(tmp_path: Path) -> None:
+    copier.copy(str(PROJECT_TEMPLATE) + "_extensions_default", tmp_path)
     super_file = tmp_path / "super_file.md"
     assert super_file.exists()
-    expected = "path\n"
-    assert super_file.read_text() == expected
+    assert super_file.read_text() == "path\n"
 
 
-def test_additional_jinja2_extensions(tmp_path):
-    copier.copy(
-        str(PROJECT_TEMPLATE) + "_extensions_additional",
-        tmp_path,
-    )
+def test_additional_jinja2_extensions(tmp_path: Path) -> None:
+    copier.copy(str(PROJECT_TEMPLATE) + "_extensions_additional", tmp_path)
     super_file = tmp_path / "super_file.md"
     assert super_file.exists()
-    expected = "super var! super func! super filter!\n"
-    assert super_file.read_text() == expected
+    assert super_file.read_text() == "super var! super func! super filter!\n"
 
 
-def test_to_json_filter_with_conf(tmp_path_factory):
-    template = tmp_path_factory.mktemp("template")
-    project = tmp_path_factory.mktemp("project")
+def test_to_json_filter_with_conf(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template / "conf.json.jinja": "{{ _copier_conf|to_json }}",
+            src / "conf.json.jinja": "{{ _copier_conf|to_json }}",
         }
     )
-    copier.copy(
-        str(template),
-        project,
-    )
-    conf_file = project / "conf.json"
+    copier.copy(str(src), dst)
+    conf_file = dst / "conf.json"
     assert conf_file.exists()
     # must not raise an error
     assert json.loads(conf_file.read_text())

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -81,112 +81,108 @@ def test_pre_migration_modifies_answers(
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
     # v1 of template asks for a favourite song and writes it to songs.json
-    build_file_tree(
-        {
-            (src / "[[ _copier_conf.answers_file ]].jinja"): (
-                "[[ _copier_answers|tojson ]]"
-            ),
-            (src / "copier.yml"): (
-                f"""\
-                _envops: {BRACKET_ENVOPS_JSON}
-                best_song: la vie en rose
-                """
-            ),
-            (src / "songs.json.jinja"): "[ [[ best_song|tojson ]] ]",
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                "[[ _copier_conf.answers_file ]].jinja": (
+                    "[[ _copier_answers|tojson ]]"
+                ),
+                "copier.yml": (
+                    f"""\
+                    _envops: {BRACKET_ENVOPS_JSON}
+                    best_song: la vie en rose
+                    """
+                ),
+                "songs.json.jinja": "[ [[ best_song|tojson ]] ]",
+            }
+        )
         git("init")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "v1")
-
     # User copies v1 template into subproject
-    copy(src_path=str(src), dst_path=dst, defaults=True, overwrite=True)
-    answers = json.loads((dst / ".copier-answers.yml").read_text())
-    assert answers["_commit"] == "v1"
-    assert answers["best_song"] == "la vie en rose"
-    assert json.loads((dst / "songs.json").read_text()) == ["la vie en rose"]
-
     with local.cwd(dst):
+        copy(src_path=str(src), defaults=True, overwrite=True)
+        answers = json.loads(Path(".copier-answers.yml").read_text())
+        assert answers["_commit"] == "v1"
+        assert answers["best_song"] == "la vie en rose"
+        assert json.loads(Path("songs.json").read_text()) == ["la vie en rose"]
         git("init")
         git("add", ".")
         git("commit", "-m1")
-
-    build_file_tree(
-        {
-            # v2 of template supports multiple songs, has a different default
-            # and includes a data format migration script
-            (src / "copier.yml"): (
-                f"""\
-                _envops: {BRACKET_ENVOPS_JSON}
-                best_song_list:
-                    default: [paranoid android]
-                _migrations:
-                -   version: v2
-                    before:
-                    -   - python
-                        - -c
-                        - |
-                            import sys, json, pathlib
-                            answers_path = pathlib.Path(*sys.argv[1:])
-                            answers = json.loads(answers_path.read_text())
-                            answers["best_song_list"] = [answers.pop("best_song")]
-                            answers_path.write_text(json.dumps(answers))
-                        - "[[ _copier_conf.dst_path ]]"
-                        - "[[ _copier_conf.answers_file ]]"
-                """
-            ),
-            (src / "songs.json.jinja"): "[[ best_song_list|tojson ]]",
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                # v2 of template supports multiple songs, has a different default
+                # and includes a data format migration script
+                "copier.yml": (
+                    f"""\
+                    _envops: {BRACKET_ENVOPS_JSON}
+                    best_song_list:
+                        default: [paranoid android]
+                    _migrations:
+                    -   version: v2
+                        before:
+                        -   - python
+                            - -c
+                            - |
+                                import sys, json, pathlib
+                                answers_path = pathlib.Path(*sys.argv[1:])
+                                answers = json.loads(answers_path.read_text())
+                                answers["best_song_list"] = [answers.pop("best_song")]
+                                answers_path.write_text(json.dumps(answers))
+                            - "[[ _copier_conf.dst_path ]]"
+                            - "[[ _copier_conf.answers_file ]]"
+                    """
+                ),
+                "songs.json.jinja": "[[ best_song_list|tojson ]]",
+            }
+        )
         git("add", ".")
         git("commit", "-m2")
         git("tag", "v2")
     # User updates subproject to v2 template
-    copy(dst_path=dst, defaults=True, overwrite=True)
-    answers = json.loads((dst / ".copier-answers.yml").read_text())
-    assert answers["_commit"] == "v2"
-    assert "best_song" not in answers
-    assert answers["best_song_list"] == ["la vie en rose"]
-    assert json.loads((dst / "songs.json").read_text()) == ["la vie en rose"]
+    with local.cwd(dst):
+        copy(defaults=True, overwrite=True)
+        answers = json.loads(Path(".copier-answers.yml").read_text())
+        assert answers["_commit"] == "v2"
+        assert "best_song" not in answers
+        assert answers["best_song_list"] == ["la vie en rose"]
+        assert json.loads(Path("songs.json").read_text()) == ["la vie en rose"]
 
 
 def test_prereleases(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Test prereleases support for copying and updating."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    # Build template in v1.0.0
-    build_file_tree(
-        {
-            (src / "version.txt"): "v1.0.0",
-            (src / "[[ _copier_conf.answers_file ]].jinja"): (
-                "[[_copier_answers|to_nice_yaml]]"
-            ),
-            (src / "copier.yaml"): (
-                f"""\
-                _envops: {BRACKET_ENVOPS_JSON}
-                _migrations:
-                -   version: v1.9
-                    before:
-                    - [python, -c, "import pathlib; pathlib.Path('v1.9').touch()"]
-                -   version: v2.dev0
-                    before:
-                    - [python, -c, "import pathlib; pathlib.Path('v2.dev0').touch()"]
-                -   version: v2.dev2
-                    before:
-                    - [python, -c, "import pathlib; pathlib.Path('v2.dev2').touch()"]
-                -   version: v2.a1
-                    before:
-                    - [python, -c, "import pathlib; pathlib.Path('v2.a1').touch()"]
-                -   version: v2.a2
-                    before:
-                    - [python, -c, "import pathlib; pathlib.Path('v2.a2').touch()"]
-                """
-            ),
-        }
-    )
     with local.cwd(src):
+        # Build template in v1.0.0
+        build_file_tree(
+            {
+                "version.txt": "v1.0.0",
+                "[[ _copier_conf.answers_file ]].jinja": "[[_copier_answers|to_nice_yaml]]",
+                "copier.yaml": (
+                    f"""\
+                    _envops: {BRACKET_ENVOPS_JSON}
+                    _migrations:
+                    -   version: v1.9
+                        before:
+                        - [python, -c, "import pathlib; pathlib.Path('v1.9').touch()"]
+                    -   version: v2.dev0
+                        before:
+                        - [python, -c, "import pathlib; pathlib.Path('v2.dev0').touch()"]
+                    -   version: v2.dev2
+                        before:
+                        - [python, -c, "import pathlib; pathlib.Path('v2.dev2').touch()"]
+                    -   version: v2.a1
+                        before:
+                        - [python, -c, "import pathlib; pathlib.Path('v2.a1').touch()"]
+                    -   version: v2.a2
+                        before:
+                        - [python, -c, "import pathlib; pathlib.Path('v2.a2').touch()"]
+                    """
+                ),
+            }
+        )
         git("init")
         git("add", ".")
         git("commit", "-mv1")

--- a/tests/test_minimum_version.py
+++ b/tests/test_minimum_version.py
@@ -1,4 +1,5 @@
 import warnings
+from pathlib import Path
 
 import pytest
 from packaging.version import Version
@@ -16,39 +17,48 @@ from .helpers import build_file_tree
 
 
 @pytest.fixture(scope="module")
-def template_path(tmp_path_factory) -> str:
+def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
     root = tmp_path_factory.mktemp("template")
     build_file_tree(
         {
-            root
-            / "copier.yaml": """\
+            (root / "copier.yaml"): (
+                """\
                 _min_copier_version: "10.5.1"
-            """,
-            root / "README.md": "",
+                """
+            ),
+            (root / "README.md"): "",
         }
     )
     return str(root)
 
 
-def test_version_less_than_required(template_path, tmp_path, monkeypatch):
+def test_version_less_than_required(
+    template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("copier.__version__", "0.0.0a0")
     with pytest.raises(UnsupportedVersionError):
         copier.copy(template_path, tmp_path)
 
 
-def test_version_equal_required(template_path, tmp_path, monkeypatch):
+def test_version_equal_required(
+    template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("copier.__version__", "10.5.1")
     # assert no error
     copier.copy(template_path, tmp_path)
 
 
-def test_version_greater_than_required(template_path, tmp_path, monkeypatch):
+def test_version_greater_than_required(
+    template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("copier.__version__", "99.99.99")
     # assert no error
     copier.copy(template_path, tmp_path)
 
 
-def test_minimum_version_update(template_path, tmp_path, monkeypatch):
+def test_minimum_version_update(
+    template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("copier.__version__", "11.0.0")
     copier.copy(template_path, tmp_path)
 
@@ -72,7 +82,9 @@ def test_minimum_version_update(template_path, tmp_path, monkeypatch):
     copier.copy(template_path, tmp_path)
 
 
-def test_version_0_0_0_ignored(template_path, tmp_path, monkeypatch):
+def test_version_0_0_0_ignored(
+    template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("copier.template.copier_version", lambda: Version("0.0.0"))
     # assert no error
     with warnings.catch_warnings():
@@ -81,7 +93,9 @@ def test_version_0_0_0_ignored(template_path, tmp_path, monkeypatch):
             copier.run_copy(template_path, tmp_path)
 
 
-def test_version_bigger_major_warning(template_path, tmp_path, monkeypatch):
+def test_version_bigger_major_warning(
+    template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr("copier.__version__", "11.0.0a0")
     with warnings.catch_warnings():
         warnings.simplefilter("error")

--- a/tests/test_normal_jinja2.py
+++ b/tests/test_normal_jinja2.py
@@ -1,16 +1,19 @@
 import warnings
+from textwrap import dedent
+
+import pytest
 
 import copier
 
 from .helpers import build_file_tree
 
 
-def test_normal_jinja2(tmp_path_factory):
+def test_normal_jinja2(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yml": """\
+            (src / "copier.yml"): (
+                """\
                 _templates_suffix: .jinja
                 _envops:
                     autoescape: false
@@ -24,45 +27,52 @@ def test_normal_jinja2(tmp_path_factory):
                     trim_blocks: true
                 name: Guybrush
                 todo: Become a pirate
-            """,
-            src
-            / "TODO.txt.jinja": """\
+                """
+            ),
+            (src / "TODO.txt.jinja"): (
+                """\
                 [[ {{ name }} TODO LIST]]
                 {# Let's put an ugly not-comment below #}
                 [# GROG #]
                     {% if name == 'Guybrush' %}
                     - {{ todo }}
                     {% endif %}
-            """,
+                """
+            ),
         }
     )
     # No warnings, because template is explicit
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         copier.run_auto(str(src), dst, defaults=True, overwrite=True)
-    todo = (dst / "TODO.txt").read_text()
-    expected = "[[ Guybrush TODO LIST]]\n[# GROG #]\n    - Become a pirate\n"
-    assert todo == expected
+    assert (dst / "TODO.txt").read_text() == dedent(
+        """\
+        [[ Guybrush TODO LIST]]
+        [# GROG #]
+            - Become a pirate
+        """
+    )
 
 
-def test_to_not_keep_trailing_newlines_in_jinja2(tmp_path_factory):
+def test_to_not_keep_trailing_newlines_in_jinja2(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            src
-            / "copier.yml": """
+            (src / "copier.yml"): (
+                """\
                 _templates_suffix: .jinja
                 _envops:
                     keep_trailing_newline: false
                 data: foo
-            """,
-            src / "data.txt.jinja": "This is {{ data }}.\n",
+                """
+            ),
+            (src / "data.txt.jinja"): "This is {{ data }}.\n",
         }
     )
     # No warnings, because template is explicit
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         copier.run_auto(str(src), dst, defaults=True, overwrite=True)
-    rendered = (dst / "data.txt").read_text()
-    expected = "This is foo."
-    assert rendered == expected
+    assert (dst / "data.txt").read_text() == "This is foo."

--- a/tests/test_normal_jinja2.py
+++ b/tests/test_normal_jinja2.py
@@ -1,5 +1,4 @@
 import warnings
-from textwrap import dedent
 
 import pytest
 
@@ -45,13 +44,9 @@ def test_normal_jinja2(tmp_path_factory: pytest.TempPathFactory) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         copier.run_auto(str(src), dst, defaults=True, overwrite=True)
-    assert (dst / "TODO.txt").read_text() == dedent(
-        """\
-        [[ Guybrush TODO LIST]]
-        [# GROG #]
-            - Become a pirate
-        """
-    )
+    todo = (dst / "TODO.txt").read_text()
+    expected = "[[ Guybrush TODO LIST]]\n[# GROG #]\n    - Become a pirate\n"
+    assert todo == expected
 
 
 def test_to_not_keep_trailing_newlines_in_jinja2(

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,9 +1,12 @@
 import re
+from pathlib import Path
+
+import pytest
 
 from .helpers import render
 
 
-def test_output(capsys, tmp_path):
+def test_output(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
     render(tmp_path, quiet=False)
     _, err = capsys.readouterr()
     assert re.search(r"create[^\s]*  config\.py", err)
@@ -11,7 +14,7 @@ def test_output(capsys, tmp_path):
     assert re.search(r"create[^\s]*  doc[/\\]images[/\\]nslogo\.gif", err)
 
 
-def test_output_pretend(capsys, tmp_path):
+def test_output_pretend(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
     render(tmp_path, quiet=False, pretend=True)
     _, err = capsys.readouterr()
     assert re.search(r"create[^\s]*  config\.py", err)
@@ -19,7 +22,7 @@ def test_output_pretend(capsys, tmp_path):
     assert re.search(r"create[^\s]*  doc[/\\]images[/\\]nslogo\.gif", err)
 
 
-def test_output_force(capsys, tmp_path):
+def test_output_force(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
     render(tmp_path)
     capsys.readouterr()
     render(tmp_path, quiet=False, defaults=True, overwrite=True)
@@ -30,7 +33,7 @@ def test_output_force(capsys, tmp_path):
     assert re.search(r"identical[^\s]*  doc[/\\]images[/\\]nslogo\.gif", err)
 
 
-def test_output_skip(capsys, tmp_path):
+def test_output_skip(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
     render(tmp_path)
     capsys.readouterr()
     render(tmp_path, quiet=False, skip_if_exists=["config.py"])
@@ -41,7 +44,7 @@ def test_output_skip(capsys, tmp_path):
     assert re.search(r"identical[^\s]*  doc[/\\]images[/\\]nslogo\.gif", err)
 
 
-def test_output_quiet(capsys, tmp_path):
+def test_output_quiet(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
     render(tmp_path, quiet=True)
     out, err = capsys.readouterr()
     assert out == ""

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Dict, List, Mapping, Tuple, Union
 
 import pexpect
 import pytest
@@ -6,19 +7,22 @@ import yaml
 from plumbum import local
 from plumbum.cmd import git
 
+from copier.types import StrOrPath
+
 from .helpers import (
     BRACKET_ENVOPS,
     BRACKET_ENVOPS_JSON,
     COPIER_PATH,
     SUFFIX_TMPL,
     Keyboard,
+    Spawn,
     build_file_tree,
     expect_prompt,
 )
 
-DEFAULT = object()
-MARIO_TREE = {
-    "copier.yml": f"""\
+MARIO_TREE: Mapping[StrOrPath, Union[str, bytes]] = {
+    "copier.yml": (
+        f"""\
         _templates_suffix: {SUFFIX_TMPL}
         _envops: {BRACKET_ENVOPS_JSON}
         in_love:
@@ -36,19 +40,29 @@ MARIO_TREE = {
         what_enemy_does:
             type: str
             default: "[[ your_enemy ]] hates [[ your_name ]]"
-        """,
+        """
+    ),
     "[[ _copier_conf.answers_file ]].tmpl": "[[_copier_answers|to_nice_yaml]]",
 }
 
 
-@pytest.mark.parametrize("name", [DEFAULT, None, "Luigi"])
-def test_copy_default_advertised(tmp_path_factory, spawn, name):
+@pytest.mark.parametrize(
+    "name, args",
+    [
+        ("Mario", ()),  # Default name in the template
+        ("Luigi", ("--data=your_name=Luigi",)),
+        ("None", ("--data=your_name=None",)),
+    ],
+)
+def test_copy_default_advertised(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    name: str,
+    args: Tuple[str, ...],
+) -> None:
     """Test that the questions for the user are OK"""
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
-    with local.cwd(template):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    with local.cwd(src):
         build_file_tree(MARIO_TREE)
         git("init")
         git("add", ".")
@@ -56,17 +70,9 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
         git("tag", "v1")
         git("commit", "--allow-empty", "-m", "v2")
         git("tag", "v2")
-    with local.cwd(subproject):
+    with local.cwd(dst):
         # Copy the v1 template
-        args = ()
-        if name is not DEFAULT:
-            args += (f"--data=your_name={name}",)
-        else:
-            name = "Mario"  # Default in the template
-        name = str(name)
-        tui = spawn(
-            COPIER_PATH + (str(template), ".", "--vcs-ref=v1") + args, timeout=10
-        )
+        tui = spawn(COPIER_PATH + (str(src), ".", "--vcs-ref=v1") + args, timeout=10)
         # Check what was captured
         expect_prompt(tui, "in_love", "bool")
         tui.expect_exact("(Y/n)")
@@ -154,65 +160,70 @@ def test_copy_default_advertised(tmp_path_factory, spawn, name):
         ("[% if question_1 %]FALSE[% endif %]", False),
     ),
 )
-def test_when(tmp_path_factory, question_1, question_2_when, spawn, asks):
+def test_when(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    question_1: Union[str, int, float, bool],
+    question_2_when: Union[bool, str],
+    asks: bool,
+) -> None:
     """Test that the 2nd question is skipped or not, properly."""
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
-    questions = {
-        "_envops": BRACKET_ENVOPS,
-        "_templates_suffix": SUFFIX_TMPL,
-        "question_1": question_1,
-        "question_2": {"default": "something", "type": "yaml", "when": question_2_when},
-    }
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template / "copier.yml": yaml.dump(questions),
-            template
-            / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+            (src / "copier.yml"): yaml.dump(
+                {
+                    "_envops": BRACKET_ENVOPS,
+                    "_templates_suffix": SUFFIX_TMPL,
+                    "question_1": question_1,
+                    "question_2": {
+                        "type": "yaml",
+                        "default": "something",
+                        "when": question_2_when,
+                    },
+                }
+            ),
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                "[[ _copier_answers|to_nice_yaml ]]"
+            ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", type(question_1).__name__)
     tui.sendline()
     if asks:
         expect_prompt(tui, "question_2", "yaml")
         tui.sendline()
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers == {
-        "_src_path": str(template),
+        "_src_path": str(src),
         "question_1": question_1,
         "question_2": "something",
     }
 
 
-def test_placeholder(tmp_path_factory, spawn):
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
+def test_placeholder(tmp_path_factory: pytest.TempPathFactory, spawn: Spawn) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yml": yaml.dump(
-                {
-                    "_envops": BRACKET_ENVOPS,
-                    "_templates_suffix": SUFFIX_TMPL,
-                    "question_1": "answer 1",
-                    "question_2": {
-                        "type": "str",
-                        "help": "write a list of answers",
-                        "placeholder": "Write something like [[ question_1 ]], but better",
-                    },
-                }
+            (src / "copier.yml"): (
+                f"""\
+                _envops: {BRACKET_ENVOPS_JSON}
+                _templates_suffix: {SUFFIX_TMPL}
+                question_1: answer 1
+                question_2:
+                    type: str
+                    help: write a list of answers
+                    placeholder: Write something like [[ question_1 ]], but better
+                """
             ),
-            template
-            / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                "[[ _copier_answers|to_nice_yaml ]]"
+            ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     tui.sendline()
@@ -220,45 +231,45 @@ def test_placeholder(tmp_path_factory, spawn):
     tui.expect_exact("Write something like answer 1, but better")
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers == {
-        "_src_path": str(template),
+        "_src_path": str(src),
         "question_1": "answer 1",
         "question_2": None,
     }
 
 
-@pytest.mark.parametrize("type_", ("str", "yaml", "json"))
-def test_multiline(tmp_path_factory, spawn, type_):
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
+@pytest.mark.parametrize("type_", ["str", "yaml", "json"])
+def test_multiline(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn, type_: str
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yml": yaml.dump(
-                {
-                    "_envops": BRACKET_ENVOPS,
-                    "_templates_suffix": SUFFIX_TMPL,
-                    "question_1": "answer 1",
-                    "question_2": {"type": type_},
-                    "question_3": {"type": type_, "multiline": True},
-                    "question_4": {
-                        "type": type_,
-                        "multiline": "[[ question_1 == 'answer 1' ]]",
-                    },
-                    "question_5": {
-                        "type": type_,
-                        "multiline": "[[ question_1 != 'answer 1' ]]",
-                    },
-                }
+            (src / "copier.yml"): (
+                f"""\
+                _envops: {BRACKET_ENVOPS_JSON}
+                _templates_suffix: {SUFFIX_TMPL}
+                question_1: answer 1
+                question_2:
+                    type: {type_}
+                question_3:
+                    type: {type_}
+                    multiline: true
+                question_4:
+                    type: {type_}
+                    multiline: "[[ question_1 == 'answer 1' ]]"
+                question_5:
+                    type: {type_}
+                    multiline: "[[ question_1 != 'answer 1' ]]"
+                """
             ),
-            template
-            / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                "[[ _copier_answers|to_nice_yaml ]]"
+            ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     tui.sendline()
@@ -273,10 +284,10 @@ def test_multiline(tmp_path_factory, spawn, type_):
     expect_prompt(tui, "question_5", type_)
     tui.sendline('"answer 5"')
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     if type_ == "str":
         assert answers == {
-            "_src_path": str(template),
+            "_src_path": str(src),
             "question_1": "answer 1",
             "question_2": '"answer 2"',
             "question_3": ('"answer 3"\n'),
@@ -285,7 +296,7 @@ def test_multiline(tmp_path_factory, spawn, type_):
         }
     else:
         assert answers == {
-            "_src_path": str(template),
+            "_src_path": str(src),
             "question_1": "answer 1",
             "question_2": ("answer 2"),
             "question_3": ("answer 3"),
@@ -302,65 +313,70 @@ def test_multiline(tmp_path_factory, spawn, type_):
         {"one": 1, "two": 2, "three": 3},
     ),
 )
-def test_update_choice(tmp_path_factory, spawn, choices):
+def test_update_choice(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    choices: Union[
+        List[int],
+        List[List[Union[str, int]]],  # actually `List[Tuple[str, int]]`
+        Dict[str, int],
+    ],
+) -> None:
     """Choices are properly remembered and selected in TUI when updating."""
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     # Create template
     build_file_tree(
         {
-            template
-            / "copier.yml": f"""
-                _templates_suffix: {SUFFIX_TMPL}
+            (src / "copier.yml"): (
+                f"""\
                 _envops: {BRACKET_ENVOPS_JSON}
+                _templates_suffix: {SUFFIX_TMPL}
                 pick_one:
                     type: float
                     default: 3
                     choices: {choices}
-                """,
-            template
-            / "[[ _copier_conf.answers_file ]].tmpl": "[[ _copier_answers|to_nice_yaml ]]",
+                """
+            ),
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                "[[ _copier_answers|to_nice_yaml ]]"
+            ),
         }
     )
-    with local.cwd(template):
+    with local.cwd(src):
         git("init")
         git("add", ".")
         git("commit", "-m one")
         git("tag", "v1")
     # Copy
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "pick_one", "float")
     tui.sendline(Keyboard.Up)
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["pick_one"] == 2.0
-    with local.cwd(subproject):
+    with local.cwd(dst):
         git("init")
         git("add", ".")
         git("commit", "-m1")
     # Update
-    tui = spawn(COPIER_PATH + (str(subproject),), timeout=10)
+    tui = spawn(COPIER_PATH + (str(dst),), timeout=10)
     expect_prompt(tui, "pick_one", "float")
     tui.sendline(Keyboard.Down)
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["pick_one"] == 3.0
 
 
 @pytest.mark.skip("TODO: fix this")
-def test_multiline_defaults(tmp_path_factory, spawn):
+def test_multiline_defaults(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+) -> None:
     """Multiline questions with scalar defaults produce multiline defaults."""
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
-    # Create template
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yaml": """
+            (src / "copier.yaml"): (
+                """\
                 yaml_single:
                     type: yaml
                     default: &default
@@ -379,13 +395,14 @@ def test_multiline_defaults(tmp_path_factory, spawn):
                     type: json
                     multiline: yes
                     default: *default
-                """,
-            template
-            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
         }
     )
-    # Copy
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "yaml_single", "yaml")
     # This test will always fail here, because python prompt toolkit gives
     # syntax highlighting to YAML and JSON outputs, encoded into terminal
@@ -405,33 +422,32 @@ def test_multiline_defaults(tmp_path_factory, spawn):
     )
     tui.send(Keyboard.Alt + Keyboard.Enter)
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert (
-        answers["yaml_single"]
+        ["one", "two", {"three": ["four"]}]
+        == answers["yaml_single"]
         == answers["yaml_multi"]
         == answers["json_single"]
         == answers["json_multi"]
-        == ["one", "two", {"three": ["four"]}]
     )
 
 
-def test_partial_interrupt(tmp_path_factory, spawn):
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
+def test_partial_interrupt(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yml": yaml.safe_dump(
-                {
-                    "question_1": "answer 1",
-                    "question_2": "answer 2",
-                }
-            ),
+            (src / "copier.yml"): (
+                """\
+                question_1: answer 1
+                question_2: answer 2
+                """
+            )
         }
     )
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     # Answer the first question using the default.
@@ -446,34 +462,32 @@ def test_partial_interrupt(tmp_path_factory, spawn):
     tui.expect_exact(pexpect.EOF)
 
 
-def test_var_name_value_allowed(tmp_path_factory, spawn):
+def test_var_name_value_allowed(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+) -> None:
     """Test that a question var name "value" causes no name collision.
 
     See https://github.com/copier-org/copier/pull/780 for more details.
     """
-    template, subproject = (
-        tmp_path_factory.mktemp("template"),
-        tmp_path_factory.mktemp("subproject"),
-    )
-    # Create template
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
-            template
-            / "copier.yaml": """
+            (src / "copier.yaml"): (
+                """\
                 value:
                     type: str
                     default: string
-                """,
-            template
-            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
         }
     )
-    # Copy
-    tui = spawn(COPIER_PATH + (str(template), str(subproject)), timeout=10)
+    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "value", "str")
     tui.expect_exact("string")
     tui.send(Keyboard.Alt + Keyboard.Enter)
     tui.expect_exact(pexpect.EOF)
-    # Check answers file
-    answers = yaml.safe_load((subproject / ".copier-answers.yml").read_text())
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["value"] == "string"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -169,20 +169,15 @@ def test_when(
 ) -> None:
     """Test that the 2nd question is skipped or not, properly."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    questions = {
+        "_envops": BRACKET_ENVOPS,
+        "_templates_suffix": SUFFIX_TMPL,
+        "question_1": question_1,
+        "question_2": {"default": "something", "type": "yaml", "when": question_2_when},
+    }
     build_file_tree(
         {
-            (src / "copier.yml"): yaml.dump(
-                {
-                    "_envops": BRACKET_ENVOPS,
-                    "_templates_suffix": SUFFIX_TMPL,
-                    "question_1": question_1,
-                    "question_2": {
-                        "type": "yaml",
-                        "default": "something",
-                        "when": question_2_when,
-                    },
-                }
-            ),
+            (src / "copier.yml"): yaml.dump(questions),
             (src / "[[ _copier_conf.answers_file ]].tmpl"): (
                 "[[ _copier_answers|to_nice_yaml ]]"
             ),

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -1,6 +1,7 @@
+import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import Literal, Union
+from typing import Union
 
 import pytest
 import yaml
@@ -10,6 +11,12 @@ from plumbum.cmd import git
 import copier
 
 from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
+
+# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
+if sys.version_info >= (3, 8):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 
 def git_init(message="hello world"):

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -239,7 +239,6 @@ def test_new_version_uses_subdirectory(
 
     # Now change the template
     with local.cwd(src):
-
         # Update the README
         Path("README.md").write_text("upstream version 2")
 
@@ -309,7 +308,6 @@ def test_new_version_changes_subdirectory(
 
     # Now change the template
     with local.cwd(src):
-
         # Update the README
         Path("subdir1", "README.md").write_text("upstream version 2")
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -9,7 +9,7 @@ from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
 
 @pytest.fixture(scope="module")
 def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
-    root = tmp_path_factory.mktemp("template")
+    root = tmp_path_factory.mktemp("demo_tasks")
     build_file_tree(
         {
             (root / "copier.yaml"): (

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 import copier
@@ -6,12 +8,12 @@ from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
 
 
 @pytest.fixture(scope="module")
-def demo_template(tmp_path_factory):
-    root = tmp_path_factory.mktemp("demo_tasks")
+def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
+    root = tmp_path_factory.mktemp("template")
     build_file_tree(
         {
-            root
-            / "copier.yaml": f"""
+            (root / "copier.yaml"): (
+                f"""\
                 _templates_suffix: {SUFFIX_TMPL}
                 _envops: {BRACKET_ENVOPS_JSON}
 
@@ -25,19 +27,20 @@ def demo_template(tmp_path_factory):
                     - cd hello && touch world
                     - touch [[ other_file ]]
                     - ["[[ _copier_python ]]", "-c", "open('pyfile', 'w').close()"]
-            """
+                """
+            )
         }
     )
     return str(root)
 
 
-def test_render_tasks(tmp_path, demo_template):
-    copier.copy(demo_template, tmp_path, data={"other_file": "custom"})
+def test_render_tasks(template_path: str, tmp_path: Path) -> None:
+    copier.copy(template_path, tmp_path, data={"other_file": "custom"})
     assert (tmp_path / "custom").is_file()
 
 
-def test_copy_tasks(tmp_path, demo_template):
-    copier.copy(demo_template, tmp_path, quiet=True, defaults=True, overwrite=True)
+def test_copy_tasks(template_path: str, tmp_path: Path) -> None:
+    copier.copy(template_path, tmp_path, quiet=True, defaults=True, overwrite=True)
     assert (tmp_path / "hello").exists()
     assert (tmp_path / "hello").is_dir()
     assert (tmp_path / "hello" / "world").exists()

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -232,8 +232,8 @@ def test_templated_prompt_builtins(tmp_path_factory: pytest.TempPathFactory) -> 
                     default: "[[ make_secret() ]]"
                 """
             ),
-            (src / "now.tmpl"): "[[ question1 ]]",
-            (src / "make_secret.tmpl"): "[[ question2 ]]",
+            src / "now.tmpl": "[[ question1 ]]",
+            src / "make_secret.tmpl": "[[ question2 ]]",
         }
     )
     Worker(str(src), dst, defaults=True, overwrite=True).run_copy()

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -244,12 +244,12 @@ def test_templated_prompt_builtins(tmp_path_factory: pytest.TempPathFactory) -> 
 
 @pytest.mark.parametrize(
     "questions, raises, returns",
-    [
+    (
         ({"question": {"default": "{{ not_valid }}"}}, None, ""),
         ({"question": {"help": "{{ not_valid }}"}}, None, "None"),
         ({"question": {"type": "{{ not_valid }}"}}, InvalidTypeError, "None"),
         ({"question": {"choices": ["{{ not_valid }}"]}}, None, "None"),
-    ],
+    ),
 )
 def test_templated_prompt_invalid(
     tmp_path_factory: pytest.TempPathFactory,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -7,13 +7,13 @@ from poethepoet.app import PoeThePoet
 from copier.tools import TemporaryDirectory
 
 
-def test_types():
+def test_types() -> None:
     """Ensure source code static typing."""
     result = PoeThePoet(Path("."))(["types"])
     assert result == 0
 
 
-def test_temporary_directory_with_readonly_files_deletion():
+def test_temporary_directory_with_readonly_files_deletion() -> None:
     """Ensure temporary directories containing read-only files are properly deleted, whatever the OS."""
     with TemporaryDirectory() as tmp_dir:
         ro_file = Path(tmp_dir) / "readonly.txt"
@@ -23,7 +23,7 @@ def test_temporary_directory_with_readonly_files_deletion():
     assert not Path(tmp_dir).exists()
 
 
-def test_temporary_directory_with_git_repo_deletion():
+def test_temporary_directory_with_git_repo_deletion() -> None:
     """Ensure temporary directories containing git repositories are properly deleted, whatever the OS."""
     with TemporaryDirectory() as tmp_dir:
         git("init")

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -40,7 +40,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
                 """
             ),
             (repo / "README.txt.jinja"): (
-                """\
+                """
                 Let me introduce myself.
 
                 My name is {{author_name}}, and my project is {{project_name}}.
@@ -115,7 +115,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
                 """
             ),
             (repo / "README.txt.jinja"): (
-                """\
+                """
                 Let me introduce myself.
 
                 My name is {{author_name}}.
@@ -158,7 +158,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
         """
     )
     assert readme.read_text() == dedent(
-        """\
+        """
         Let me introduce myself.
 
         My name is Guybrush, and my project is to become a pirate.
@@ -178,7 +178,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
         # Emulate the user modifying the README by hand
         readme.write_text(
             dedent(
-                """\
+                """
                 Let me introduce myself.
 
                 My name is Guybrush, and my project is to become a pirate.
@@ -229,7 +229,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
             """
         )
         assert readme.read_text() == dedent(
-            """\
+            """
             Let me introduce myself.
 
             My name is Guybrush.
@@ -252,7 +252,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
             vcs_ref="HEAD",
         )
         assert readme.read_text() == dedent(
-            """\
+            """
             Let me introduce myself.
 
             My name is Largo LaGrande.
@@ -271,7 +271,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
             vcs_ref="HEAD",
         ).run_copy()
         assert readme.read_text() == dedent(
-            """\
+            """
             Let me introduce myself.
 
             My name is Largo LaGrande.
@@ -295,51 +295,51 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
     """Commit hooks are taken into account when producing the update diff."""
     # Prepare source template v1
     src, dst1, dst2 = map(tmp_path_factory.mktemp, ("src", "dst1", "dst2"))
-    build_file_tree(
-        {
-            (src / "copier.yml"): (
-                f"""\
-                _envops: {BRACKET_ENVOPS_JSON}
-                _templates_suffix: {SUFFIX_TMPL}
-                _tasks:
-                    - git init
-                    - pre-commit install
-                    - pre-commit run -a || true
-                what: grog
-                """
-            ),
-            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
-                """\
-                [[ _copier_answers|to_nice_yaml ]]
-                """
-            ),
-            (src / ".pre-commit-config.yaml"): (
-                r"""
-                repos:
-                -   repo: https://github.com/pre-commit/mirrors-prettier
-                    rev: v2.0.4
-                    hooks:
-                    -   id: prettier
-                -   repo: local
-                    hooks:
-                    -   id: forbidden-files
-                        name: forbidden files
-                        entry: found forbidden files; remove them
-                        language: fail
-                        files: "\\.rej$"
-                """
-            ),
-            (src / "life.yml.tmpl"): (
-                """\
-                # Following code should be reformatted by pre-commit after copying
-                Line 1:      hello
-                Line 2:      [[ what ]]
-                Line 3:      bye
-                """
-            ),
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                "copier.yml": (
+                    f"""
+                    _envops: {BRACKET_ENVOPS_JSON}
+                    _templates_suffix: {SUFFIX_TMPL}
+                    _tasks:
+                        - git init
+                        - pre-commit install
+                        - pre-commit run -a || true
+                    what: grog
+                    """
+                ),
+                "[[ _copier_conf.answers_file ]].tmpl": (
+                    """
+                    [[ _copier_answers|to_nice_yaml ]]
+                    """
+                ),
+                ".pre-commit-config.yaml": (
+                    r"""
+                    repos:
+                    -   repo: https://github.com/pre-commit/mirrors-prettier
+                        rev: v2.0.4
+                        hooks:
+                        -   id: prettier
+                    -   repo: local
+                        hooks:
+                        -   id: forbidden-files
+                            name: forbidden files
+                            entry: found forbidden files; remove them
+                            language: fail
+                            files: "\\.rej$"
+                    """
+                ),
+                "life.yml.tmpl": (
+                    """
+                    # Following code should be reformatted by pre-commit after copying
+                    Line 1:      hello
+                    Line 2:      [[ what ]]
+                    Line 3:      bye
+                    """
+                ),
+            }
+        )
         git("init")
         git("add", ".")
         git("commit", "-m", "commit 1")
@@ -362,21 +362,21 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
             """
         )
     # Evolve source template to v2
-    build_file_tree(
-        {
-            (src / "life.yml.tmpl"): (
-                """\
-                # Following code should be reformatted by pre-commit after copying
-                Line 1:     hello world
-                Line 2:     grow up
-                Line 3:     [[ what ]]
-                Line 4:     grow old
-                Line 5:     bye bye world
-                """
-            ),
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                "life.yml.tmpl": (
+                    """\
+                    # Following code should be reformatted by pre-commit after copying
+                    Line 1:     hello world
+                    Line 2:     grow up
+                    Line 3:     [[ what ]]
+                    Line 4:     grow old
+                    Line 5:     bye bye world
+                    """
+                ),
+            }
+        )
         git("init")
         git("add", ".")
         git("commit", "-m", "commit 2")
@@ -446,27 +446,20 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
 def test_update_from_tagged_to_head(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     # Build a template
-    build_file_tree(
-        {
-            (src / "{{ _copier_conf.answers_file }}.jinja"): (
-                "{{ _copier_answers|to_nice_yaml }}"
-            ),
-            (src / "example"): "1",
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+                "example": "1",
+            }
+        )
         git("init")
         git("add", "-A")
         git("commit", "-m1")
         # Publish v1 release
         git("tag", "v1")
-    # New commit, no release
-    build_file_tree(
-        {
-            src / "example": "2",
-        }
-    )
-    with local.cwd(src):
+        # New commit, no release
+        build_file_tree({"example": "2"})
         git("commit", "-am2")
         sha = git("rev-parse", "--short", "HEAD").strip()
     # Copy it without specifying version
@@ -488,16 +481,14 @@ def test_update_from_tagged_to_head(tmp_path_factory: pytest.TempPathFactory) ->
 
 def test_skip_update(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            (src / "copier.yaml"): "_skip_if_exists: [skip_me]",
-            (src / "{{ _copier_conf.answers_file }}.jinja"): (
-                "{{ _copier_answers|to_yaml }}"
-            ),
-            (src / "skip_me"): "1",
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                "copier.yaml": "_skip_if_exists: [skip_me]",
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+                "skip_me": "1",
+            }
+        )
         git("init")
         git("add", ".")
         git("commit", "-m1")
@@ -513,12 +504,8 @@ def test_skip_update(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("init")
         git("add", ".")
         git("commit", "-m1")
-    build_file_tree(
-        {
-            src / "skip_me": "3",
-        }
-    )
     with local.cwd(src):
+        build_file_tree({"skip_me": "3"})
         git("commit", "-am2")
         git("tag", "2.0.0")
     run_update(dst, defaults=True, overwrite=True)
@@ -536,26 +523,19 @@ def test_overwrite_answers_file_always(
     tmp_path_factory: pytest.TempPathFactory, answers_file: Optional[str]
 ):
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    build_file_tree(
-        {
-            (src / "copier.yaml"): "question_1: true",
-            (src / "{{ _copier_conf.answers_file }}.jinja"): (
-                "{{ _copier_answers|to_yaml }}"
-            ),
-            (src / "answer_1.jinja"): "{{ question_1 }}",
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                "copier.yaml": "question_1: true",
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+                "answer_1.jinja": "{{ question_1 }}",
+            }
+        )
         git("init")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "1")
-    build_file_tree(
-        {
-            src / "copier.yaml": "question_1: false",
-        }
-    )
-    with local.cwd(src):
+        build_file_tree({"copier.yaml": "question_1: false"})
         git("commit", "-am2")
         git("tag", "2")
     # When copying, there's nothing to overwrite, overwrite=False shouldn't hang
@@ -578,37 +558,34 @@ def test_overwrite_answers_file_always(
 def test_file_removed(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     # Add a file in the template repo
-    build_file_tree(
-        {
-            (src / "{{ _copier_conf.answers_file }}.jinja"): (
-                "{{ _copier_answers|to_yaml }}"
-            ),
-            (src / "1.txt"): "content 1",
-            (src / "dir 2" / "2.txt"): "content 2",
-            (src / "dir 3" / "subdir 3" / "3.txt"): "content 3",
-            (src / "dir 4" / "subdir 4" / "4.txt"): "content 4",
-            (src / "dir 5" / "subdir 5" / "5.txt"): "content 5",
-        }
-    )
     with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+                "1.txt": "content 1",
+                Path("dir 2", "2.txt"): "content 2",
+                Path("dir 3", "subdir 3", "3.txt"): "content 3",
+                Path("dir 4", "subdir 4", "4.txt"): "content 4",
+                Path("dir 5", "subdir 5", "5.txt"): "content 5",
+            }
+        )
         git("init")
         git("add", "-A")
         git("commit", "-m1")
         git("tag", "1")
     # Copy in subproject
-    run_copy(str(src), dst)
     with local.cwd(dst):
         git("init")
-    # Subproject has an extra file
-    build_file_tree(
-        {
-            (dst / "I.txt"): "content I",
-            (dst / "dir II" / "II.txt"): "content II",
-            (dst / "dir 3" / "subdir III" / "III.txt"): "content III",
-            (dst / "dir 4" / "subdir 4" / "IV.txt"): "content IV",
-        }
-    )
-    with local.cwd(dst):
+        run_copy(str(src))
+        # Subproject has an extra file
+        build_file_tree(
+            {
+                "I.txt": "content I",
+                Path("dir II", "II.txt"): "content II",
+                Path("dir 3", "subdir III", "III.txt"): "content III",
+                Path("dir 4", "subdir 4", "IV.txt"): "content IV",
+            }
+        )
         git("add", "-A")
         git("commit", "-m2")
     # All files exist
@@ -623,17 +600,13 @@ def test_file_removed(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert (dst / "dir 3" / "subdir III" / "III.txt").is_file()
     assert (dst / "dir 4" / "subdir 4" / "IV.txt").is_file()
     # Template removes file 1
-    (src / "1.txt").unlink()
-    rmtree(src / "dir 2")
-    rmtree(src / "dir 3")
-    rmtree(src / "dir 4")
-    rmtree(src / "dir 5")
-    build_file_tree(
-        {
-            src / "6.txt": "content 6",
-        }
-    )
     with local.cwd(src):
+        Path("1.txt").unlink()
+        rmtree("dir 2")
+        rmtree("dir 3")
+        rmtree("dir 4")
+        rmtree("dir 5")
+        build_file_tree({"6.txt": "content 6"})
         git("add", "-A")
         git("commit", "-m3")
         git("tag", "2")

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -12,13 +12,12 @@ from plumbum.cmd import git
 from copier import Worker, copy
 from copier.cli import CopierApp
 from copier.main import run_copy, run_update
-from copier.types import RelativePath
 
 from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
 
 
 @pytest.mark.impure
-def test_updatediff(tmp_path_factory):
+def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     # Prepare repo bundle
     repo = src / "repo"
@@ -26,26 +25,29 @@ def test_updatediff(tmp_path_factory):
     last_commit = ""
     build_file_tree(
         {
-            repo
-            / ".copier-answers.yml.jinja": """\
+            (repo / ".copier-answers.yml.jinja"): (
+                """\
                 # Changes here will be overwritten by Copier
                 {{ _copier_answers|to_nice_yaml }}
-            """,
-            repo
-            / "copier.yml": """\
+                """
+            ),
+            (repo / "copier.yml"): (
+                """\
                 _envops:
                     "keep_trailing_newline": True
                 project_name: to become a pirate
                 author_name: Guybrush
-            """,
-            repo
-            / "README.txt.jinja": """
+                """
+            ),
+            (repo / "README.txt.jinja"): (
+                """\
                 Let me introduce myself.
 
                 My name is {{author_name}}, and my project is {{project_name}}.
 
                 Thanks for your attention.
-            """,
+                """
+            ),
         }
     )
     with local.cwd(repo):
@@ -55,8 +57,8 @@ def test_updatediff(tmp_path_factory):
         git("tag", "v0.0.1")
     build_file_tree(
         {
-            repo
-            / "copier.yml": """\
+            (repo / "copier.yml"): (
+                """\
                 _envops:
                     "keep_trailing_newline": True
                 project_name: to become a pirate
@@ -77,7 +79,8 @@ def test_updatediff(tmp_path_factory):
                             - touch before-v1.0.0
                         after:
                             - touch after-v1.0.0
-            """,
+                """
+            ),
         }
     )
     with local.cwd(repo):
@@ -87,8 +90,8 @@ def test_updatediff(tmp_path_factory):
         git("tag", "v0.0.2")
     build_file_tree(
         {
-            repo
-            / "copier.yml": """\
+            (repo / "copier.yml"): (
+                """\
                 _envops:
                     "keep_trailing_newline": True
                 project_name: to rule
@@ -109,9 +112,10 @@ def test_updatediff(tmp_path_factory):
                             - touch before-v1.0.0
                         after:
                             - touch after-v1.0.0
-            """,
-            repo
-            / "README.txt.jinja": """
+                """
+            ),
+            (repo / "README.txt.jinja"): (
+                """\
                 Let me introduce myself.
 
                 My name is {{author_name}}.
@@ -119,7 +123,8 @@ def test_updatediff(tmp_path_factory):
                 My project is {{project_name}}.
 
                 Thanks for your attention.
-            """,
+                """
+            ),
         }
     )
     with local.cwd(repo):
@@ -145,15 +150,15 @@ def test_updatediff(tmp_path_factory):
     # Check it's copied OK
     assert answers.read_text() == dedent(
         f"""\
-            # Changes here will be overwritten by Copier
-            _commit: v0.0.1
-            _src_path: {bundle}
-            author_name: Guybrush
-            project_name: to become a pirate\n
+        # Changes here will be overwritten by Copier
+        _commit: v0.0.1
+        _src_path: {bundle}
+        author_name: Guybrush
+        project_name: to become a pirate\n
         """
     )
     assert readme.read_text() == dedent(
-        """
+        """\
         Let me introduce myself.
 
         My name is Guybrush, and my project is to become a pirate.
@@ -171,28 +176,27 @@ def test_updatediff(tmp_path_factory):
         git("add", ".")
         commit("-m", "hello world")
         # Emulate the user modifying the README by hand
-        with open(readme, "w") as readme_fd:
-            readme_fd.write(
-                dedent(
-                    """
-                    Let me introduce myself.
+        readme.write_text(
+            dedent(
+                """\
+                Let me introduce myself.
 
-                    My name is Guybrush, and my project is to become a pirate.
+                My name is Guybrush, and my project is to become a pirate.
 
-                    Thanks for your grog.
-                    """
-                )
+                Thanks for your grog.
+                """
             )
+        )
         commit("-m", "I prefer grog")
         # Update target to latest tag and check it's updated in answers file
         CopierApp.invoke(defaults=True, overwrite=True)
         assert answers.read_text() == dedent(
             f"""\
-                # Changes here will be overwritten by Copier
-                _commit: v0.0.2
-                _src_path: {bundle}
-                author_name: Guybrush
-                project_name: to become a pirate\n
+            # Changes here will be overwritten by Copier
+            _commit: v0.0.2
+            _src_path: {bundle}
+            author_name: Guybrush
+            project_name: to become a pirate\n
             """
         )
         # Check migrations were executed properly
@@ -217,15 +221,15 @@ def test_updatediff(tmp_path_factory):
         # Check it's updated OK
         assert answers.read_text() == dedent(
             f"""\
-                # Changes here will be overwritten by Copier
-                _commit: {last_commit}
-                _src_path: {bundle}
-                author_name: Guybrush
-                project_name: to become a pirate\n
+            # Changes here will be overwritten by Copier
+            _commit: {last_commit}
+            _src_path: {bundle}
+            author_name: Guybrush
+            project_name: to become a pirate\n
             """
         )
         assert readme.read_text() == dedent(
-            """
+            """\
             Let me introduce myself.
 
             My name is Guybrush.
@@ -248,7 +252,7 @@ def test_updatediff(tmp_path_factory):
             vcs_ref="HEAD",
         )
         assert readme.read_text() == dedent(
-            """
+            """\
             Let me introduce myself.
 
             My name is Largo LaGrande.
@@ -267,7 +271,7 @@ def test_updatediff(tmp_path_factory):
             vcs_ref="HEAD",
         ).run_copy()
         assert readme.read_text() == dedent(
-            """
+            """\
             Let me introduce myself.
 
             My name is Largo LaGrande.
@@ -287,14 +291,14 @@ def test_updatediff(tmp_path_factory):
     condition=platform.system() == "Windows", reason="Git broken on Windows?"
 )
 @pytest.mark.impure
-def test_commit_hooks_respected(tmp_path_factory):
+def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Commit hooks are taken into account when producing the update diff."""
     # Prepare source template v1
     src, dst1, dst2 = map(tmp_path_factory.mktemp, ("src", "dst1", "dst2"))
-    with local.cwd(src):
-        build_file_tree(
-            {
-                "copier.yml": f"""
+    build_file_tree(
+        {
+            (src / "copier.yml"): (
+                f"""\
                 _envops: {BRACKET_ENVOPS_JSON}
                 _templates_suffix: {SUFFIX_TMPL}
                 _tasks:
@@ -302,11 +306,15 @@ def test_commit_hooks_respected(tmp_path_factory):
                     - pre-commit install
                     - pre-commit run -a || true
                 what: grog
-                """,
-                "[[ _copier_conf.answers_file ]].tmpl": """
+                """
+            ),
+            (src / "[[ _copier_conf.answers_file ]].tmpl"): (
+                """\
                 [[ _copier_answers|to_nice_yaml ]]
-                """,
-                ".pre-commit-config.yaml": r"""
+                """
+            ),
+            (src / ".pre-commit-config.yaml"): (
+                r"""
                 repos:
                 -   repo: https://github.com/pre-commit/mirrors-prettier
                     rev: v2.0.4
@@ -319,15 +327,19 @@ def test_commit_hooks_respected(tmp_path_factory):
                         entry: found forbidden files; remove them
                         language: fail
                         files: "\\.rej$"
-                """,
-                "life.yml.tmpl": """
+                """
+            ),
+            (src / "life.yml.tmpl"): (
+                """\
                 # Following code should be reformatted by pre-commit after copying
                 Line 1:      hello
                 Line 2:      [[ what ]]
                 Line 3:      bye
-                """,
-            }
-        )
+                """
+            ),
+        }
+    )
+    with local.cwd(src):
         git("init")
         git("add", ".")
         git("commit", "-m", "commit 1")
@@ -350,19 +362,21 @@ def test_commit_hooks_respected(tmp_path_factory):
             """
         )
     # Evolve source template to v2
-    with local.cwd(src):
-        build_file_tree(
-            {
-                "life.yml.tmpl": """
+    build_file_tree(
+        {
+            (src / "life.yml.tmpl"): (
+                """\
                 # Following code should be reformatted by pre-commit after copying
                 Line 1:     hello world
                 Line 2:     grow up
                 Line 3:     [[ what ]]
                 Line 4:     grow old
                 Line 5:     bye bye world
-                """,
-            }
-        )
+                """
+            ),
+        }
+    )
+    with local.cwd(src):
         git("init")
         git("add", ".")
         git("commit", "-m", "commit 2")
@@ -429,50 +443,61 @@ def test_commit_hooks_respected(tmp_path_factory):
         assert Path(f"{life}.rej").is_file()
 
 
-def test_update_from_tagged_to_head(src_repo, tmp_path):
+def test_update_from_tagged_to_head(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     # Build a template
-    with local.cwd(src_repo):
-        build_file_tree(
-            {
-                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
-                "example": "1",
-            }
-        )
+    build_file_tree(
+        {
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
+            (src / "example"): "1",
+        }
+    )
+    with local.cwd(src):
+        git("init")
         git("add", "-A")
         git("commit", "-m1")
         # Publish v1 release
         git("tag", "v1")
-        # New commit, no release
-        build_file_tree({"example": "2"})
+    # New commit, no release
+    build_file_tree(
+        {
+            src / "example": "2",
+        }
+    )
+    with local.cwd(src):
         git("commit", "-am2")
         sha = git("rev-parse", "--short", "HEAD").strip()
     # Copy it without specifying version
-    run_copy(src_path=str(src_repo), dst_path=tmp_path)
-    example = tmp_path / "example"
-    answers_file = tmp_path / ".copier-answers.yml"
+    run_copy(src_path=str(src), dst_path=dst)
+    example = dst / "example"
+    answers_file = dst / ".copier-answers.yml"
     assert example.read_text() == "1"
     assert yaml.safe_load(answers_file.read_text())["_commit"] == "v1"
     # Build repo on copy
-    with local.cwd(tmp_path):
+    with local.cwd(dst):
         git("init")
         git("add", "-A")
         git("commit", "-m3")
     # Update project, it must let us do it
-    run_update(tmp_path, vcs_ref="HEAD", defaults=True, overwrite=True)
+    run_update(dst, vcs_ref="HEAD", defaults=True, overwrite=True)
     assert example.read_text() == "2"
     assert yaml.safe_load(answers_file.read_text())["_commit"] == f"v1-1-g{sha}"
 
 
-def test_skip_update(tmp_path_factory):
+def test_skip_update(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yaml"): "_skip_if_exists: [skip_me]",
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_yaml }}"
+            ),
+            (src / "skip_me"): "1",
+        }
+    )
     with local.cwd(src):
-        build_file_tree(
-            {
-                "copier.yaml": "_skip_if_exists: [skip_me]",
-                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
-                "skip_me": "1",
-            }
-        )
         git("init")
         git("add", ".")
         git("commit", "-m1")
@@ -488,8 +513,12 @@ def test_skip_update(tmp_path_factory):
         git("init")
         git("add", ".")
         git("commit", "-m1")
+    build_file_tree(
+        {
+            src / "skip_me": "3",
+        }
+    )
     with local.cwd(src):
-        build_file_tree({"skip_me": "3"})
         git("commit", "-am2")
         git("tag", "2.0.0")
     run_update(dst, defaults=True, overwrite=True)
@@ -501,29 +530,36 @@ def test_skip_update(tmp_path_factory):
 
 @pytest.mark.timeout(20)
 @pytest.mark.parametrize(
-    "answers_file", (None, ".copier-answers.yml", ".custom.copier-answers.yaml")
+    "answers_file", [None, ".copier-answers.yml", ".custom.copier-answers.yaml"]
 )
 def test_overwrite_answers_file_always(
-    tmp_path_factory, answers_file: Optional[RelativePath]
+    tmp_path_factory: pytest.TempPathFactory, answers_file: Optional[str]
 ):
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yaml"): "question_1: true",
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_yaml }}"
+            ),
+            (src / "answer_1.jinja"): "{{ question_1 }}",
+        }
+    )
     with local.cwd(src):
-        build_file_tree(
-            {
-                "copier.yaml": "question_1: true",
-                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
-                "answer_1.jinja": "{{ question_1 }}",
-            }
-        )
         git("init")
         git("add", ".")
         git("commit", "-m1")
         git("tag", "1")
-        build_file_tree({"copier.yaml": "question_1: false"})
+    build_file_tree(
+        {
+            src / "copier.yaml": "question_1: false",
+        }
+    )
+    with local.cwd(src):
         git("commit", "-am2")
         git("tag", "2")
     # When copying, there's nothing to overwrite, overwrite=False shouldn't hang
-    run_copy(str(src), str(dst), vcs_ref="1", defaults=True, answers_file=answers_file)
+    run_copy(str(src), dst, vcs_ref="1", defaults=True, answers_file=answers_file)
     with local.cwd(dst):
         git("init")
         git("add", ".")
@@ -532,79 +568,88 @@ def test_overwrite_answers_file_always(
         # which shouldn't ask, so also this shouldn't hang with overwrite=False
         run_update(defaults=True, answers_file=answers_file)
     answers = yaml.safe_load(
-        Path(dst, answers_file or ".copier-answers.yml").read_bytes()
+        (dst / (answers_file or ".copier-answers.yml")).read_bytes()
     )
     assert answers["question_1"] is True
     assert answers["_commit"] == "2"
     assert (dst / "answer_1").read_text() == "True"
 
 
-def test_file_removed(src_repo, tmp_path):
+def test_file_removed(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     # Add a file in the template repo
-    with local.cwd(src_repo):
-        build_file_tree(
-            {
-                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
-                "1.txt": "content 1",
-                Path("dir 2", "2.txt"): "content 2",
-                Path("dir 3", "subdir 3", "3.txt"): "content 3",
-                Path("dir 4", "subdir 4", "4.txt"): "content 4",
-                Path("dir 5", "subdir 5", "5.txt"): "content 5",
-            }
-        )
+    build_file_tree(
+        {
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_yaml }}"
+            ),
+            (src / "1.txt"): "content 1",
+            (src / "dir 2" / "2.txt"): "content 2",
+            (src / "dir 3" / "subdir 3" / "3.txt"): "content 3",
+            (src / "dir 4" / "subdir 4" / "4.txt"): "content 4",
+            (src / "dir 5" / "subdir 5" / "5.txt"): "content 5",
+        }
+    )
+    with local.cwd(src):
+        git("init")
         git("add", "-A")
         git("commit", "-m1")
         git("tag", "1")
     # Copy in subproject
-    with local.cwd(tmp_path):
+    run_copy(str(src), dst)
+    with local.cwd(dst):
         git("init")
-        run_copy(str(src_repo))
-        # Subproject has an extra file
-        build_file_tree(
-            {
-                "I.txt": "content I",
-                Path("dir II", "II.txt"): "content II",
-                Path("dir 3", "subdir III", "III.txt"): "content III",
-                Path("dir 4", "subdir 4", "IV.txt"): "content IV",
-            }
-        )
+    # Subproject has an extra file
+    build_file_tree(
+        {
+            (dst / "I.txt"): "content I",
+            (dst / "dir II" / "II.txt"): "content II",
+            (dst / "dir 3" / "subdir III" / "III.txt"): "content III",
+            (dst / "dir 4" / "subdir 4" / "IV.txt"): "content IV",
+        }
+    )
+    with local.cwd(dst):
         git("add", "-A")
         git("commit", "-m2")
     # All files exist
-    assert tmp_path.joinpath(".copier-answers.yml").is_file()
-    assert tmp_path.joinpath("1.txt").is_file()
-    assert tmp_path.joinpath("dir 2", "2.txt").is_file()
-    assert tmp_path.joinpath("dir 3", "subdir 3", "3.txt").is_file()
-    assert tmp_path.joinpath("dir 4", "subdir 4", "4.txt").is_file()
-    assert tmp_path.joinpath("dir 5", "subdir 5", "5.txt").is_file()
-    assert tmp_path.joinpath("I.txt").is_file()
-    assert tmp_path.joinpath("dir II", "II.txt").is_file()
-    assert tmp_path.joinpath("dir 3", "subdir III", "III.txt").is_file()
-    assert tmp_path.joinpath("dir 4", "subdir 4", "IV.txt").is_file()
+    assert (dst / ".copier-answers.yml").is_file()
+    assert (dst / "1.txt").is_file()
+    assert (dst / "dir 2" / "2.txt").is_file()
+    assert (dst / "dir 3" / "subdir 3" / "3.txt").is_file()
+    assert (dst / "dir 4" / "subdir 4" / "4.txt").is_file()
+    assert (dst / "dir 5" / "subdir 5" / "5.txt").is_file()
+    assert (dst / "I.txt").is_file()
+    assert (dst / "dir II" / "II.txt").is_file()
+    assert (dst / "dir 3" / "subdir III" / "III.txt").is_file()
+    assert (dst / "dir 4" / "subdir 4" / "IV.txt").is_file()
     # Template removes file 1
-    with local.cwd(src_repo):
-        Path("1.txt").unlink()
-        rmtree("dir 2")
-        rmtree("dir 3")
-        rmtree("dir 4")
-        rmtree("dir 5")
-        build_file_tree({"6.txt": "content 6"})
+    (src / "1.txt").unlink()
+    rmtree(src / "dir 2")
+    rmtree(src / "dir 3")
+    rmtree(src / "dir 4")
+    rmtree(src / "dir 5")
+    build_file_tree(
+        {
+            src / "6.txt": "content 6",
+        }
+    )
+    with local.cwd(src):
         git("add", "-A")
         git("commit", "-m3")
         git("tag", "2")
     # Subproject updates
-    with local.cwd(tmp_path):
+    with local.cwd(dst):
         run_update(conflict="rej")
     # Check what must still exist
-    assert tmp_path.joinpath(".copier-answers.yml").is_file()
-    assert tmp_path.joinpath("I.txt").is_file()
-    assert tmp_path.joinpath("dir II", "II.txt").is_file()
-    assert tmp_path.joinpath("dir 3", "subdir III", "III.txt").is_file()
-    assert tmp_path.joinpath("dir 4", "subdir 4", "IV.txt").is_file()
-    assert tmp_path.joinpath("6.txt").is_file()
+    assert (dst / ".copier-answers.yml").is_file()
+    assert (dst / "I.txt").is_file()
+    assert (dst / "dir II" / "II.txt").is_file()
+    assert (dst / "dir 3" / "subdir III" / "III.txt").is_file()
+    assert (dst / "dir 4" / "subdir 4" / "IV.txt").is_file()
+    assert (dst / "6.txt").is_file()
     # Check what must not exist
-    assert not tmp_path.joinpath("1.txt").exists()
-    assert not tmp_path.joinpath("dir 2").exists()
-    assert not tmp_path.joinpath("dir 3", "subdir 3").exists()
-    assert not tmp_path.joinpath("dir 4", "subdir 4", "4.txt").exists()
-    assert not tmp_path.joinpath("dir 5").exists()
+    assert not (dst / "1.txt").exists()
+    assert not (dst / "dir 2").exists()
+    assert not (dst / "dir 3" / "subdir 3").exists()
+    assert not (dst / "dir 4" / "subdir 4" / "4.txt").exists()
+    assert not (dst / "dir 5").exists()

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -56,8 +56,9 @@ def test_get_repo() -> None:
     assert get("git.myproject.org/MyProject") is None
     assert get("https://google.com") is None
 
-    assert get(str(Path("tests", "demo_updatediff_repo.bundle"))) == str(
-        Path("tests", "demo_updatediff_repo.bundle")
+    assert (
+        get(str(Path("tests", "demo_updatediff_repo.bundle")))
+        == Path("tests", "demo_updatediff_repo.bundle").as_posix()
     )
 
 

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -56,8 +56,8 @@ def test_get_repo() -> None:
     assert get("git.myproject.org/MyProject") is None
     assert get("https://google.com") is None
 
-    assert (
-        get("tests/demo_updatediff_repo.bundle") == "tests/demo_updatediff_repo.bundle"
+    assert get(str(Path("tests", "demo_updatediff_repo.bundle"))) == str(
+        Path("tests", "demo_updatediff_repo.bundle")
     )
 
 


### PR DESCRIPTION
I've added type hints to the tests, so they are type-checked by `mypy` as well, and cleaned up the tests a bit, e.g. more consistent setup of temporary template and subproject directories, formatting of template tree creation code for improved readability (IMO), consistent usage of the `pathlib` API instead of the `os`/`os.path` API, etc.

I know it's a quite big PR and probably not much fun to review :see_no_evil: - sorry about that :confused: -, but I felt the tests could use some love :smile_cat:.