### PR TITLE
feat(cli): add runtime type to `--answers-file` switch

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -121,6 +121,7 @@ class CopierApp(cli.Application):
 
     answers_file: cli.SwitchAttr = cli.SwitchAttr(
         ["-a", "--answers-file"],
+        cli.ExistingFile,
         default=None,
         help=(
             "Update using this path (relative to `destination_path`) "


### PR DESCRIPTION
Just a minor improvement of the CLI switch `--answers-file`.