### PR TITLE
Do not immediately fail if git is not available

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -56,7 +56,7 @@ from .types import (
     StrSeq,
 )
 from .user_data import DEFAULT_DATA, AnswersMap, Question
-from .vcs import git
+from .vcs import get_git
 
 
 @dataclass(config=ConfigDict(extra="forbid"))
@@ -815,6 +815,7 @@ class Worker:
         self._print_message(self.template.message_after_update)
 
     def _apply_update(self):
+        git = get_git()
         subproject_top = Path(
             git(
                 "-C",
@@ -931,6 +932,7 @@ class Worker:
 
     def _git_initialize_repo(self):
         """Initialize a git repository in the current directory."""
+        git = get_git()
         git("init", retcode=None)
         git("add", ".")
         git("config", "user.name", "Copier")

--- a/copier/main.py
+++ b/copier/main.py
@@ -31,7 +31,6 @@ from jinja2.sandbox import SandboxedEnvironment
 from pathspec import PathSpec
 from plumbum import ProcessExecutionError, colors
 from plumbum.cli.terminal import ask
-from plumbum.cmd import git
 from plumbum.machines import local
 from pydantic import ConfigDict, PositiveInt
 from pydantic.dataclasses import dataclass
@@ -57,6 +56,7 @@ from .types import (
     StrSeq,
 )
 from .user_data import DEFAULT_DATA, AnswersMap, Question
+from .vcs import git
 
 
 @dataclass(config=ConfigDict(extra="forbid"))

--- a/copier/subproject.py
+++ b/copier/subproject.py
@@ -14,7 +14,7 @@ from pydantic.dataclasses import dataclass
 
 from .template import Template
 from .types import AbsolutePath, AnyByStrDict, VCSTypes
-from .vcs import git, is_in_git_repo
+from .vcs import get_git, is_in_git_repo
 
 
 @dataclass
@@ -41,7 +41,7 @@ class Subproject:
         """
         if self.vcs == "git":
             with local.cwd(self.local_abspath):
-                return bool(git("status", "--porcelain").strip())
+                return bool(get_git()("status", "--porcelain").strip())
         return False
 
     def _cleanup(self):

--- a/copier/subproject.py
+++ b/copier/subproject.py
@@ -9,13 +9,12 @@ from pathlib import Path
 from typing import Callable, List, Optional
 
 import yaml
-from plumbum.cmd import git
 from plumbum.machines import local
 from pydantic.dataclasses import dataclass
 
 from .template import Template
 from .types import AbsolutePath, AnyByStrDict, VCSTypes
-from .vcs import is_in_git_repo
+from .vcs import git, is_in_git_repo
 
 
 @dataclass

--- a/copier/template.py
+++ b/copier/template.py
@@ -27,7 +27,7 @@ from .errors import (
 )
 from .tools import copier_version, handle_remove_readonly
 from .types import AnyByStrDict, Env, OptStr, StrSeq, Union, VCSTypes
-from .vcs import checkout_latest_tag, clone, get_repo, get_git
+from .vcs import checkout_latest_tag, clone, get_git, get_repo
 
 # Default list of files in the template to exclude from the rendered project
 DEFAULT_EXCLUDE: Tuple[str, ...] = (

--- a/copier/template.py
+++ b/copier/template.py
@@ -14,7 +14,6 @@ import packaging.version
 import yaml
 from funcy import lflatten
 from packaging.version import Version, parse
-from plumbum.cmd import git
 from plumbum.machines import local
 from pydantic.dataclasses import dataclass
 from yamlinclude import YamlIncludeConstructor
@@ -28,7 +27,7 @@ from .errors import (
 )
 from .tools import copier_version, handle_remove_readonly
 from .types import AnyByStrDict, Env, OptStr, StrSeq, Union, VCSTypes
-from .vcs import checkout_latest_tag, clone, get_repo
+from .vcs import checkout_latest_tag, clone, get_repo, git
 
 # Default list of files in the template to exclude from the rendered project
 DEFAULT_EXCLUDE: Tuple[str, ...] = (

--- a/copier/template.py
+++ b/copier/template.py
@@ -27,7 +27,7 @@ from .errors import (
 )
 from .tools import copier_version, handle_remove_readonly
 from .types import AnyByStrDict, Env, OptStr, StrSeq, Union, VCSTypes
-from .vcs import checkout_latest_tag, clone, get_repo, git
+from .vcs import checkout_latest_tag, clone, get_repo, get_git
 
 # Default list of files in the template to exclude from the rendered project
 DEFAULT_EXCLUDE: Tuple[str, ...] = (
@@ -248,13 +248,13 @@ class Template:
         """If the template is VCS-tracked, get its commit description."""
         if self.vcs == "git":
             with local.cwd(self.local_abspath):
-                return git("describe", "--tags", "--always").strip()
+                return get_git()("describe", "--tags", "--always").strip()
 
     @cached_property
     def commit_hash(self) -> OptStr:
         """If the template is VCS-tracked, get its commit full hash."""
         if self.vcs == "git":
-            return git("-C", self.local_abspath, "rev-parse", "HEAD").strip()
+            return get_git()("-C", self.local_abspath, "rev-parse", "HEAD").strip()
 
     @cached_property
     def config_data(self) -> AnyByStrDict:

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -57,7 +57,10 @@ def is_in_git_repo(path: StrOrPath) -> bool:
 def is_git_shallow_repo(path: StrOrPath) -> bool:
     """Indicate if a given path is a git shallow repo directory."""
     try:
-        return get_git()("-C", path, "rev-parse", "--is-shallow-repository").strip() == "true"
+        return (
+            get_git()("-C", path, "rev-parse", "--is-shallow-repository").strip()
+            == "true"
+        )
     except (OSError, ProcessExecutionError):
         return False
 

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -20,16 +20,10 @@ def get_git():
     return local["git"]
 
 
-try:
-    GIT_VERSION = Version(re.findall(r"\d+\.\d+\.\d+", get_git()("version"))[0])
-except OSError:
-    import warnings
+def get_git_version():
+    git = get_git()
 
-    warnings.warn(
-        "git command not found, some functionality might not work", UserWarning
-    )
-
-    GIT_VERSION = None  # type: ignore
+    return Version(re.findall(r"\d+\.\d+\.\d+", git("version"))[0])
 
 
 GIT_PREFIX = ("git@", "git://", "git+", "https://github.com/", "https://gitlab.com/")
@@ -158,10 +152,11 @@ def clone(url: str, ref: OptStr = None) -> str:
             Reference to checkout. For Git repos, defaults to `HEAD`.
     """
     git = get_git()
+    git_version = get_git_version()
     location = mkdtemp(prefix=f"{__name__}.clone.")
     _clone = git["clone", "--no-checkout", url, location]
     # Faster clones if possible
-    if GIT_VERSION >= Version("2.27"):
+    if git_version >= Version("2.27"):
         url_match = re.match("(file://)?(.*)", url)
         if url_match is not None:
             file_url = url_match.groups()[-1]

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -17,11 +17,8 @@ from .types import OptBool, OptStr, StrOrPath
 
 def get_git():
     """Gets `git` command, or fails if it's not available"""
-    try:
-        from plumbum.cmd import git
-        return git
-    except ImportError as exc:
-        raise OSError("git is not available") from exc
+    return local["git"]
+
 
 try:
     GIT_VERSION = Version(re.findall(r"\d+\.\d+\.\d+", get_git()("version"))[0])

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -10,14 +10,29 @@ from warnings import warn
 from packaging import version
 from packaging.version import InvalidVersion, Version
 from plumbum import TF, ProcessExecutionError, colors, local
-from plumbum.cmd import git
 
 from .errors import DirtyLocalWarning, ShallowCloneWarning
 from .types import OptBool, OptStr, StrOrPath
 
+try:
+    from plumbum.cmd import git
+
+    GIT_VERSION = Version(re.findall(r"\d+\.\d+\.\d+", git("version"))[0])
+except ImportError:
+    import warnings
+
+    warnings.warn(
+        "git command not found, some functionality might not work", UserWarning
+    )
+
+    def git(*args, **kwargs):
+        raise OSError("git is not available")
+
+    GIT_VERSION = None
+
+
 GIT_PREFIX = ("git@", "git://", "git+", "https://github.com/", "https://gitlab.com/")
 GIT_POSTFIX = ".git"
-GIT_VERSION = Version(re.findall(r"\d+\.\d+\.\d+", git("version"))[0])
 REPLACEMENTS = (
     (re.compile(r"^gh:/?(.*\.git)$"), r"https://github.com/\1"),
     (re.compile(r"^gh:/?(.*)$"), r"https://github.com/\1.git"),

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -11,7 +11,7 @@ from plumbum.cmd import git
 
 from copier import Worker, run_copy, run_update
 from copier.errors import ShallowCloneWarning
-from copier.vcs import get_git_version, checkout_latest_tag, clone, get_repo
+from copier.vcs import checkout_latest_tag, clone, get_git_version, get_repo
 
 
 def test_get_repo() -> None:

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -11,7 +11,7 @@ from plumbum.cmd import git
 
 from copier import Worker, run_copy, run_update
 from copier.errors import ShallowCloneWarning
-from copier.vcs import GIT_VERSION, checkout_latest_tag, clone, get_repo
+from copier.vcs import get_git_version, checkout_latest_tag, clone, get_repo
 
 
 def test_get_repo() -> None:
@@ -93,7 +93,7 @@ def test_shallow_clone(tmp_path: Path, recwarn: pytest.WarningsRecorder) -> None
     git("clone", "--depth=2", "https://github.com/copier-org/autopretty.git", src_path)
     assert Path(src_path, "README.md").exists()
 
-    if GIT_VERSION >= Version("2.27"):
+    if get_git_version() >= Version("2.27"):
         with pytest.warns(ShallowCloneWarning):
             local_tmp = clone(str(src_path))
     else:


### PR DESCRIPTION
Fix gh-312.

There are several ways of doing this, I picked one that I considered simple enough. The idea is to always import `git` from a centralized place, and in that place do a soft fail if `git` fails to be imported from `plumbum.cmd`.

This is how `copier --version` looks like with these changes:

```
root@885f691c5e79:/# which git || echo "git is not available"
git is not available
root@885f691c5e79:/# copier --version
/usr/local/lib/python3.10/site-packages/copier/vcs.py:25: UserWarning: git command not found, some functionality might not work
  warnings.warn(
copier 7.1.0a0.post98.dev0+5d600ff
```

On the other hand, I made `copier.vcs.is_git_bundle` more consistent with `is_git_shallow_repo` and `is_in_git_repo`, and now it returns `False` if there is an `OSError` or `ProcessExecutionError` error. Thanks to that, now copier can work with gitless templates as well, as mentioned in https://github.com/copier-org/copier/issues/1045#issuecomment-1492956700:

```
root@885f691c5e79:/# copier /home/copier-pylib-main/ /tmp/
/usr/local/lib/python3.10/site-packages/copier/vcs.py:25: UserWarning: git command not found, some functionality might not work
  warnings.warn(
🎤 Your account or organization
   astrojuanlu
...

Copying from template version None
 identical  .
    create  .gitignore
...
```

I have two questions:

1. First, I have no idea how to test this. Initially, I tried some form of mocking or monkeypatching, but since `plumbum.cmd.git` is not an actual attribute, things are more complicated:

```
    @pytest.fixture
    def no_plumbum_git(monkeypatch):
>       monkeypatch.delattr("plumbum.cmd.git")
E       AttributeError: git

tests/test_main.py:6: AttributeError
```

I could do a very deep patching of how `plumbum.local` retrieves the command, but wanted to ask for advice first.

2. As I explained in the second commit, one could actually consider that `copier.vcs.is_git_bundle`, `is_git_shallow_repo`, and `is_in_git_repo` should return None or something else than `True` or `False`, if the git status could not be determined because the git command is missing. In this scheme, returning `None` would mean "I don't know if this directory is actually a git repo". For this reason, I preferred to wait before proceeding any further adding tests.

Let me know what you folks think.

For the record, I too was a bit puzzled by the heavyweight requirements to run the linter https://github.com/copier-org/copier/issues/931 so going forward I think I'll use Gitpod to continue this PR (I have only used Nix a bit when experimenting with Replit earlier this year, not sure if I already want to commit to installing it on my home laptop).