### PR TITLE
test: add return type hints

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -134,7 +134,7 @@ def test_good_cli_run_dot_config(
     tmp_path: Path,
     template_path_with_dot_config: Callable[[str], str],
     config_folder: Path,
-):
+) -> None:
     """Function to test different locations of the answersfile.
 
     Added based on the discussion: https://github.com/copier-org/copier/discussions/859

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -124,7 +124,7 @@ def check_invalid(
     invalid_value: str,
     help: OptStr = None,
     err: str = "Invalid input",
-):
+) -> None:
     """Check that invalid input is reported correctly"""
     expect_prompt(tui, name, format, help)
     tui.sendline(invalid_value)
@@ -307,7 +307,7 @@ def test_api_str_data(template_path: str, tmp_path: Path) -> None:
 
 def test_cli_interatively_with_flag_data_and_type_casts(
     template_path: str, tmp_path: Path, spawn: Spawn
-):
+) -> None:
     """Assert how choices work when copier is invoked with --data interactively."""
     tui = spawn(
         COPIER_PATH

--- a/tests/test_conditional_file_name.py
+++ b/tests/test_conditional_file_name.py
@@ -31,7 +31,7 @@ def test_dont_render_conditional(tmp_path_factory: TempPathFactory) -> None:
     assert not (dst / "file.txt").exists()
 
 
-def test_render_conditional_subdir(tmp_path_factory: TempPathFactory):
+def test_render_conditional_subdir(tmp_path_factory: TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
@@ -44,7 +44,7 @@ def test_render_conditional_subdir(tmp_path_factory: TempPathFactory):
     assert (dst / "subdir" / "file.txt").read_text() == "This is True."
 
 
-def test_dont_render_conditional_subdir(tmp_path_factory: TempPathFactory):
+def test_dont_render_conditional_subdir(tmp_path_factory: TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -464,7 +464,7 @@ def test_validate_init_data(
     spec: AnyByStrDict,
     value: str,
     expected: ContextManager[None],
-):
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -520,7 +520,7 @@ def test_skip_update(tmp_path_factory: pytest.TempPathFactory) -> None:
 )
 def test_overwrite_answers_file_always(
     tmp_path_factory: pytest.TempPathFactory, answers_file: Optional[str]
-):
+) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     with local.cwd(src):
         build_file_tree(


### PR DESCRIPTION
I didn't notice a couple of missing return type hints when preparing #1057.