### PR TITLE
fix: properly support update in repo subdirectory

### DIFF
--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -12,6 +12,7 @@ from plumbum.cmd import git
 from copier import Worker, copy
 from copier.cli import CopierApp
 from copier.main import run_copy, run_update
+from copier.types import Literal
 
 from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
 
@@ -625,3 +626,63 @@ def test_file_removed(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert not (dst / "dir 3" / "subdir 3").exists()
     assert not (dst / "dir 4" / "subdir 4" / "4.txt").exists()
     assert not (dst / "dir 5").exists()
+
+
+@pytest.mark.parametrize("conflict", ["rej", "inline"])
+def test_update_in_repo_subdirectory(
+    tmp_path_factory: pytest.TempPathFactory, conflict: Literal["rej", "inline"]
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    subdir = Path("subdir")
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+                "version.txt": "v1",
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
+
+    run_copy(str(src), dst / subdir)
+
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+
+    assert (dst / subdir / ".copier-answers.yml").is_file()
+    assert (dst / subdir / "version.txt").is_file()
+    assert (dst / subdir / "version.txt").read_text() == "v1"
+
+    with local.cwd(dst):
+        build_file_tree({subdir / "version.txt": "v1 edited"})
+        git("add", ".")
+        git("commit", "-m1e")
+
+    with local.cwd(src):
+        build_file_tree({"version.txt": "v2"})
+        git("add", ".")
+        git("commit", "-m2")
+        git("tag", "v2")
+
+    run_update(dst / subdir, overwrite=True, conflict=conflict)
+
+    assert (dst / subdir / ".copier-answers.yml").is_file()
+    assert (dst / subdir / "version.txt").is_file()
+    if conflict == "rej":
+        assert (dst / subdir / "version.txt").read_text() == "v2"
+        assert (dst / subdir / "version.txt.rej").is_file()
+    else:
+        assert (dst / subdir / "version.txt").read_text() == dedent(
+            """\
+            <<<<<<< before updating
+            v1 edited
+            =======
+            v2
+            >>>>>>> after updating
+            """
+        )


### PR DESCRIPTION
I've fixed a bug related to updating a project located in a subdirectory of a Git repo (e.g. in a monorepo). Before, Copier didn't detect merge conflicts (i.e. no `.rej` files or inline markers were created) and simply overwrote modified files in the subproject.

The fix is relatively simple. The update algorithm now recreates the subdirectory layout (or rather the relevant slice) of the original Git repo, so the diffing and applying of patches occurs consistently from the Git repo root.

Fixes #671.