### PR TITLE
fix(cleanup): don't clean up local template in parent folder

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -460,7 +460,9 @@ class Template:
                 checkout_latest_tag(result, self.use_prereleases)
         if not result.is_dir():
             raise ValueError("Local template must be a directory.")
-        return result.absolute()
+        with suppress(OSError):
+            result = result.resolve()
+        return result
 
     @cached_property
     def url_expanded(self) -> str:

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,6 +1,8 @@
+from pathlib import Path
 from subprocess import CalledProcessError
 
 import pytest
+from plumbum import local
 
 import copier
 
@@ -34,3 +36,16 @@ def test_no_cleanup_when_folder_existed(tmp_path):
         copier.copy("./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=True)
     assert tmp_path.exists()
     assert preexisting_file.exists()
+
+
+def test_no_cleanup_when_template_in_parent_folder(tmp_path: Path) -> None:
+    """Copier will not delete a local template in a parent folder."""
+    src = tmp_path / "src"
+    src.mkdir()
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    with local.cwd(cwd):
+        copier.copy(str(Path("..", "src")), dst, quiet=True)
+    assert src.exists()


### PR DESCRIPTION
I've fixed a bug where a local template in a parent folder (with a relative path component `..` in the source path) was incorrectly cleaned up.

The problem was that the path comparison

https://github.com/copier-org/copier/blob/91966047d9741099b4925612c5c0c3a0dbe2490c/copier/template.py#L226

failed when the template path contained `..` because [`Path(...).absolute()` does not perform path normalization](https://docs.python.org/3/library/pathlib.html#pathlib.Path.absolute) such as relative path resolution, so the absolute path of `clone_path` still contained `..` whereas the absolute path of `original_path` did not. I've replaced `Path(...).absolute()` by [`Path(...).resolve()` which does perform path normalization](https://docs.python.org/3/library/pathlib.html#pathlib.Path.resolve).

Fixes #1029.