### PR TITLE
fix: fix using a branch name as VCS ref

### DIFF
--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -182,7 +182,7 @@ def clone(url: str, ref: OptStr = None) -> str:
                 )
 
     with local.cwd(location):
-        git("reset", "--hard", ref or "HEAD")
+        git("checkout", "-f", ref or "HEAD")
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 
     return location

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -104,6 +104,19 @@ def test_copy_with_non_version_tags_and_vcs_ref(
     )
 
 
+def test_copy_with_vcs_ref_branch(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    with local.cwd(src):
+        git("init")
+        main_branch = git("branch", "--show-current").strip()
+        git("add", ".")
+        git("commit", "-m1", "--allow-empty")
+        git("checkout", "-b", "branch")
+        git("commit", "-m2", "--allow-empty")
+        git("checkout", main_branch)
+    copy(str(src), dst, vcs_ref="branch")
+
+
 def test_copy(tmp_path: Path) -> None:
     render(tmp_path)
 


### PR DESCRIPTION
I've fixed a regression introduced by #1047 related to using a branch name as a VCS ref via the CLI switch `-r` or the API argument `vcs_ref` which caused the following error:

```
plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 128
Command line: | git reset --hard my-branch
Stderr:       | fatal: ambiguous argument '<branch_name>': unknown revision or path not in the working tree.
```

Fixes #1093.