### PR TITLE
refactor(tests): remove unknown timeout marker

### DIFF
--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -499,7 +499,6 @@ def test_skip_update(tmp_path_factory):
     assert not (dst / "skip_me.rej").exists()
 
 
-@pytest.mark.timeout(20)
 @pytest.mark.parametrize(
     "answers_file", (None, ".copier-answers.yml", ".custom.copier-answers.yaml")
 )


### PR DESCRIPTION
I've removed an unknown `pytest` marker `pytest.mark.timeout(...)`. A warning is shown when running the test suite:

```shell-session
$ pytest tests/test_updatediff.py
...
  copier/tests/test_updatediff.py:502: PytestUnknownMarkWarning: Unknown pytest.mark.timeout - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.timeout(20)
...
```

The test was added in #424, but I don't think the timeout marker ever worked because [`pytest` v6.2.2](https://github.com/copier-org/copier/blob/7bbd0406b854664954dd98634a281cfff311cb7d/poetry.lock#L793-L794) was used at the time and [didn't seem to contain this marker](https://docs.pytest.org/en/6.2.x/search.html?q=timeout). [`pytest-timeout`](https://github.com/pytest-dev/pytest-timeout) provides it but wasn't and isn't installed. Since it seems the marker never had an effect and since it's used nowhere else in the test suite, I think it's fine to remove it.