### PR TITLE
docs: add supported Git URL patterns

### DIFF
--- a/docs/generating.md
+++ b/docs/generating.md
@@ -18,50 +18,10 @@ Or within Python code:
 copier.run_auto("path/to/project/template", "path/to/destination")
 ```
 
-The "template" parameter can be a local path, a URL, or a shortcut URL. The following
-shortcut URLs are supported:
+The "template" parameter can be a local path, an URL, or a shortcut URL:
 
 -   GitHub: `gh:namespace/project`
 -   GitLab: `gl:namespace/project`
-
-When using a URL, `https://github.com/*` and `https://gitlab.com/*` are automatically
-recognized as Git URLs. For other Git server URLs, the following combinations of
-prefixes and postfixes are compatible:
-
-=== "HTTP protocol"
-
-    |  `git+` prefix   |  `.git` postfix  |
-    | :--------------: | :--------------: |
-    | :material-check: |                  |
-    |                  | :material-check: |
-    | :material-check: | :material-check: |
-
-=== "SSH protocol"
-
-    |  `git@` prefix   | `git+ssh://` prefix | `ssh://` prefix  |  `.git` postfix  |
-    | :--------------: | :-----------------: | :--------------: | :--------------: |
-    | :material-check: |                     |                  |                  |
-    | :material-check: |                     |                  | :material-check: |
-    |                  |  :material-check:   |                  |                  |
-    |                  |  :material-check:   |                  | :material-check: |
-    |                  |                     | :material-check: | :material-check: |
-
-=== "Git protocol"
-
-    | `git://` prefix  |  `.git` postfix  |
-    | :--------------: | :--------------: |
-    | :material-check: |                  |
-    | :material-check: | :material-check: |
-
-    !!! danger
-
-        The Git protocol is [discouraged for security reasons][git-protocol-cons] and
-        not supported by [GitHub][git-protocol-github] and GitLab.
-
-[git-protocol-cons]:
-    https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_the_cons_4
-[git-protocol-github]:
-    https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git)
 
 Use the `--data` command-line argument or the `data` parameter of the
 `copier.run_auto()` function to pass whatever extra context you want to be available in

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -23,6 +23,9 @@ The "template" parameter can be a local path, an URL, or a shortcut URL:
 -   GitHub: `gh:namespace/project`
 -   GitLab: `gl:namespace/project`
 
+If Copier doesn't detect your remote URL as a Git repository, make sure it starts with
+one of `git+https://`, `git+ssh://`, `git@` or `git://`, or it ends with `.git`.
+
 Use the `--data` command-line argument or the `data` parameter of the
 `copier.run_auto()` function to pass whatever extra context you want to be available in
 the templates. The arguments can be any valid Python value, even a function.

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -18,10 +18,50 @@ Or within Python code:
 copier.run_auto("path/to/project/template", "path/to/destination")
 ```
 
-The "template" parameter can be a local path, an URL, or a shortcut URL:
+The "template" parameter can be a local path, a URL, or a shortcut URL. The following
+shortcut URLs are supported:
 
 -   GitHub: `gh:namespace/project`
 -   GitLab: `gl:namespace/project`
+
+When using a URL, `https://github.com/*` and `https://gitlab.com/*` are automatically
+recognized as Git URLs. For other Git server URLs, the following combinations of
+prefixes and postfixes are compatible:
+
+=== "HTTP protocol"
+
+    |  `git+` prefix   |  `.git` postfix  |
+    | :--------------: | :--------------: |
+    | :material-check: |                  |
+    |                  | :material-check: |
+    | :material-check: | :material-check: |
+
+=== "SSH protocol"
+
+    |  `git@` prefix   | `git+ssh://` prefix | `ssh://` prefix  |  `.git` postfix  |
+    | :--------------: | :-----------------: | :--------------: | :--------------: |
+    | :material-check: |                     |                  |                  |
+    | :material-check: |                     |                  | :material-check: |
+    |                  |  :material-check:   |                  |                  |
+    |                  |  :material-check:   |                  | :material-check: |
+    |                  |                     | :material-check: | :material-check: |
+
+=== "Git protocol"
+
+    | `git://` prefix  |  `.git` postfix  |
+    | :--------------: | :--------------: |
+    | :material-check: |                  |
+    | :material-check: | :material-check: |
+
+    !!! danger
+
+        The Git protocol is [discouraged for security reasons][git-protocol-cons] and
+        not supported by [GitHub][git-protocol-github] and GitLab.
+
+[git-protocol-cons]:
+    https://git-scm.com/book/en/v2/Git-on-the-Server-The-Protocols#_the_cons_4
+[git-protocol-github]:
+    https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git)
 
 Use the `--data` command-line argument or the `data` parameter of the
 `copier.run_auto()` function to pass whatever extra context you want to be available in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,8 +60,12 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-  - pymdownx.emoji
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.magiclink
+  - pymdownx.tabbed:
+      alternate_style: true
   - toc:
       permalink: true
   - footnotes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,12 +60,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
-  - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+  - pymdownx.emoji
   - pymdownx.magiclink
-  - pymdownx.tabbed:
-      alternate_style: true
   - toc:
       permalink: true
   - footnotes


### PR DESCRIPTION
I've added documentation on the supported Git URL patterns, mainly URL prefix/postfix compatibility tables in which case Copier will recognize a URL as a Git URL. This documentation is based on the `copier.vcs.get_repo(url)` function:

https://github.com/copier-org/copier/blob/47f3d59c27094e6f8ef0bc71acc74d88cbf6bb78/copier/vcs.py#L67-L95

Resolves #1043.

Would this additional documentation have helped you, @sandeeps311?