### PR TITLE
fix: work around Pydantic bug when parsing choices

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -202,7 +202,7 @@ class Question:
     var_name: str
     answers: AnswersMap
     jinja_env: SandboxedEnvironment
-    choices: Union[Dict[Any, Any], Sequence[Any]] = field(default_factory=list)
+    choices: Union[Sequence[Any], Dict[Any, Any]] = field(default_factory=list)
     default: Any = MISSING
     help: str = ""
     multiline: Union[str, bool] = False

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -475,6 +475,11 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
             "k: v",
             does_not_raise(),
         ),
+        (
+            {"type": "yaml", "choices": [{"one": 1, "two": 2}]},
+            "one: 1\ntwo: 2",
+            does_not_raise(),
+        ),
     ],
 )
 def test_validate_init_data(


### PR DESCRIPTION
I've fixed a bug when parsing complex-valued choices caused by an [upstream bug in Pydantic v1](https://github.com/pydantic/pydantic/issues/5523).

The workaround is to change the order of the type union so that list-style choices are parsed using the `Sequence[Any]` type because it matches before `Dict[Any, Any]` (which shouldn't match in that case at all but does due to the bug).

Related to #1108 & #1110.