### PR TITLE
feat: customizable update accuracy

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -330,6 +330,15 @@ class CopierUpdateSubApp(cli.Application):
             "markers (inline is still experimental)"
         ),
     )
+    context_lines: cli.SwitchAttr = cli.SwitchAttr(
+        ["-c", "--context-lines"],
+        int,
+        default=1,
+        help=(
+            "Lines of context to use for detecting conflicts. Increase for "
+            "accuracy, decrease for resilience."
+        ),
+    )
 
     @handle_exceptions
     def main(self, destination_path: cli.ExistingDirectory = ".") -> int:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -683,6 +683,28 @@ code hunk in the file itself, similar to the behavior of `git merge`.
 
     Not supported in `copier.yml`.
 
+### `context_lines`
+
+-   Format: `Int`
+-   CLI flags: `-c`, `--context-lines` (only available in `copier update` subcommand)
+-   Default value: `1`
+
+During a project update, Copier needs to compare the template evolution with the
+subproject evolution. This way, it can detect what changed, where and how to merge those
+changes. [Refer here for more details on this process](./updating.md).
+
+The more lines you use, the more accurate Copier will be when detecting conflicts. But
+you will also have more conflicts to solve by yourself. FWIW, Git uses 3 lines by
+default.
+
+The less lines you use, the less conflicts you will have. However, Copier will not be so
+accurate and could even move lines around if the file it's comparing has several similar
+code chunks.
+
+!!! info
+
+    Not supported in `copier.yml`.
+
 ### `data`
 
 -   Format: `dict|List[str=str]`

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -796,3 +796,144 @@ def test_update_in_repo_subdirectory(
             >>>>>>> after updating
             """
         )
+
+
+@pytest.mark.parametrize(
+    "context_lines",
+    [
+        pytest.param(
+            1,
+            marks=pytest.mark.xfail(
+                reason="Not enough context lines to resolve the conflict.", strict=True
+            ),
+        ),
+        pytest.param(
+            2,
+            marks=pytest.mark.xfail(
+                reason="Not enough context lines to resolve the conflict.", strict=True
+            ),
+        ),
+        3,
+    ],
+)
+def test_update_needs_more_context(
+    tmp_path_factory: pytest.TempPathFactory, context_lines: int
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    # Create a template where some code blocks are similar
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+                "sample.py": dedent(
+                    """\
+                    def function_one():
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("Previous line lied.")
+
+                    def function_two():
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("Previous line lied.")
+                    """
+                ),
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
+    # Render and evolve that project
+    with local.cwd(dst):
+        run_copy(str(src), ".")
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        build_file_tree(
+            {
+                "sample.py": dedent(
+                    """\
+                    def function_one():
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("Previous line lied.")
+
+                    def function_two():
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is new.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("Previous line lied.")
+                    """
+                )
+            }
+        )
+        git("commit", "-am2")
+    # Evolve the template
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "sample.py": dedent(
+                    """\
+                    def function_zero():
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("Previous line lied.")
+
+                    def function_one():
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("Previous line lied.")
+
+                    def function_two():
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("This line is equal to the next one.")
+                        print("Previous line lied.")
+                    """
+                )
+            }
+        )
+        git("commit", "-am3")
+        git("tag", "v2")
+    # Update the project
+    run_update(dst, overwrite=True, conflict="inline", context_lines=context_lines)
+    # Check the update result
+    assert (dst / "sample.py").read_text() == dedent(
+        """\
+        def function_zero():
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("Previous line lied.")
+
+        def function_one():
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("Previous line lied.")
+
+        def function_two():
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("This line is new.")
+            print("This line is equal to the next one.")
+            print("This line is equal to the next one.")
+            print("Previous line lied.")
+        """
+    )


### PR DESCRIPTION
Until today, the updatediff algorithm always used just 1 line of context when detecting conflicts. This was because:

- Solving conflicts wasn't very ergonomic with those `.rej` files around.
- More lines meant too many conflicts usually.

However, it made the diff detection less accurate.

With this change, we allow the users to configure that algorithm. Since they have now the `--context inline` option, more conflicts isn't so much of a problem.

@moduon MT-2638