### PR TITLE
docs: use tree fence for filesystem trees

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ A library and CLI app for rendering project templates.
 To create a template:
 
 ```shell
-📁 my_copier_template ------------------------ # your template project
-├── 📄 copier.yml ---------------------------- # your template configuration
-├── 📁 .git/ --------------------------------- # your template is a Git repository
-├── 📁 {{project_name}} ---------------------- # a folder with a templated name
-│   └── 📄 {{module_name}}.py.jinja ---------- # a file with a templated name
-└── 📄 {{_copier_conf.answers_file}}.jinja --- # answers are recorded here
+📁 my_copier_template                        # your template project
+├── 📄 copier.yml                            # your template configuration
+├── 📁 .git/                                 # your template is a Git repository
+├── 📁 {{project_name}}                      # a folder with a templated name
+│   └── 📄 {{module_name}}.py.jinja          # a file with a templated name
+└── 📄 {{_copier_conf.answers_file}}.jinja   # answers are recorded here
 ```
 
 ```yaml title="copier.yml"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To create a template:
 ```shell
 📁 my_copier_template ------------------------ # your template project
 ├── 📄 copier.yml ---------------------------- # your template configuration
-├── 📁 .git ---------------------------------- # your template is a Git repository
+├── 📁 .git/ --------------------------------- # your template is a Git repository
 ├── 📁 {{project_name}} ---------------------- # a folder with a templated name
 │   └── 📄 {{module_name}}.py.jinja ---------- # a file with a templated name
 └── 📄 {{_copier_conf.answers_file}}.jinja --- # answers are recorded here

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -414,10 +414,10 @@ use_precommit:
 
 And then, you can generate a `.pre-commit-config.yaml` file only if they answered "yes":
 
-```shell
-📁 your_template
-├── 📄 copier.yml
-└── 📄 {% if use_precommit %}.pre-commit-config.yaml{% endif %}.jinja
+```tree result="shell"
+your_template
+    copier.yml
+    {% if use_precommit %}.pre-commit-config.yaml{% endif %}.jinja
 ```
 
 !!! important
@@ -439,14 +439,13 @@ ci:
     default: github
 ```
 
-```shell
-📁 your_template
-├── 📄 copier.yml
-├── 📁 {% if ci == 'github' %}.github{% endif %}
-│   └── 📁 workflows
-│       └── 📄 ci.yml
-└── 📄 {% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
-
+```tree result="shell"
+your_template
+    copier.yml
+    {% if ci == 'github' %}.github{% endif %}
+        workflows
+            ci.yml
+    {% if ci == 'gitlab' %}.gitlab-ci.yml{% endif %}.jinja
 ```
 
 !!! important
@@ -468,10 +467,10 @@ package:
     help: Package name
 ```
 
-```shell
-📁 your_template
-├── 📄 copier.yml
-└── 📄 {{ package.replace('.', _copier_conf.sep) }}{{ _copier_conf.sep }}__main__.py.jinja
+```tree result="shell"
+your_template
+    copier.yml
+    {{ package.replace('.', _copier_conf.sep) }}{{ _copier_conf.sep }}__main__.py.jinja
 ```
 
 If you answer
@@ -480,12 +479,12 @@ If you answer
 
 Copier will generate this structure:
 
-```shell
-📁 your_project
-└── 📁 your_package
-    └── 📁 cli
-        └── 📁 main
-            └── 📄 __main__.py
+```tree result="shell"
+your_project
+    your_package
+        cli
+            main
+                __main__.py
 ```
 
 You can either use any separator, like `.`, and replace it with `_copier_conf.sep`, like
@@ -988,12 +987,12 @@ This allows you to keep separate the template metadata and the template code.
     !!! example "Example project with different `.gitignore` files"
 
 
-        ```shell title="Project layout"
-        📁 my_copier_template
-        ├── 📄 copier.yml       # (1)
-        ├── 📄 .gitignore       # (2)
-        └── 📁 template         # (3)
-            └── 📄 .gitignore   # (4)
+        ```tree result="shell" title="Project layout"
+        my_copier_template
+            copier.yml       # (1)
+            .gitignore       # (2)
+            template         # (3)
+                .gitignore   # (4)
         ```
 
         1.  Same contents as the example above.
@@ -1021,15 +1020,15 @@ This allows you to keep separate the template metadata and the template code.
                 - pipenv
         ```
 
