### PR TITLE
build(lint): use podman before docker

### DIFF
--- a/devtasks.py
+++ b/devtasks.py
@@ -64,7 +64,7 @@ def lint(recycle_container=False):
         local["nix"].with_cwd(HERE)[args] & TEE
     except CommandNotFound:
         _logger.warn("Nix not found; fallback to a container")
-        runner = local.get("docker", "podman")
+        runner = local.get("podman", "docker")
         try:
             (
                 runner[


### PR DESCRIPTION
Folks that have both tend to prefer podman.