### PR TITLE
build(direnv): simpler config by inheriting flake configs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -13,7 +13,5 @@ layout_poetry() {
     export VIRTUAL_ENV
 }
 
-use flake . \
-    --extra-substituters 'https://copier.cachix.org https://devenv.cachix.org' \
-    --extra-trusted-public-keys 'copier.cachix.org-1:sVkdQyyNXrgc53qXPCH9zuS91zpt5eBYcg7JQSmTBG4= devenv.cachix.org-1:w1cLUi8dv3hnoSPGAuibQv+f9TZLr6cv/Hm9XgU50cw='
+use flake . --impure --accept-flake-config
 layout_poetry


### PR DESCRIPTION
Before this patch, opening Copier on Gitpod made direnv freeze.