### PR TITLE
build(flake): fix wrong spelling of substituters, and use nicer list syntax

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,18 @@
 {
   description = "Source code project lifecycle management tool";
 
-  # HACK https://github.com/NixOS/nix/issues/6771
-  # TODO Leave only Copier's settings when fixed
   nixConfig = {
-    extra-trusted-public-keys = "copier.cachix.org-1:sVkdQyyNXrgc53qXPCH9zuS91zpt5eBYcg7JQSmTBG4= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw=";
-    extra-substitutes = "https://copier.cachix.org https://devenv.cachix.org";
+    # HACK https://github.com/NixOS/nix/issues/6771
+    # TODO Leave only own cache settings when fixed
+    extra-trusted-public-keys = [
+      "copier.cachix.org-1:sVkdQyyNXrgc53qXPCH9zuS91zpt5eBYcg7JQSmTBG4="
+      "devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw="
+    ];
+    extra-substituters = [
+      "https://copier.cachix.org"
+      "https://devenv.cachix.org"
+    ];
   };
-
   inputs = {
     devenv.url = "github:cachix/devenv/v0.5";
     flake-compat = {


### PR DESCRIPTION
Oops, I did it wrong in 62b5dc36b3818ef550d21932ee49dccae5f3f494. Fixing.