### PR TITLE
test: select latest version tag

### DIFF
--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -178,7 +178,7 @@ def test_select_latest_version_tag(
     sorter: Callable[[Sequence[str]], Iterator[str]],
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
-    filename = "verison.txt"
+    filename = "version.txt"
 
     with local.cwd(src):
         git("init")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Callable, Iterator, Sequence
 
 import pytest
+import yaml
 from packaging.version import Version
 from plumbum import local
 from plumbum.cmd import git
@@ -182,6 +183,9 @@ def test_select_latest_version_tag(
 
     with local.cwd(src):
         git("init")
+        Path("{{ _copier_conf.answers_file }}.jinja").write_text(
+            "{{ _copier_answers|to_nice_yaml }}"
+        )
         for version in sorter(["v1", "v1.0", "v1.0.0", "v1.0.1"]):
             Path(filename).write_text(version)
             git("add", ".")
@@ -192,3 +196,5 @@ def test_select_latest_version_tag(
 
     assert (dst / filename).is_file()
     assert (dst / filename).read_text() == "v1.0.1"
+    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    assert answers["_commit"] == "v1.0.1"


### PR DESCRIPTION
I've added a test that ensures the latest version tag is selected with heterogeneous version formats such as `v1`, `v1.0`, `v1.0.0`, and `v1.0.1` in this as well as reverse creation order (just to be on the safe side that there's no order sensitivity of some kind).

I cannot reproduce the issue reported in #987 both on `master`, `v7.0.1`, and `v6.2.0`. Nevertheless, I think it's good to have a test that ensures the expected behavior.

Closes #987.