### PR TITLE
fix: skip question when skip condition is met

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -390,6 +390,12 @@ class Worker:
                 var_name=var_name,
                 **details,
             )
+            # Skip a question when the skip condition is met and remove any data
+            # from the answers map, so no answer for this question is recorded
+            # in the answers file.
+            if not question.get_when():
+                result.remove(var_name)
+                continue
             if var_name in result.init:
                 # Try to parse the answer value.
                 answer = question.parse_answer(result.init[var_name])
@@ -413,15 +419,7 @@ class Worker:
                     )[question.var_name]
             except KeyboardInterrupt as err:
                 raise CopierAnswersInterrupt(result, question, self.template) from err
-            previous_answer = result.combined.get(question.var_name)
-            # If question was skipped and it's the 1st
-            # run, you could be getting a raw templated value
-            default_answer = result.default.get(question.var_name)
-            if new_answer == default_answer:
-                new_answer = question.render_value(default_answer)
-                new_answer = question.filter_answer(new_answer)
-            if new_answer != previous_answer:
-                result.user[question.var_name] = new_answer
+            result.user[var_name] = new_answer
 
         return result
 

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -16,6 +16,7 @@ from typing import (
     Mapping,
     Optional,
     Sequence,
+    Set,
     Union,
 )
 
@@ -118,6 +119,7 @@ class AnswersMap:
 
     # Private
     local: AnyByStrDict = field(default_factory=dict, init=False)
+    removed: Set[str] = field(default_factory=set, init=False)
 
     # Public
     user: AnyByStrDict = field(default_factory=dict)
@@ -127,23 +129,33 @@ class AnswersMap:
     user_defaults: AnyByStrDict = field(default_factory=dict)
     default: AnyByStrDict = field(default_factory=dict)
 
-    @cached_property
+    @property
     def combined(self) -> Mapping[str, Any]:
         """Answers combined from different sources, sorted by priority."""
-        return ChainMap(
-            self.local,
-            self.user,
-            self.init,
-            self.metadata,
-            self.last,
-            self.user_defaults,
-            self.default,
-            DEFAULT_DATA,
+        combined = dict(
+            ChainMap(
+                self.local,
+                self.user,
+                self.init,
+                self.metadata,
+                self.last,
+                self.user_defaults,
+                self.default,
+                DEFAULT_DATA,
+            )
         )
+        for key in self.removed:
+            if key in combined:
+                del combined[key]
+        return combined
 
     def old_commit(self) -> OptStr:
         """Commit when the project was updated from this template the last time."""
         return self.last.get("_commit")
+
+    def remove(self, key: str) -> None:
+        """Remove an answer by key."""
+        self.removed.add(key)
 
 
 @dataclass(config=AllowArbitraryTypes)
@@ -327,7 +339,7 @@ class Question:
             "mouse_support": True,
             "name": self.var_name,
             "qmark": "🕵️" if self.secret else "🎤",
-            "when": self.get_when,
+            "when": lambda _: self.get_when(),
         }
         default = self.get_default_rendered()
         if default is not MISSING:
@@ -385,7 +397,7 @@ class Question:
             raise ValidationError(message=err_msg)
         return True
 
-    def get_when(self, answers) -> bool:
+    def get_when(self) -> bool:
         """Get skip condition for question."""
         return cast_str_to_bool(self.render_value(self.when))
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -512,6 +512,42 @@ def test_validate_init_data(
         copier.copy(str(src), dst, data={"q": value})
 
 
+@pytest.mark.parametrize("defaults", [False, True])
+def test_validate_init_data_with_skipped_question(
+    tmp_path_factory: pytest.TempPathFactory, defaults: bool
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yml"): (
+                f"""\
+                _envops: {BRACKET_ENVOPS_JSON}
+
+                kind:
+                    type: str
+                    help: What kind do you need?
+                    choices:
+                        foo: foo
+                        bar: bar
+
+                testbar:
+                    when: "[[ kind == 'bar' ]]"
+                    type: str
+                    help: any string bar?
+
+                testfoo:
+                    when: "[[ kind == 'foo' ]]"
+                    type: str
+                    help: any string foo?
+                """
+            ),
+        }
+    )
+    copier.copy(
+        str(src), dst, defaults=defaults, data={"kind": "foo", "testfoo": "helloworld"}
+    )
+
+
 @pytest.mark.parametrize(
     "type_name",
     ["str", "int", "float", "bool", "json", "yaml"],

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -194,7 +194,7 @@ def test_when(
     assert answers == {
         "_src_path": str(src),
         "question_1": question_1,
-        "question_2": "something",
+        **({"question_2": "something"} if asks else {}),
     }
 
 


### PR DESCRIPTION
I've indirectly fixed the validation of answers to questions for which the skip condition is met. Before, a question with a truthy skip condition was not properly skipped such that (a) its default value (if present) was still validated and could cause a validation error or (b) an error was raised that the question was required although it should have been skipped. As a side effect of the previous implementation (which didn't properly skip questions), answers of skipped questions were recorded in the answers file which IMO makes no sense.

I've changed the way skipped questions are handled such that the skip condition is evaluated early and the question is immediately skipped when the skip condition is truthy. To prevent records of such answers in the answers file, e.g. when they originate from previous runs, when they are provided by the user via the `--data` flag, etc., any answers in the internal answers map are removed (or rather marked as removed). As a result, I needed to adapt a few tests and even removed one that specifically tested for the records in the answers file.

This new behavior should be backwards compatible and is more logical in my opinion. As a side effect, some slightly confusing code block could be removed which handled some special case of using a templated default answer.

Fixes #1125.