### PR TITLE
feat: Parse templates in _answers_file setting

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -419,7 +419,7 @@ class Worker:
         """
         path = self.answers_file or self.template.answers_relpath
         template = self.jinja_env.from_string(str(path))
-        return Path(template.render())
+        return Path(template.render(**self.answers.combined))
 
     @cached_property
     def all_exclusions(self) -> StrSeq:

--- a/copier/main.py
+++ b/copier/main.py
@@ -417,7 +417,9 @@ class Worker:
         2. Template default.
         3. Copier default.
         """
-        return self.answers_file or self.template.answers_relpath
+        path = self.answers_file or self.template.answers_relpath
+        template = self.jinja_env.from_string(str(path))
+        return Path(template.render())
 
     @cached_property
     def all_exclusions(self) -> StrSeq:

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 import pytest
 
 import copier
@@ -52,8 +50,7 @@ def test_answersfile_templating(template_path, tmp_path, answers_file):
         if answers_file is None
         else ".changed-by-user.yml"
     )
-    path = Path(tmp_path) / (first_answers_file)
-    assert path.exists()
+    assert (tmp_path / first_answers_file).exists()
     answers = load_answersfile_data(tmp_path, first_answers_file)
     assert answers["module_name"] == "mymodule"
 
@@ -67,13 +64,11 @@ def test_answersfile_templating(template_path, tmp_path, answers_file):
 
     # Assert second one created
     second_answers_file = ".copier-answers-anothermodule.yml"
-    path = Path(tmp_path) / (second_answers_file)
-    assert path.exists()
+    assert (tmp_path / second_answers_file).exists()
     answers = load_answersfile_data(tmp_path, second_answers_file)
     assert answers["module_name"] == "anothermodule"
 
     # Assert first one still exists
-    path = Path(tmp_path) / (first_answers_file)
-    assert path.exists()
+    assert (tmp_path / first_answers_file).exists()
     answers = load_answersfile_data(tmp_path, first_answers_file)
     assert answers["module_name"] == "mymodule"

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import pytest
+
+import copier
+
+from .helpers import build_file_tree
+
+
+@pytest.fixture(scope="module")
+def template_path(tmp_path_factory) -> str:
+    root = tmp_path_factory.mktemp("template")
+    build_file_tree(
+        {
+            root
+            / ".copier-answers-{{module_name}}.yml": """\
+                # Changes here will be overwritten by Copier
+                [[ _copier_answers|to_nice_yaml ]]
+                """,
+            root
+            / "copier.yml": """\
+                _answers_file: .answers-file-changed-in-template.yml
+
+                module_name:
+                    type: str
+                """,
+        }
+    )
+    return str(root)
+
+
+@pytest.mark.parametrize("answers_file", [None, ".changed-by-user.yaml"])
+def test_answersfile_templating(template_path, tmp_path, answers_file):
+    """Test copier behaves properly when using an answersfile."""
+    copier.copy(
+        template_path,
+        tmp_path,
+        {"module_name": "mymodule"},
+        answers_file=answers_file,
+        defaults=True,
+        overwrite=True,
+    )
+    answers_file = ".copier-answers-mymodule.yml"
+    path = Path(tmp_path) / (answers_file)
+    assert path.exists()
+    copier.copy(
+        template_path,
+        tmp_path,
+        {"module_name": "anothermodule"},
+        defaults=True,
+        overwrite=True,
+    )
+    answers_file = ".copier-answers-anothermodule.yml"
+    path = Path(tmp_path) / (answers_file)
+    assert path.exists()
+    answers_file = ".copier-answers-mymodule.yml"
+    path = Path(tmp_path) / (answers_file)
+    assert path.exists()


### PR DESCRIPTION
Adds the ability for `_answers_file` to contain template variables. For example:
```yaml
# copier.yml
_answers_file: ".copier-answers.{{ foo }}.yml"

foo:
  type: str
```

Closes #866

Since #882 seems to have been abandoned and the tests weren't actually working, I've opened up this PR instead.
