### PR TITLE
fix: fix answer validation for question with complex choices

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -417,10 +417,10 @@ class Question:
         """Parse the answer according to the question's type."""
         cast_fn = self.get_cast_fn()
         ans = cast_answer_type(answer, cast_fn)
-        choice_values = {
+        choice_values = [
             cast_answer_type(choice.value, cast_fn)
             for choice in self._formatted_choices
-        }
+        ]
         if choice_values and ans not in choice_values:
             raise ValueError("Invalid choice")
         return ans

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -465,6 +465,16 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
             "three",
             pytest.raises(ValueError),
         ),
+        (
+            {"type": "yaml", "choices": {"array": "[a, b]"}},
+            "[a, b]",
+            does_not_raise(),
+        ),
+        (
+            {"type": "yaml", "choices": {"object": "k: v"}},
+            "k: v",
+            does_not_raise(),
+        ),
     ],
 )
 def test_validate_init_data(


### PR DESCRIPTION
I've fixed a bug related to answer validation of questions with complex choices. Previously, choice values were collected in a set which requires the choice values to be hashable. But complex choice values such as `dict` or `list` values aren't hashable. Now, they are collected in a list.

Fixes #1108.