### PR TITLE
chore: use MkDocs' builtin watch feature

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ site_description: Library and command-line utility for rendering projects templa
 site_url: https://copier.readthedocs.io/
 repo_url: https://github.com/copier-org/copier
 repo_name: copier-org/copier
+watch: [copier]
 
 nav:
   - Overview: "index.md"
@@ -68,6 +69,4 @@ markdown_extensions:
 plugins:
   - autorefs
   - search
-  - mkdocstrings:
-      watch:
-        - copier
+  - mkdocstrings


### PR DESCRIPTION
I've migrated from `mkdocstrings`' deprecated watch feature to MkDocs' builtin watch feature. `mkdocstrings`' watch feature was deprecated in [v0.19.0](https://mkdocstrings.github.io/changelog/#0190-2022-05-28).

Prior to this PR, serving the docs locally showed the deprecation warning:

```shell-session
$ mkdocs serve
INFO     -  Building documentation...
INFO     -  mkdocstrings: DEPRECATION: mkdocstrings' watch feature is deprecated in favor of MkDocs' watch feature, see https://www.mkdocs.org/user-guide/configuration/#watch
...
```