### PR TITLE
introducing project mode

### DIFF
--- a/copier/renderer.py
+++ b/copier/renderer.py
@@ -1,0 +1,139 @@
+from dataclasses import dataclass
+from functools import cached_property
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional
+
+from jinja2 import Environment
+
+from .subproject import Subproject
+from .template import Template
+
+
+@dataclass
+class Renderer:
+    template: Template
+    subproject: Subproject
+    _render_allowed: Callable
+    pretend: bool
+    jinja_env: Environment
+    answers_relpath: Path
+    _render_context: Mapping[str, Any]
+
+    def render(self):
+        self._render_folder(self.template.local_abspath)
+
+    def _render_folder(self, src_abspath: Path) -> None:
+        """Recursively render a folder.
+
+        Args:
+            src_abspath:
+                Folder to be rendered. It must be an absolute path within
+                the template.
+        """
+        assert src_abspath.is_absolute()
+        src_relpath = src_abspath.relative_to(self.template_copy_root)
+        dst_relpath = self._render_path(src_relpath)
+        if dst_relpath is None:
+            return
+        if not self._render_allowed(dst_relpath, is_dir=True):
+            return
+        dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
+        if not self.pretend:
+            dst_abspath.mkdir(parents=True, exist_ok=True)
+        for file in src_abspath.iterdir():
+            if file.is_dir():
+                self._render_folder(file)
+            else:
+                self._render_file(file)
+
+    def _render_path(self, relpath: Path) -> Optional[Path]:
+        """Render one relative path.
+
+        Args:
+            relpath:
+                The relative path to be rendered. Obviously, it can be templated.
+        """
+        is_template = relpath.name.endswith(self.template.templates_suffix)
+        templated_sibling = (
+            self.template.local_abspath / f"{relpath}{self.template.templates_suffix}"
+        )
+        # With an empty suffix, the templated sibling always exists.
+        if templated_sibling.exists() and self.template.templates_suffix:
+            return None
+        if self.template.templates_suffix and is_template:
+            relpath = relpath.with_suffix("")
+        rendered_parts = []
+        for part in relpath.parts:
+            # Skip folder if any part is rendered as an empty string
+            part = self.render_string(part)
+            if not part:
+                return None
+            # {{ _copier_conf.answers_file }} becomes the full path; in that case,
+            # restore part to be just the end leaf
+            if str(self.answers_relpath) == part:
+                part = Path(part).name
+            rendered_parts.append(part)
+        result = Path(*rendered_parts)
+        if not is_template:
+            templated_sibling = (
+                self.template.local_abspath
+                / f"{result}{self.template.templates_suffix}"
+            )
+            if templated_sibling.exists():
+                return None
+        return result
+
+    def _render_file(self, src_abspath: Path) -> None:
+        """Render one file.
+
+        Args:
+            src_abspath:
+                The absolute path to the file that will be rendered.
+        """
+        # TODO Get from main.render_file()
+        assert src_abspath.is_absolute()
+        src_relpath = src_abspath.relative_to(self.template.local_abspath).as_posix()
+        src_renderpath = src_abspath.relative_to(self.template_copy_root)
+        dst_relpath = self._render_path(src_renderpath)
+        if dst_relpath is None:
+            return
+        if src_abspath.name.endswith(self.template.templates_suffix):
+            try:
+                tpl = self.jinja_env.get_template(src_relpath)
+            except UnicodeDecodeError:
+                if self.template.templates_suffix:
+                    # suffix is not empty, re-raise
+                    raise
+                # suffix is empty, fallback to copy
+                new_content = src_abspath.read_bytes()
+            else:
+                new_content = tpl.render(**self._render_context).encode()
+        else:
+            new_content = src_abspath.read_bytes()
+        dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
+        src_mode = src_abspath.stat().st_mode
+        if not self._render_allowed(dst_relpath, expected_contents=new_content):
+            return
+        if not self.pretend:
+            dst_abspath.parent.mkdir(parents=True, exist_ok=True)
+            dst_abspath.write_bytes(new_content)
+            dst_abspath.chmod(src_mode)
+
+    def render_string(self, string: str) -> str:
+        """Render one templated string.
+
+        Args:
+            string:
+                The template source string.
+        """
+        tpl = self.jinja_env.from_string(string)
+        return tpl.render(**self._render_context)
+
+    @cached_property
+    def template_copy_root(self) -> Path:
+        """Absolute path from where to start copying.
+
+        It points to the cloned template local abspath + the rendered subdir, if any.
+        """
+        subdir = self.render_string(self.template.subdirectory) or ""
+        return self.template.local_abspath / subdir

