### PR TITLE
fix: parse CLI data using question's answer parser

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -50,7 +50,6 @@ from pathlib import Path
 from textwrap import dedent
 from unittest.mock import patch
 
-import yaml
 from plumbum import cli, colors
 
 from copier.tools import copier_version
@@ -191,7 +190,6 @@ class CopierApp(cli.Application):
         """
         for arg in values:
             key, value = arg.split("=", 1)
-            value = yaml.safe_load(value)
             self.data[key] = value
 
     def _worker(self, src_path: OptStr = None, dst_path: str = ".", **kwargs) -> Worker:

--- a/copier/main.py
+++ b/copier/main.py
@@ -367,14 +367,14 @@ class Worker:
                 **details,
             )
             if var_name in result.init:
-                answer = result.init[var_name]
                 # Try to parse the answer value.
-                question.parse_answer(answer)
+                answer = question.parse_answer(result.init[var_name])
                 # Try to validate the answer value if the question has a
                 # validator.
                 question.validate_answer(answer)
                 # At this point, the answer value is valid. Do not ask the
-                # question again.
+                # question again, but set answer as the user's answer instead.
+                result.user[var_name] = answer
                 continue
 
             questions.append(question)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -66,6 +66,63 @@ def test_good_cli_run(tmp_path, template_path):
 
 
 @pytest.mark.parametrize(
+    "type_, answer, expected",
+    [
+        ("str", "string", "string"),
+        ("str", "1", "1"),
+        ("str", "1.2", "1.2"),
+        ("str", "true", "true"),
+        ("str", "null", "null"),
+        ("str", '["string", 1, 1.2, true, null]', '["string", 1, 1.2, true, null]'),
+        ("int", "1", 1),
+        ("float", "1.2", 1.2),
+        ("bool", "true", True),
+        ("bool", "false", False),
+        ("yaml", '"string"', "string"),
+        ("yaml", "1", 1),
+        ("yaml", "1.2", 1.2),
+        ("yaml", "true", True),
+        ("yaml", "null", None),
+        ("yaml", '["string", 1, 1.2, true, null]', ["string", 1, 1.2, True, None]),
+        ("json", '"string"', "string"),
+        ("json", "1", 1),
+        ("json", "1.2", 1.2),
+        ("json", "true", True),
+        ("json", "null", None),
+        ("json", '["string", 1, 1.2, true, null]', ["string", 1, 1.2, True, None]),
+    ],
+)
+def test_cli_data_parsed_by_question_type(
+    tmp_path_factory: pytest.TempPathFactory, type_, answer, expected
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yml"): (
+                f"""\
+                question:
+                    type: {type_}
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+        }
+    )
+    run_result = CopierApp.run(
+        ["--quiet", f"--data=question={answer}", str(src), str(dst)],
+        exit=False,
+    )
+    assert run_result[1] == 0
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    assert answers["_src_path"] == str(src)
+    assert answers["question"] == expected
+
+
+@pytest.mark.parametrize(
     "config_folder",
     map(
         Path,

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -280,16 +280,16 @@ def test_api_str_data(tmp_path, template_path):
     results_file = tmp_path / "results.txt"
     assert results_file.read_text() == dedent(
         """\
-            love_me: "false"
+            love_me: false
             your_name: "LeChuck"
-            your_age: "220"
-            your_height: "1.9"
-            more_json_info: "[\\"bad\\", \\"guy\\"]"
-            anything_else: "{\\u0027hates\\u0027: \\u0027all\\u0027}"
+            your_age: 220
+            your_height: 1.9
+            more_json_info: ["bad", "guy"]
+            anything_else: {"hates": "all"}
             choose_list: "first"
             choose_tuple: "second"
             choose_dict: "third"
-            choose_number: "0"
+            choose_number: 0.0
             minutes_under_water: 10
             optional_value: null
         """
@@ -356,7 +356,7 @@ def test_cli_interatively_with_flag_data_and_type_casts(
             choose_list: "second"
             choose_tuple: "third"
             choose_dict: "first"
-            choose_number: 1
+            choose_number: 1.0
             minutes_under_water: 10
             optional_value: null
         """


### PR DESCRIPTION
I've fixed the parsing of answers provided via CLI using the `--data` flag (or implicitly also via API using the `data` argument when answers are provided as strings).

Before, answers passed via the `--data` flag (i.e. string values) were [parsed using `yaml.safe_load(...)`](https://github.com/copier-org/copier/blob/ab31906aba40bec33bffec99e9ea15fe717690e2/copier/cli.py#L194) which in general is not the same as parsing answers via the [question's answer parser](https://github.com/copier-org/copier/blob/ab31906aba40bec33bffec99e9ea15fe717690e2/copier/user_data.py#L401-L411). For instance, `--data=str_question=1.2` was parsed as a `float` value although it's a `str` question. I've removed the incorrect `yaml.safe_load(...)` parser and use the question's parser instead, so that answer are parsed according to the type of their corresponding question.

Note also that two tests in `tests/test_complex_questions.py` turned out to have incorrect expectations. I've fixed those, too.