### PR TITLE
Add multiple choice prompt (map list type to questionary checkbox)

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -326,7 +326,7 @@ class Question:
         if type_name == "bool":
             questionary_type = "confirm"
         if self.choices:
-            questionary_type = "select"
+            questionary_type = "checkbox" if type_name == 'list' else "select"
             result["choices"] = self._formatted_choices
         if questionary_type == "input":
             if self.secret:
@@ -454,4 +454,5 @@ CAST_STR_TO_NATIVE: Mapping[str, Callable] = {
     "json": json.loads,
     "str": str,
     "yaml": parse_yaml_string,
+    'list': list,
 }

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -272,6 +272,9 @@ class Question:
         choices = self.choices
         if isinstance(self.choices, dict):
             choices = list(self.choices.items())
+        
+        islist = self.get_type_name() == "list"
+        default = self.get_default()
         for choice in choices:
             # If a choice is a value pair
             if isinstance(choice, (tuple, list)):
@@ -279,11 +282,12 @@ class Question:
             # If a choice is a single value
             else:
                 name = value = choice
+            checked = islist and value in default
             # The name must always be a str
             name = str(self.render_value(name))
             # The value can be templated
             value = self.render_value(value)
-            result.append(Choice(name, value))
+            result.append(Choice(name, value, checked=checked))
         return result
 
     def filter_answer(self, answer) -> Any:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -215,6 +215,8 @@ class Question:
         if v == "":
             default_type_name = type(values.get("default")).__name__
             v = default_type_name if default_type_name in CAST_STR_TO_NATIVE else "yaml"
+        if v == "list" and not values.get("choices"):
+            raise ValueError("List-type questions must provide choices")
         return v
 
     def get_default(self) -> Any:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -215,8 +215,6 @@ class Question:
         if v == "":
             default_type_name = type(values.get("default")).__name__
             v = default_type_name if default_type_name in CAST_STR_TO_NATIVE else "yaml"
-        if v == "list" and not values.get("choices"):
-            raise ValueError("List-type questions must provide choices")
         return v
 
     def get_default(self) -> Any:
@@ -328,7 +326,7 @@ class Question:
         if type_name == "bool":
             questionary_type = "confirm"
         if self.choices:
-            questionary_type = "checkbox" if type_name == 'list' else "select"
+            questionary_type = "checkbox" if type_name == "list" else "select"
             result["choices"] = self._formatted_choices
         if questionary_type == "input":
             if self.secret:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -456,5 +456,5 @@ CAST_STR_TO_NATIVE: Mapping[str, Callable] = {
     "json": json.loads,
     "str": str,
     "yaml": parse_yaml_string,
-    'list': list,
+    "list": list,
 }

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -274,7 +274,9 @@ class Question:
             choices = list(self.choices.items())
         
         islist = self.get_type_name() == "list"
-        default = self.get_default()
+        defaults = ()
+        if islist:
+            defaults = self.get_default() or ()
         for choice in choices:
             # If a choice is a value pair
             if isinstance(choice, (tuple, list)):
@@ -282,7 +284,7 @@ class Question:
             # If a choice is a single value
             else:
                 name = value = choice
-            checked = islist and value in default
+            checked = islist and value in defaults
             # The name must always be a str
             name = str(self.render_value(name))
             # The value can be templated

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -491,6 +491,7 @@ def test_var_name_value_allowed(
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["value"] == "string"
 
+
 @pytest.mark.parametrize(
     "choices",
     (

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -532,11 +532,14 @@ def test_list_checkbox(
     # Copy
     tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "pick_one", "list")
-    tui.send('i')  # invert selection
+    tui.send(Keyboard.Down)
+    tui.send(" ")  # select 2
+    tui.send(Keyboard.Down)
+    tui.send(" ")  # deselect 3
     tui.send(Keyboard.Enter)
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
-    assert answers["pick_one"] == [2]
+    assert answers["pick_one"] == [1, 2]
 
     with local.cwd(dst):
         git("init")
@@ -545,8 +548,8 @@ def test_list_checkbox(
     # Update
     tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
     expect_prompt(tui, "pick_one", "list")
-    tui.send('i')  # invert selection
+    tui.send("i")  # invert selection
     tui.send(Keyboard.Enter)
     tui.expect_exact(pexpect.EOF)
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
-    assert answers["pick_one"] == [1, 3]
+    assert answers["pick_one"] == [3]


### PR DESCRIPTION
Closes #218 by supporting `questionary.checkbox` when the question `type` is `list`.

```yaml
toppings:
    type: list
    choices:
        - Cheese
        - Tomatoes
        - Pepperoni
        - Sausage
```

This is a tiny PR at the moment... and it works fine for many cases.  But feel free to point me to edge cases that you want caught and tested.  (No need to guide my on the fixes yet, just state any concerns and I'll try to figure them out)

A potential elaboration would be to support `list[<type>]` with a more complicated `cast_fn`

For now, I am raising a validation error if `type == 'list'` but no `choices` are provided, which makes the validation logic much easier (since you'll always get a checkbox prompt from questionary).  In the future, or here if you prefer, we can add logic to cast more general strings to lists