--- a/tests/test_project_mode.py
+++ b/tests/test_project_mode.py
@@ -1,0 +1,120 @@
+import warnings
+
+import copier
+from tests.helpers import build_file_tree
+
+
+def test_render_items(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src
+            / "copier.yml": """
+                _items: items
+            """,
+            src
+            / "items"
+            / "{{_item}}.txt.jinja": "This is {{ _item }}. Hello {{hello}}",
+        }
+    )
+    # No warnings, because template is explicit
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        copier.run_auto(
+            str(src),
+            dst,
+            data={
+                "items": ["one", "two", "three"],
+                "hello": "world",
+            },
+            defaults=True,
+            overwrite=True,
+        )
+
+        one_rendered = (dst / "one.txt").read_text()
+        one_expected = "This is one. Hello world"
+        assert one_rendered == one_expected
+
+        one_rendered = (dst / "two.txt").read_text()
+        one_expected = "This is two. Hello world"
+        assert one_rendered == one_expected
+
+        one_rendered = (dst / "three.txt").read_text()
+        one_expected = "This is three. Hello world"
+        assert one_rendered == one_expected
+
+
+def test_render_items_conditional(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src
+            / "copier.yml": """
+                _items: a
+            """,
+            src
+            / "a"
+            / "{{_item.value}}.txt.jinja": "This is {{ _item.value }}. Hello {{hello}}",
+        }
+    )
+    # No warnings, because template is explicit
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        data = {
+            "a": [
+                {"value": "one"},
+            ],
+            "b": [
+                {"value": "two"},
+            ],
+            "hello": "world",
+        }
+        copier.run_auto(str(src), dst, data=data, defaults=True, overwrite=True)
+
+        one_rendered = (dst / "one.txt").read_text()
+        one_expected = "This is one. Hello world"
+        assert one_rendered == one_expected
+
+        assert not (dst / "two.txt").exists()
+
+
+def test_render_items_list(tmp_path_factory):
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src
+            / "copier.yml": """
+                _items:
+                - apples
+                - oranges
+            """,
+            src
+            / "apples"
+            / "{{_item.value}}.txt.jinja": "This is {{ _item.value }}. Hello {{hello}}",
+            src
+            / "oranges"
+            / "{{_item.value}}.txt.jinja": "This is {{ _item.value }}. Hello {{hello}}",
+        }
+    )
+    # No warnings, because template is explicit
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        data = {
+            "apples": [
+                {"value": "apple_one"},
+                {"value": "apple_two"},
+            ],
+            "oranges": [
+                {"value": "orange_one"},
+                {"value": "orange_two"},
+            ],
+            "hello": "world",
+        }
+        copier.run_auto(str(src), dst, data=data, defaults=True, overwrite=True)
+
+        assert (dst / "apple_one.txt").read_text() == "This is apple_one. Hello world"
+        assert (dst / "apple_two.txt").read_text() == "This is apple_two. Hello world"
+        assert (dst / "orange_one.txt").read_text() == "This is orange_one. Hello world"
+        assert (dst / "orange_one.txt").read_text() == "This is orange_one. Hello world"


### PR DESCRIPTION
1. First commit extracts a Renderer class from Worker.
     Not only Worker is huge and does a lot, but the new class greatly simplifies rendering the template for each project-mode item in the next commit.
    The idea behind it was that it encapsulates the template and accepts answers to render the output.
    I decided to leave _allow_render in Worker and pass it as a function argument, as it uses data stored in Worker. Let me know if you can think of a better way to split responsibility between those two.
2. Add looping over items
  - accept `_items` in `copier.yaml` as either a string or a list of strings. Internally it's always a list.
  - use each key to read a list of items from answers, and render _its part_ of the template, stored under `{{template_root}}/{{key}}`
    So if you have _items: ['a'], copier expects an answer `a` to be a list of values, and uses each value to render a sub-template stored in 'a'.
  - all directories under root ,that are named like the keys under `_items` are excluded from normal rendering.
3. Not sure how to structure the documentation. Needs changes to both the template and configuration parts. Shell I create a new file for the project mode?
4. If nobody minds, I'd like to disable the "identical" message for directories. I'm getting it a hundred of times when run in a loop and it doesn't do anything useful for directories.

example template: https://github.com/python-lapidary/lapidary-template/tree/test2