### PR TITLE
Fix filesystem view to match later graphic (and homepage)

### DIFF
--- a/docs/creating.md
+++ b/docs/creating.md
@@ -21,7 +21,7 @@ my_copier_template                            # your template project
     .git/                                     # your template is a Git repository
     {{project_name}}                          # a folder with a templated name
         {{module_name}}.py.jinja              # a file with a templated name
-        {{_copier_conf.answers_file}}.jinja   # answers are recorded here
+    {{_copier_conf.answers_file}}.jinja       # answers are recorded here
 ```
 
 ```yaml title="copier.yml"


### PR DESCRIPTION
This is a really minor change, but it looks like the 'Minimal Example' filesystem graphic on the [Creating a template](https://copier.readthedocs.io/en/stable/creating/#minimal-example) page is slightly off.

According to the graphic a bit further down on the page, `.copier-answers.yml` should be found under `generated_project`, and so `{{_copier_conf.answers_file}}.jinja` should be directly inside the `my_copier_template` (not `{{project_name}}`. 

<img width="500px" src="https://github.com/copier-org/copier/assets/21086604/4d266b98-4163-46c5-87c3-dc4509a0aea3" />