-        ```shell title="Project layout"
-        📁 my_copier_template
-        ├── 📄 copier.yaml # (1)
-        ├── 📁 poetry
-        │   ├── 📄 {{ _copier_conf.answers_file }}.jinja # (2)
-        │   └── 📄 pyproject.toml.jinja
-        └── 📁 pipenv
-            ├── 📄 {{ _copier_conf.answers_file }}.jinja
-            └── 📄 Pipfile.jinja
+        ```tree result="shell" title="Project layout"
+        my_copier_template
+            copier.yaml # (1)
+            poetry
+                {{ _copier_conf.answers_file }}.jinja # (2)
+                pyproject.toml.jinja
+            pipenv
+                {{ _copier_conf.answers_file }}.jinja
+                Pipfile.jinja
         ```
 
         1.  The configuration from the previous example snippet.

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -15,13 +15,13 @@ project, the user will be prompted to fill in or confirm the default values.
 
 ## Minimal example
 
-```shell
-📁 my_copier_template ------------------------ # your template project
-├── 📄 copier.yml ---------------------------- # your template configuration
-├── 📁 .git ---------------------------------- # your template is a Git repository
-├── 📁 {{project_name}} ---------------------- # a folder with a templated name
-│   └── 📄 {{module_name}}.py.jinja ---------- # a file with a templated name
-└── 📄 {{_copier_conf.answers_file}}.jinja --- # answers are recorded here
+```tree result="shell"
+my_copier_template ---------------------------- # your template project
+    copier.yml -------------------------------- # your template configuration
+    .git/ ------------------------------------- # your template is a Git repository
+    {{project_name}} -------------------------- # a folder with a templated name
+        {{module_name}}.py.jinja -------------- # a file with a templated name
+        {{_copier_conf.answers_file}}.jinja --- # answers are recorded here
 ```
 
 ```yaml title="copier.yml"
@@ -48,11 +48,11 @@ Generating a project from this template with `super_project` and `world` as answ
 the `project_name` and `module_name` questions respectively would create in the
 following directory and files:
 
-```shell
-📁 generated_project
-├── 📁 super_project
-│   └── 📄 world.py
-└── 📄 .copier-answers.yml
+```tree result="shell"
+generated_project
+    super_project
+        world.py
+    .copier-answers.yml
 ```
 
 ```python title="super_project/world.py"

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -16,12 +16,12 @@ project, the user will be prompted to fill in or confirm the default values.
 ## Minimal example
 
 ```tree result="shell"
-my_copier_template ---------------------------- # your template project
-    copier.yml -------------------------------- # your template configuration
-    .git/ ------------------------------------- # your template is a Git repository
-    {{project_name}} -------------------------- # a folder with a templated name
-        {{module_name}}.py.jinja -------------- # a file with a templated name
-        {{_copier_conf.answers_file}}.jinja --- # answers are recorded here
+my_copier_template                            # your template project
+    copier.yml                                # your template configuration
+    .git/                                     # your template is a Git repository
+    {{project_name}}                          # a folder with a templated name
+        {{module_name}}.py.jinja              # a file with a templated name
+        {{_copier_conf.answers_file}}.jinja   # answers are recorded here
 ```
 
 ```yaml title="copier.yml"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ markdown_extensions:
 plugins:
   - autorefs
   - search
+  - markdown-exec
   - mkdocstrings:
       watch:
         - copier

--- a/poetry.lock
+++ b/poetry.lock
@@ -499,6 +499,24 @@ importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 testing = ["coverage", "pyyaml"]
 
 [[package]]
+name = "markdown-exec"
+version = "1.3.0"
+description = "Utilities to execute code blocks in Markdown files."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "markdown-exec-1.3.0.tar.gz", hash = "sha256:5aea8a557da4e700f5a45a79c4ec5791261221ed89a8db31a02cf21f791605e4"},
+    {file = "markdown_exec-1.3.0-py3-none-any.whl", hash = "sha256:67d55ea5934b8a6194e43ea9b6e9243637991a29033956e5043e964276bfe92a"},
+]
+
+[package.dependencies]
+pymdown-extensions = ">=9"
+
+[package.extras]
+ansi = ["pygments-ansi-color"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1476,4 +1494,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<4.0"
-content-hash = "bf3631631b104b7c1fbccb5021598dda52fffa82f57b5014df051944959b4d23"
+content-hash = "54c9127b668a0dd2e026a883f63fc594427a253086e1b0d5ed1368e426996b84"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ types-psutil = "*"
 optional = true
 
 [tool.poetry.group.docs.dependencies]
+markdown-exec = ">=1.3.0"
 mkdocs-material = ">=8.2,<9.0.0"
 mkdocstrings = { version = ">=0.19.0", extras = ["python"] }
 


### PR DESCRIPTION
I've added the [`markdown-exec`](https://github.com/pawamoy/markdown-exec) MkDocs plugin and replaced the manually written filesystem trees using Unicode characters by [`markdown-exec`'s `tree` fence](https://pawamoy.github.io/markdown-exec/usage/tree/) that automates the rendering of filesystem trees.

See https://github.com/copier-org/copier/pull/988#issuecomment-1436892212 for a prior discussion.