### PR TITLE
Break dance 🕺

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,14 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: debug tests",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "internalConsole",
+      "purpose": ["debug-test"],
+      "justMyCode": false
+    }
+  ]
+}

--- a/copier/__init__.py
+++ b/copier/__init__.py
@@ -4,7 +4,6 @@ Docs: https://copier.readthedocs.io/
 """
 
 from .main import *  # noqa: F401,F403
-from .main import run_auto as copy  # noqa: F401; Backwards compatibility
 
 # This version is a placeholder autoupdated by poetry-dynamic-versioning
 __version__ = "0.0.0"

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -304,16 +304,15 @@ class CopierUpdateSubApp(_Subcommand):
     conflict = cli.SwitchAttr(
         ["-o", "--conflict"],
         cli.Set("rej", "inline"),
-        default="rej",
+        default="inline",
         help=(
-            "Behavior on conflict: rej=Create .rej file, inline=inline conflict "
-            "markers (inline is still experimental)"
+            "Behavior on conflict: Create .rej files, or add inline conflict markers."
         ),
     )
     context_lines = cli.SwitchAttr(
         ["-c", "--context-lines"],
         int,
-        default=1,
+        default=3,
         help=(
             "Lines of context to use for detecting conflicts. Increase for "
             "accuracy, decrease for resilience."

--- a/copier/main.py
+++ b/copier/main.py
@@ -182,8 +182,8 @@ class Worker:
     overwrite: bool = False
     pretend: bool = False
     quiet: bool = False
-    conflict: str = "rej"
-    context_lines: PositiveInt = 1
+    conflict: str = "inline"
+    context_lines: PositiveInt = 3
 
     def __enter__(self):
         """Allow using worker as a context manager."""

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -707,11 +707,11 @@ running `copier update`, this setting has no effect.
 
 -   Format: `Literal["rej", "inline"]`
 -   CLI flags: `-o`, `--conflict` (only available in `copier update` subcommand)
--   Default value: `rej`
+-   Default value: `inline`
 
 When updating a project, sometimes Copier doesn't know what to do with a diff code hunk.
-This option controls the output format if this happens. The default, `rej`, creates
-`*.rej` files that contain the unresolved diffs. The `inline` option includes the diff
+This option controls the output format if this happens. Using `rej`, creates `*.rej`
+files that contain the unresolved diffs. The `inline` option (default) includes the diff
 code hunk in the file itself, similar to the behavior of `git merge`.
 
 !!! info

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -185,3 +185,14 @@ How to overcome that situation?
    versions.
 1. Or you can just [recopy the project][regenerating-a-project] when you update to a
    newer Copier major release.
+
+## When the update gets broken because while replaying old copy
+
+This is uncommon, but it can happen sometimes. For example, maybe the last update was
+relying on some external resources that are not longer available. Generally, you should
+keep your templates as pure as possible to avoid those situations.
+
+However, if this is happening to you, try the `copier recopy` command, which will
+discard all the smart update algorithm explained here. It will behave just like if you
+were applying the template for the 1st time, but it will keep your answers from the last
+update.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -25,11 +25,11 @@ answers you provided when copied last time. However, sometimes it's impossible f
 Copier to know what to do with a diff code hunk. In those cases, copier handles the
 conflict in one of two ways, controlled with the `--conflict` option:
 
--   `--conflict rej` (default): Creates a separate `.rej` file for each file with
-    conflicts. These files contain the unresolved diffs.
--   `--conflict inline` (experimental): Updates the file with conflict markers. This is
-    quite similar to the conflict markers created when a `git merge` command encounters
-    a conflict. For more information, see the "Checking Out Conflicts" section of the
+-   `--conflict rej`: Creates a separate `.rej` file for each file with conflicts. These
+    files contain the unresolved diffs.
+-   `--conflict inline` (default): Updates the file with conflict markers. This is quite
+    similar to the conflict markers created when a `git merge` command encounters a
+    conflict. For more information, see the "Checking Out Conflicts" section of the
     [`git` documentation](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging).
 
 If the update results in conflicts, _you should review those manually_ before

--- a/poetry.lock
+++ b/poetry.lock
@@ -242,6 +242,18 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
+name = "decorator"
+version = "5.1.1"
+description = "Decorators for Humans"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
+    {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+
+[[package]]
 name = "distlib"
 version = "0.3.6"
 description = "Distribution utilities"
@@ -1430,6 +1442,18 @@ files = [
 ]
 
 [[package]]
+name = "types-decorator"
+version = "5.1.8.3"
+description = "Typing stubs for decorator"
+category = "dev"
+optional = false
+python-versions = "*"
+files = [
+    {file = "types-decorator-5.1.8.3.tar.gz", hash = "sha256:32dd380fc88d0e7a1f27a84ba1ce6e29ba0ad42caaa1b88e7b5d27e61f6e4962"},
+    {file = "types_decorator-5.1.8.3-py3-none-any.whl", hash = "sha256:2ad329af49b824db8069ebba9bf03b1cbcafba72eb338be255a1fd902e85edb9"},
+]
+
+[[package]]
 name = "types-psutil"
 version = "5.9.5.12"
 description = "Typing stubs for psutil"
@@ -1575,5 +1599,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<4.0"
-content-hash = "c1002faa20b75b62f8161aec53fb4a512b7bca426da442efdaa695258f2d5a62"
+python-versions = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
+content-hash = "d7efb51bf09f33c6785f98b1f8ad5cb4a6f5d359b68ec0bbef3fb5963fc7a245"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ copier = "copier.__main__:copier_app_run"
 python = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
 "backports.cached-property" = { version = ">=1.0.0", python = "<3.8" }
 colorama = ">=0.4.3"
+decorator = ">=5.1.1"
 dunamai = ">=1.7.0"
 funcy = ">=1.17"
 importlib-metadata = { version = ">=3.4,<7.0", python = "<3.8" }
@@ -57,6 +58,7 @@ pytest = ">=7.2.0"
 pytest-cov = ">=3.0.0"
 pytest-xdist = ">=2.5.0"
 types-backports = ">=0.1.3"
+types-decorator = ">=5.1.1"
 types-pyyaml = ">=6.0.4"
 types-psutil = "*"
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -10,6 +10,7 @@ from typing import Mapping, Optional, Tuple, Union
 
 from pexpect.popen_spawn import PopenSpawn
 from plumbum import local
+from plumbum.cmd import git
 from prompt_toolkit.input.ansi_escape_sequences import REVERSE_ANSI_SEQUENCES
 from prompt_toolkit.keys import Keys
 
@@ -90,7 +91,7 @@ class Keyboard(str, Enum):
 
 def render(tmp_path: Path, **kwargs) -> None:
     kwargs.setdefault("quiet", True)
-    copier.copy(str(PROJECT_TEMPLATE), tmp_path, data=DATA, **kwargs)
+    copier.run_copy(str(PROJECT_TEMPLATE), tmp_path, data=DATA, **kwargs)
 
 
 def assert_file(tmp_path: Path, *path: str) -> None:
@@ -136,3 +137,21 @@ def expect_prompt(
         tui.expect_exact(name)
         if expected_type != "str":
             tui.expect_exact(f"({expected_type})")
+
+
+def git_save(
+    dst: StrOrPath = ".", message: str = "Test commit", tag: Optional[str] = None
+):
+    """Save the current repo state in git.
+
+    Args:
+        dst: Path to the repo to save.
+        message: Commit message.
+        tag: Tag to create, optionally.
+    """
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m", message)
+        if tag:
+            git("tag", tag)

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -57,7 +57,7 @@ def test_answersfile(template_path: str, tmp_path: Path, answers_file: OptStr) -
     round_file = tmp_path / "round.txt"
 
     # Check 1st round is properly executed and remembered
-    copier.copy(
+    copier.run_copy(
         template_path,
         tmp_path,
         answers_file=answers_file,
@@ -81,7 +81,7 @@ def test_answersfile(template_path: str, tmp_path: Path, answers_file: OptStr) -
     assert "password_2" not in log
 
     # Check 2nd round is properly executed and remembered
-    copier.copy(
+    copier.run_copy(
         template_path,
         tmp_path,
         {"round": "2nd"},
@@ -105,7 +105,7 @@ def test_answersfile(template_path: str, tmp_path: Path, answers_file: OptStr) -
     assert "password_2" not in log
 
     # Check repeating 2nd is properly executed and remembered
-    copier.copy(
+    copier.run_copy(
         template_path,
         tmp_path,
         answers_file=answers_file,

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -42,7 +42,7 @@ def test_answersfile_templating(
     copy that resolves to a different answers file doesn't clobber the
     old answers file.
     """
-    copier.copy(
+    copier.run_copy(
         template_path,
         tmp_path,
         {"module_name": "mymodule"},
@@ -59,7 +59,7 @@ def test_answersfile_templating(
     answers = load_answersfile_data(tmp_path, first_answers_file)
     assert answers["module_name"] == "mymodule"
 
-    copier.copy(
+    copier.run_copy(
         template_path,
         tmp_path,
         {"module_name": "anothermodule"},

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -11,7 +11,7 @@ def test_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and removes it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", dst, quiet=True)
+        copier.run_copy("./tests/demo_cleanup", dst, quiet=True)
     assert not dst.exists()
 
 
@@ -19,7 +19,7 @@ def test_do_not_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and keeps it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False)
+        copier.run_copy("./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False)
     assert dst.exists()
 
 
@@ -28,7 +28,9 @@ def test_no_cleanup_when_folder_existed(tmp_path: Path) -> None:
     preexisting_file = tmp_path / "something"
     preexisting_file.touch()
     with pytest.raises(CalledProcessError):
-        copier.copy("./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=True)
+        copier.run_copy(
+            "./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=True
+        )
     assert tmp_path.exists()
     assert preexisting_file.exists()
 
@@ -42,5 +44,5 @@ def test_no_cleanup_when_template_in_parent_folder(tmp_path: Path) -> None:
     cwd = tmp_path / "cwd"
     cwd.mkdir()
     with local.cwd(cwd):
-        copier.copy(str(Path("..", "src")), dst, quiet=True)
+        copier.run_copy(str(Path("..", "src")), dst, quiet=True)
     assert src.exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -182,11 +182,20 @@ def git_commands() -> None:
 
 
 def test_help() -> None:
-    COPIER_CMD("--help-all")
+    _help = COPIER_CMD("--help-all")
+    assert "copier copy [SWITCHES] template_src destination_path" in _help
+    assert "copier update [SWITCHES] [destination_path=.]" in _help
+
+
+def test_copy_help() -> None:
+    _help = COPIER_CMD("copy", "--help")
+    assert "copier copy [SWITCHES] template_src destination_path" in _help
 
 
 def test_update_help() -> None:
-    assert "-o, --conflict" in COPIER_CMD("update", "--help")
+    _help = COPIER_CMD("update", "--help")
+    assert "-o, --conflict" in _help
+    assert "copier update [SWITCHES] [destination_path=.]" in _help
 
 
 def test_python_run() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,7 +54,15 @@ def template_path_with_dot_config(
 
 def test_good_cli_run(template_path: str, tmp_path: Path) -> None:
     run_result = CopierApp.run(
-        ["--quiet", "-a", "altered-answers.yml", template_path, str(tmp_path)],
+        [
+            "copier",
+            "copy",
+            "--quiet",
+            "-a",
+            "altered-answers.yml",
+            template_path,
+            str(tmp_path),
+        ],
         exit=False,
     )
     a_txt = tmp_path / "a.txt"
@@ -114,7 +122,7 @@ def test_cli_data_parsed_by_question_type(
         }
     )
     run_result = CopierApp.run(
-        ["--quiet", f"--data=question={answer}", str(src), str(dst)],
+        ["copier", "copy", f"--data=question={answer}", str(src), str(dst), "--quiet"],
         exit=False,
     )
     assert run_result[1] == 0
@@ -147,9 +155,11 @@ def test_good_cli_run_dot_config(
 
     run_result = CopierApp.run(
         [
+            "copier",
+            "copy",
             "--quiet",
             "-a",
-            config_folder / "altered-answers.yml",
+            str(config_folder / "altered-answers.yml"),
             src,
             str(tmp_path),
         ],
@@ -168,8 +178,16 @@ def test_good_cli_run_dot_config(
     with local.cwd(str(tmp_path)):
         git_commands()
 
-    run_update = CopierApp.invoke(
-        str(tmp_path), answers_file=config_folder / "altered-answers.yml", quiet=True
+    run_update = CopierApp.run(
+        [
+            "copier",
+            "update",
+            str(tmp_path),
+            "--answers-file",
+            str(config_folder / "altered-answers.yml"),
+            "--quiet",
+        ],
+        exit=False,
     )
     assert run_update[1] == 0
     assert answers["_src_path"] == src
@@ -206,6 +224,8 @@ def test_python_run() -> None:
 def test_skip_filenotexists(template_path: str, tmp_path: Path) -> None:
     run_result = CopierApp.run(
         [
+            "copier",
+            "copy",
             "--quiet",
             "-a",
             "altered-answers.yml",
@@ -230,6 +250,8 @@ def test_skip_fileexists(template_path: str, tmp_path: Path) -> None:
     a_txt.write_text("PREVIOUS_CONTENT")
     run_result = CopierApp.run(
         [
+            "copier",
+            "copy",
             "--quiet",
             "-a",
             "altered-answers.yml",

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -10,7 +10,7 @@ from pexpect.popen_spawn import PopenSpawn
 from plumbum import local
 from plumbum.cmd import git
 
-from copier import copy, run_auto, run_update
+from copier import run_copy, run_update
 from copier.types import OptStr
 
 from .helpers import (
@@ -134,7 +134,7 @@ def check_invalid(
 
 def test_api(template_path: str, tmp_path: Path) -> None:
     """Test copier correctly processes advanced questions and answers through API."""
-    copy(
+    run_copy(
         template_path,
         tmp_path,
         {
@@ -272,7 +272,7 @@ def test_api_str_data(template_path: str, tmp_path: Path) -> None:
 
     This happens i.e. when using the --data CLI argument.
     """
-    copy(
+    run_copy(
         template_path,
         tmp_path,
         data={
@@ -312,11 +312,11 @@ def test_cli_interatively_with_flag_data_and_type_casts(
     tui = spawn(
         COPIER_PATH
         + (
+            "copy",
             "--data=choose_list=second",
             "--data=choose_dict=first",
             "--data=choose_tuple=third",
             "--data=choose_number=1",
-            "copy",
             template_path,
             str(tmp_path),
         ),
@@ -518,12 +518,12 @@ def test_multi_template_answers(tmp_path_factory: pytest.TempPathFactory) -> Non
             git("commit", "-m1")
     with local.cwd(dst):
         # Apply template 1
-        run_auto(str(tpl1), overwrite=True, defaults=True)
+        run_copy(str(tpl1), overwrite=True, defaults=True)
         git("init")
         git("add", "-A")
         git("commit", "-m1")
         # Apply template 2
-        run_auto(str(tpl2), overwrite=True, defaults=True)
+        run_copy(str(tpl2), overwrite=True, defaults=True)
         git("init")
         git("add", "-A")
         git("commit", "-m2")
@@ -561,6 +561,6 @@ def test_omit_answer_for_skipped_question(
             ),
         }
     )
-    copy(str(src), dst, defaults=True, data={"disabled": "hello"})
+    run_copy(str(src), dst, defaults=True, data={"disabled": "hello"})
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers == {"_src_path": str(src)}

--- a/tests/test_conditional_file_name.py
+++ b/tests/test_conditional_file_name.py
@@ -18,7 +18,7 @@ def test_render_conditional(tmp_path_factory: TempPathFactory) -> None:
             ),
         }
     )
-    copier.run_auto(str(src), dst, data={"conditional": {"variable": True}})
+    copier.run_copy(str(src), dst, data={"conditional": {"variable": True}})
     assert (dst / "file.txt").read_text() == "This is True."
 
 
@@ -31,7 +31,7 @@ def test_dont_render_conditional(tmp_path_factory: TempPathFactory) -> None:
             ),
         }
     )
-    copier.run_auto(str(src), dst)
+    copier.run_copy(str(src), dst)
     assert not (dst / "file.txt").exists()
 
 
@@ -44,7 +44,7 @@ def test_render_conditional_subdir(tmp_path_factory: TempPathFactory) -> None:
             ),
         }
     )
-    copier.run_auto(str(src), dst, data={"conditional": {"variable": True}})
+    copier.run_copy(str(src), dst, data={"conditional": {"variable": True}})
     assert (dst / "subdir" / "file.txt").read_text() == "This is True."
 
 
@@ -57,7 +57,7 @@ def test_dont_render_conditional_subdir(tmp_path_factory: TempPathFactory) -> No
             ),
         }
     )
-    copier.run_auto(str(src), dst)
+    copier.run_copy(str(src), dst)
     assert not (dst / "subdir" / "file.txt").exists()
 
 
@@ -84,14 +84,14 @@ def test_answer_changes(
         git("tag", "v1")
 
     if interactive:
-        tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
         expect_prompt(tui, "condition", "bool")
         tui.expect_exact("(y/N)")
         tui.sendline("y")
         tui.expect_exact("Yes")
         tui.expect_exact(pexpect.EOF)
     else:
-        copier.copy(str(src), dst, data={"condition": True})
+        copier.run_copy(str(src), dst, data={"condition": True})
 
     assert (dst / "file.txt").exists()
 
@@ -101,13 +101,13 @@ def test_answer_changes(
         git("commit", "-mv1")
 
     if interactive:
-        tui = spawn(COPIER_PATH + ("--overwrite", "update", str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("update", "--overwrite", str(dst)), timeout=10)
         expect_prompt(tui, "condition", "bool")
         tui.expect_exact("(Y/n)")
         tui.sendline("n")
         tui.expect_exact("No")
         tui.expect_exact(pexpect.EOF)
     else:
-        copier.copy(dst_path=dst, data={"condition": False}, overwrite=True)
+        copier.run_update(dst_path=dst, data={"condition": False}, overwrite=True)
 
     assert not (dst / "file.txt").exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -87,7 +87,7 @@ def test_read_data(
             ),
         }
     )
-    copier.copy(str(src), dst, defaults=True, overwrite=True)
+    copier.run_copy(str(src), dst, defaults=True, overwrite=True)
     assert (dst / "user_data.txt").read_text() == dedent(
         """\
         A string: lorem ipsum
@@ -228,7 +228,7 @@ def test_flags_extra_fails() -> None:
 
 def test_missing_template(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
-        copier.copy("./i_do_not_exist", tmp_path)
+        copier.run_copy("./i_do_not_exist", tmp_path)
 
 
 def is_subdict(small: Dict[Any, Any], big: Dict[Any, Any]) -> bool:
@@ -374,7 +374,7 @@ def test_user_defaults(
             ),
         }
     )
-    copier.copy(
+    copier.run_copy(
         str(src),
         dst,
         defaults=True,
@@ -504,7 +504,7 @@ def test_user_defaults_updated(
         )
         git_init()
 
-    copier.copy(
+    copier.run_copy(
         str(src),
         dst,
         defaults=True,

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -12,7 +12,7 @@ from plumbum.cmd import git
 from prompt_toolkit.validation import ValidationError
 
 import copier
-from copier import copy
+from copier import run_copy
 from copier.types import AnyByStrDict
 
 from .helpers import (
@@ -28,10 +28,10 @@ from .helpers import (
 
 def test_project_not_found(tmp_path: Path) -> None:
     with pytest.raises(ValueError):
-        copier.copy("foobar", tmp_path)
+        copier.run_copy("foobar", tmp_path)
 
     with pytest.raises(ValueError):
-        copier.copy(__file__, tmp_path)
+        copier.run_copy(__file__, tmp_path)
 
 
 def test_copy_with_non_version_tags(tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -59,7 +59,7 @@ def test_copy_with_non_version_tags(tmp_path_factory: pytest.TempPathFactory) ->
         git("commit", "-m1")
         git("tag", "test_tag.post23+deadbeef")
 
-    copy(
+    run_copy(
         str(src),
         dst,
         defaults=True,
@@ -95,7 +95,7 @@ def test_copy_with_non_version_tags_and_vcs_ref(
         git("commit", "-m1")
         git("tag", "test_tag.post23+deadbeef")
 
-    copy(
+    run_copy(
         str(src),
         dst,
         defaults=True,
@@ -114,7 +114,7 @@ def test_copy_with_vcs_ref_branch(tmp_path_factory: pytest.TempPathFactory) -> N
         git("checkout", "-b", "branch")
         git("commit", "-m2", "--allow-empty")
         git("checkout", main_branch)
-    copy(str(src), dst, vcs_ref="branch")
+    run_copy(str(src), dst, vcs_ref="branch")
 
 
 def test_copy(tmp_path: Path) -> None:
@@ -153,7 +153,7 @@ def test_copy(tmp_path: Path) -> None:
 
 @pytest.mark.impure
 def test_copy_repo(tmp_path: Path) -> None:
-    copier.copy(
+    copier.run_copy(
         "gh:copier-org/copier.git",
         tmp_path,
         vcs_ref="HEAD",
@@ -202,7 +202,7 @@ def test_exclude_extends(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("init")
         git("add", ".")
         git("commit", "-m", "hello world")
-    copier.copy(str(src), dst, exclude=["*.txt"])
+    copier.run_copy(str(src), dst, exclude=["*.txt"])
     assert (dst / "test.json").is_file()
     assert not (dst / "test.txt").exists()
     # .git exists in src, but not in dst because it is excluded by default
@@ -221,7 +221,7 @@ def test_exclude_replaces(tmp_path_factory: pytest.TempPathFactory) -> None:
             src / "copier.yml": "_exclude: ['*.json']",
         }
     )
-    copier.copy(str(src), dst, exclude=["*.txt"])
+    copier.run_copy(str(src), dst, exclude=["*.txt"])
     assert (dst / "test.yaml").is_file()
     assert not (dst / "test.txt").exists()
     assert not (dst / "test.json").exists()
@@ -230,8 +230,8 @@ def test_exclude_replaces(tmp_path_factory: pytest.TempPathFactory) -> None:
 
 
 def test_skip_if_exists(tmp_path: Path) -> None:
-    copier.copy(str(Path("tests", "demo_skip_dst")), tmp_path)
-    copier.copy(
+    copier.run_copy(str(Path("tests", "demo_skip_dst")), tmp_path)
+    copier.run_copy(
         "tests/demo_skip_src",
         tmp_path,
         skip_if_exists=["b.noeof.txt", "meh/c.noeof.txt"],
@@ -245,8 +245,8 @@ def test_skip_if_exists(tmp_path: Path) -> None:
 
 
 def test_skip_if_exists_rendered_patterns(tmp_path: Path) -> None:
-    copier.copy("tests/demo_skip_dst", tmp_path)
-    copier.copy(
+    copier.run_copy("tests/demo_skip_dst", tmp_path)
+    copier.run_copy(
         "tests/demo_skip_src",
         tmp_path,
         data={"name": "meh"},
@@ -380,7 +380,7 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
             ),
         }
     )
-    copier.run_auto(str(src), dst, data={"filename": "a.b.c"})
+    copier.run_copy(str(src), dst, data={"filename": "a.b.c"})
     assert (dst / "a" / "b" / "c.txt").read_text() == "This is template."
 
 
@@ -643,7 +643,7 @@ def test_validate_init_data(
         }
     )
     with expected:
-        copier.copy(str(src), dst, data={"q": value})
+        copier.run_copy(str(src), dst, data={"q": value})
 
 
 @pytest.mark.parametrize("defaults", [False, True])
@@ -684,7 +684,7 @@ def test_validate_init_data_with_skipped_question(
             ),
         }
     )
-    copier.copy(
+    copier.run_copy(
         str(src), dst, defaults=defaults, data={"kind": "foo", "testfoo": "helloworld"}
     )
     assert (dst / "result").read_text() == "foo\n\nhelloworld\n"
@@ -710,7 +710,7 @@ def test_required_question_without_data(
         }
     )
     with pytest.raises(ValueError, match='Question "question" is required'):
-        copier.copy(str(src), dst, defaults=True)
+        copier.run_copy(str(src), dst, defaults=True)
 
 
 @pytest.mark.parametrize(
@@ -740,7 +740,7 @@ def test_required_choice_question_without_data(
         }
     )
     with pytest.raises(ValueError, match='Question "question" is required'):
-        copier.copy(str(src), dst, defaults=True)
+        copier.run_copy(str(src), dst, defaults=True)
 
 
 @pytest.mark.parametrize(
@@ -823,4 +823,4 @@ def test_validate_default_value(
         }
     )
     with expected:
-        copier.copy(str(src), dst, defaults=True)
+        copier.run_copy(str(src), dst, defaults=True)

--- a/tests/test_demo_update_tasks.py
+++ b/tests/test_demo_update_tasks.py
@@ -2,7 +2,7 @@ import pytest
 from plumbum import local
 from plumbum.cmd import git
 
-from copier import copy
+from copier import run_copy, run_update
 
 from .helpers import build_file_tree
 
@@ -54,7 +54,7 @@ def test_update_tasks(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("tag", "v2")
         git("bundle", "create", bundle, "--all")
     # Copy the 1st version
-    copy(str(bundle), dst, defaults=True, overwrite=True, vcs_ref="v1")
+    run_copy(str(bundle), dst, defaults=True, overwrite=True, vcs_ref="v1")
     # Init destination as a new independent git repo
     with local.cwd(dst):
         git("init")
@@ -65,4 +65,4 @@ def test_update_tasks(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("add", ".")
         git("commit", "-m", "hello world")
     # Update target to v2
-    copy(dst_path=dst, defaults=True, overwrite=True)
+    run_update(dst_path=dst, defaults=True, overwrite=True)

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -28,7 +28,7 @@ def test_copy(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("init")
 
     with pytest.warns(DirtyLocalWarning):
-        copier.copy(str(src), dst, data=DATA, vcs_ref="HEAD", quiet=True)
+        copier.run_copy(str(src), dst, data=DATA, vcs_ref="HEAD", quiet=True)
 
     generated = (dst / "pyproject.toml").read_text()
     control = (Path(__file__).parent / "reference_files" / "pyproject.toml").read_text()

--- a/tests/test_empty_suffix.py
+++ b/tests/test_empty_suffix.py
@@ -22,7 +22,7 @@ def test_empty_suffix(tmp_path_factory: pytest.TempPathFactory) -> None:
             (root / "{{name}}" / "render_me.txt"): "Hello {{name}}!",
         }
     )
-    copier.copy(str(root), dest, defaults=True, overwrite=True)
+    copier.run_copy(str(root), dest, defaults=True, overwrite=True)
 
     assert not (dest / "copier.yaml").exists()
 
@@ -53,7 +53,7 @@ def test_binary_file_fallback_to_copy(tmp_path_factory: pytest.TempPathFactory) 
             ),
         }
     )
-    copier.copy(str(root), dest, defaults=True, overwrite=True)
+    copier.run_copy(str(root), dest, defaults=True, overwrite=True)
     logo = dest / "logo.png"
     assert logo.exists()
     logo_bytes = logo.read_bytes()

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -4,7 +4,7 @@ from typing import Mapping
 
 import pytest
 
-from copier.main import run_auto
+from copier.main import run_copy
 from copier.template import DEFAULT_EXCLUDE
 from copier.types import StrOrPath
 
@@ -14,7 +14,7 @@ from .helpers import PROJECT_TEMPLATE, build_file_tree
 def test_exclude_recursive(tmp_path: Path) -> None:
     """Copy is done properly when excluding recursively."""
     src = f"{PROJECT_TEMPLATE}_exclude"
-    run_auto(src, tmp_path)
+    run_copy(src, tmp_path)
     assert not (tmp_path / "bad").exists()
     assert not (tmp_path / "bad").is_dir()
 
@@ -22,7 +22,7 @@ def test_exclude_recursive(tmp_path: Path) -> None:
 def test_exclude_recursive_negate(tmp_path: Path) -> None:
     """Copy is done properly when copy_me.txt is the sole file copied."""
     src = f"{PROJECT_TEMPLATE}_exclude_negate"
-    run_auto(src, tmp_path)
+    run_copy(src, tmp_path)
     assert (tmp_path / "copy_me.txt").exists()
     assert (tmp_path / "copy_me.txt").is_file()
     assert not (tmp_path / "do_not_copy_me.txt").exists()
@@ -31,7 +31,7 @@ def test_exclude_recursive_negate(tmp_path: Path) -> None:
 def test_config_exclude(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree({src / "copier.yml": "_exclude: ['*.txt']", src / "aaaa.txt": ""})
-    run_auto(str(src), dst, quiet=True)
+    run_copy(str(src), dst, quiet=True)
     assert not (dst / "aaaa.txt").exists()
     assert (dst / "copier.yml").exists()
 
@@ -39,7 +39,7 @@ def test_config_exclude(tmp_path_factory: pytest.TempPathFactory) -> None:
 def test_config_exclude_extended(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree({src / "copier.yml": "_exclude: ['*.txt']", src / "aaaa.txt": ""})
-    run_auto(str(src), dst, quiet=True, exclude=["*.yml"])
+    run_copy(str(src), dst, quiet=True, exclude=["*.yml"])
     assert not (dst / "aaaa.txt").exists()
     assert not (dst / "copier.yml").exists()
 
@@ -49,7 +49,7 @@ def test_config_include(tmp_path_factory: pytest.TempPathFactory) -> None:
     build_file_tree(
         {src / "copier.yml": "_exclude: ['!.svn']", src / ".svn" / "hello": ""}
     )
-    run_auto(str(src), dst, quiet=True)
+    run_copy(str(src), dst, quiet=True)
     assert (dst / ".svn" / "hello").exists()
     assert (dst / "copier.yml").exists()
 
@@ -92,7 +92,7 @@ def test_path_filter(tmp_path_factory: pytest.TempPathFactory) -> None:
             **{(src / key): str(value) for key, value in file_excluded.items()},
         }
     )
-    run_auto(str(src), dst)
+    run_copy(str(src), dst)
     for key, value in file_excluded.items():
         assert (dst / key).exists() != value
 
@@ -111,24 +111,24 @@ def test_config_exclude_with_subdirectory(
             src / "template" / "copier.yml": "",
         }
     )
-    run_auto(str(src), dst, quiet=True)
+    run_copy(str(src), dst, quiet=True)
     assert (dst / "copier.yml").exists()
 
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {src / "copier.yml": "_subdirectory: '.'", src / "template" / "copier.yml": ""}
     )
-    run_auto(str(src), dst, quiet=True)
+    run_copy(str(src), dst, quiet=True)
     assert not (dst / "template" / "copier.yml").exists()
 
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {src / "copier.yml": "_subdirectory: ''", src / "template" / "copier.yml": ""}
     )
-    run_auto(str(src), dst, quiet=True)
+    run_copy(str(src), dst, quiet=True)
     assert not (dst / "template" / "copier.yml").exists()
 
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree({src / "copier.yml": "", src / "template" / "copier.yml": ""})
-    run_auto(str(src), dst, quiet=True)
+    run_copy(str(src), dst, quiet=True)
     assert not (dst / "template" / "copier.yml").exists()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -67,7 +67,7 @@ def test_include(
             ): "",
         }
     )
-    copier.copy(str(src), dst, defaults=True)
+    copier.run_copy(str(src), dst, defaults=True)
     assert (dst / "slug-answer.txt").read_text() == "the-name"
     assert (dst / "slug-from-include.txt").read_text() == "the-name"
     assert (dst / "the-name.txt").exists()
@@ -143,7 +143,7 @@ def test_import_macro(
             ): "",
         }
     )
-    copier.copy(str(src), dst, defaults=True)
+    copier.run_copy(str(src), dst, defaults=True)
     assert (dst / "slug-answer.txt").read_text() == "the-name"
     assert (dst / "slug-from-macro.txt").read_text() == "the-name"
     assert (dst / "the-name.txt").exists()

--- a/tests/test_jinja2_extensions.py
+++ b/tests/test_jinja2_extensions.py
@@ -36,14 +36,14 @@ class GlobalsExtension(Extension):
 
 
 def test_default_jinja2_extensions(tmp_path: Path) -> None:
-    copier.copy(str(PROJECT_TEMPLATE) + "_extensions_default", tmp_path)
+    copier.run_copy(str(PROJECT_TEMPLATE) + "_extensions_default", tmp_path)
     super_file = tmp_path / "super_file.md"
     assert super_file.exists()
     assert super_file.read_text() == "path\n"
 
 
 def test_additional_jinja2_extensions(tmp_path: Path) -> None:
-    copier.copy(str(PROJECT_TEMPLATE) + "_extensions_additional", tmp_path)
+    copier.run_copy(str(PROJECT_TEMPLATE) + "_extensions_additional", tmp_path)
     super_file = tmp_path / "super_file.md"
     assert super_file.exists()
     assert super_file.read_text() == "super var! super func! super filter!\n"
@@ -56,7 +56,7 @@ def test_to_json_filter_with_conf(tmp_path_factory: pytest.TempPathFactory) -> N
             src / "conf.json.jinja": "{{ _copier_conf|to_json }}",
         }
     )
-    copier.copy(str(src), dst)
+    copier.run_copy(str(src), dst)
     conf_file = dst / "conf.json"
     assert conf_file.exists()
     # must not raise an error

--- a/tests/test_minimum_version.py
+++ b/tests/test_minimum_version.py
@@ -37,7 +37,7 @@ def test_version_less_than_required(
 ) -> None:
     monkeypatch.setattr("copier.__version__", "0.0.0a0")
     with pytest.raises(UnsupportedVersionError):
-        copier.copy(template_path, tmp_path)
+        copier.run_copy(template_path, tmp_path)
 
 
 def test_version_equal_required(
@@ -45,7 +45,7 @@ def test_version_equal_required(
 ) -> None:
     monkeypatch.setattr("copier.__version__", "10.5.1")
     # assert no error
-    copier.copy(template_path, tmp_path)
+    copier.run_copy(template_path, tmp_path)
 
 
 def test_version_greater_than_required(
@@ -53,14 +53,14 @@ def test_version_greater_than_required(
 ) -> None:
     monkeypatch.setattr("copier.__version__", "99.99.99")
     # assert no error
-    copier.copy(template_path, tmp_path)
+    copier.run_copy(template_path, tmp_path)
 
 
 def test_minimum_version_update(
     template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("copier.__version__", "11.0.0")
-    copier.copy(template_path, tmp_path)
+    copier.run_copy(template_path, tmp_path)
 
     with local.cwd(tmp_path):
         git("init")
@@ -71,15 +71,15 @@ def test_minimum_version_update(
 
     monkeypatch.setattr("copier.__version__", "0.0.0.post0")
     with pytest.raises(UnsupportedVersionError):
-        copier.copy(template_path, tmp_path)
+        copier.run_copy(template_path, tmp_path)
 
     monkeypatch.setattr("copier.__version__", "10.5.1")
     # assert no error
-    copier.copy(template_path, tmp_path)
+    copier.run_copy(template_path, tmp_path)
 
     monkeypatch.setattr("copier.__version__", "99.99.99")
     # assert no error
-    copier.copy(template_path, tmp_path)
+    copier.run_copy(template_path, tmp_path)
 
 
 def test_version_0_0_0_ignored(

--- a/tests/test_normal_jinja2.py
+++ b/tests/test_normal_jinja2.py
@@ -43,7 +43,7 @@ def test_normal_jinja2(tmp_path_factory: pytest.TempPathFactory) -> None:
     # No warnings, because template is explicit
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        copier.run_auto(str(src), dst, defaults=True, overwrite=True)
+        copier.run_copy(str(src), dst, defaults=True, overwrite=True)
     todo = (dst / "TODO.txt").read_text()
     expected = "[[ Guybrush TODO LIST]]\n[# GROG #]\n    - Become a pirate\n"
     assert todo == expected
@@ -69,5 +69,5 @@ def test_to_not_keep_trailing_newlines_in_jinja2(
     # No warnings, because template is explicit
     with warnings.catch_warnings():
         warnings.simplefilter("error")
-        copier.run_auto(str(src), dst, defaults=True, overwrite=True)
+        copier.run_copy(str(src), dst, defaults=True, overwrite=True)
     assert (dst / "data.txt").read_text() == "This is foo."

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -72,7 +72,9 @@ def test_copy_default_advertised(
         git("tag", "v2")
     with local.cwd(dst):
         # Copy the v1 template
-        tui = spawn(COPIER_PATH + (str(src), ".", "--vcs-ref=v1") + args, timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("copy", str(src), ".", "--vcs-ref=v1") + args, timeout=10
+        )
         # Check what was captured
         expect_prompt(tui, "in_love", "bool")
         tui.expect_exact("(Y/n)")
@@ -97,7 +99,7 @@ def test_copy_default_advertised(
         git("add", ".")
         assert "_commit: v1" in Path(".copier-answers.yml").read_text()
         git("commit", "-m", "v1")
-        tui = spawn(COPIER_PATH, timeout=30)
+        tui = spawn(COPIER_PATH + ("update",), timeout=30)
         # Check what was captured
         expect_prompt(tui, "in_love", "bool")
         tui.expect_exact("(Y/n)")
@@ -183,7 +185,7 @@ def test_when(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", type(question_1).__name__)
     tui.sendline()
     if asks:
@@ -219,7 +221,7 @@ def test_placeholder(tmp_path_factory: pytest.TempPathFactory, spawn: Spawn) -> 
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     tui.sendline()
@@ -264,7 +266,7 @@ def test_multiline(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     tui.sendline()
@@ -343,7 +345,7 @@ def test_update_choice(
         git("commit", "-m one")
         git("tag", "v1")
     # Copy
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "pick_one", "float")
     tui.sendline(Keyboard.Up)
     tui.expect_exact(pexpect.EOF)
@@ -354,7 +356,14 @@ def test_update_choice(
         git("add", ".")
         git("commit", "-m1")
     # Update
-    tui = spawn(COPIER_PATH + (str(dst),), timeout=10)
+    tui = spawn(
+        COPIER_PATH
+        + (
+            "update",
+            str(dst),
+        ),
+        timeout=10,
+    )
     expect_prompt(tui, "pick_one", "float")
     tui.sendline(Keyboard.Down)
     tui.expect_exact(pexpect.EOF)
@@ -397,7 +406,7 @@ def test_multiline_defaults(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "yaml_single", "yaml")
     # This test will always fail here, because python prompt toolkit gives
     # syntax highlighting to YAML and JSON outputs, encoded into terminal
@@ -442,7 +451,7 @@ def test_partial_interrupt(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     # Answer the first question using the default.
@@ -482,7 +491,7 @@ def test_var_name_value_allowed(
         }
     )
     # Copy
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "value", "str")
     tui.expect_exact("string")
     tui.send(Keyboard.Alt + Keyboard.Enter)
@@ -523,7 +532,7 @@ def test_required_text_question(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question", type_name)
     tui.expect_exact("")
     tui.sendline()
@@ -557,7 +566,7 @@ def test_required_bool_question(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question", "bool")
     tui.expect_exact("(y/N)")
     tui.sendline()
@@ -604,7 +613,7 @@ def test_required_choice_question(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "question", type_name)
     tui.sendline()
     tui.expect_exact(pexpect.EOF)

--- a/tests/test_recopy.py
+++ b/tests/test_recopy.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+from plumbum import local
+
+from copier import run_copy, run_recopy
+from copier.cli import CopierApp
+
+from .helpers import build_file_tree, git_save
+
+
+@pytest.fixture(scope="module")
+def tpl(tmp_path_factory: pytest.TempPathFactory) -> str:
+    """A simple template that supports updates."""
+    dst = tmp_path_factory.mktemp("tpl")
+    with local.cwd(dst):
+        build_file_tree(
+            {
+                "copier.yml": "your_name: Mario",
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+                "name.txt.jinja": "This is your name: {{ your_name }}.",
+            }
+        )
+        git_save()
+    return str(dst)
+
+
+def test_recopy_discards_evolution_api(tpl: str, tmp_path: Path) -> None:
+    # First copy
+    run_copy(tpl, tmp_path, data={"your_name": "Luigi"}, defaults=True, overwrite=True)
+    git_save(tmp_path)
+    name_path = tmp_path / "name.txt"
+    assert name_path.read_text() == "This is your name: Luigi."
+    # Evolve subproject
+    name_path.write_text("This is your name: Luigi. Welcome.")
+    git_save(tmp_path)
+    # Recopy
+    run_recopy(tmp_path, defaults=True, overwrite=True)
+    assert name_path.read_text() == "This is your name: Luigi."
+
+
+def test_recopy_discards_evolution_cli(tpl: str, tmp_path: Path) -> None:
+    # First copy
+    run_copy(tpl, tmp_path, data={"your_name": "Peach"}, defaults=True, overwrite=True)
+    git_save(tmp_path)
+    name_path = tmp_path / "name.txt"
+    assert name_path.read_text() == "This is your name: Peach."
+    # Evolve subproject
+    name_path.write_text("This is your name: Peach. Welcome.")
+    git_save(tmp_path)
+    # Recopy
+    with local.cwd(tmp_path):
+        _, retcode = CopierApp.run(["copier", "recopy", "-f"], exit=False)
+    assert retcode == 0
+    assert name_path.read_text() == "This is your name: Peach."

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -67,7 +67,7 @@ def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
 
 
 def test_copy_subdirectory_api_option(template_path: str, tmp_path: Path) -> None:
-    copier.copy(
+    copier.run_copy(
         template_path,
         tmp_path,
         defaults=True,
@@ -79,18 +79,18 @@ def test_copy_subdirectory_api_option(template_path: str, tmp_path: Path) -> Non
 
 
 def test_copy_subdirectory_config(template_path: str, tmp_path: Path) -> None:
-    copier.copy(template_path, tmp_path, defaults=True, overwrite=True)
+    copier.run_copy(template_path, tmp_path, defaults=True, overwrite=True)
     assert (tmp_path / "conf_readme.md").exists()
     assert not (tmp_path / "api_readme.md").exists()
 
 
 def test_update_subdirectory(template_path: str, tmp_path: Path) -> None:
-    copier.copy(template_path, tmp_path, defaults=True, overwrite=True)
+    copier.run_copy(template_path, tmp_path, defaults=True, overwrite=True)
 
     with local.cwd(tmp_path):
         git_init()
 
-    copier.copy(dst_path=tmp_path, defaults=True, overwrite=True)
+    copier.run_update(dst_path=tmp_path, defaults=True, overwrite=True)
     assert not (tmp_path / "conf_project").exists()
     assert not (tmp_path / "api_project").exists()
     assert not (tmp_path / "api_readme.md").exists()
@@ -218,7 +218,7 @@ def test_new_version_uses_subdirectory(
         git("tag", "v1")
 
     # Generate the project a first time, assert the README exists
-    copier.copy(str(src), dst, defaults=True, overwrite=True)
+    copier.run_copy(str(src), dst, defaults=True, overwrite=True)
     assert (dst / "README.md").exists()
     assert "_commit: v1" in (dst / ".copier-answers.yml").read_text()
 
@@ -252,7 +252,7 @@ def test_new_version_uses_subdirectory(
         git("tag", "v2")
 
     # Finally, update the generated project
-    copier.copy(dst_path=dst, defaults=True, overwrite=True, conflict=conflict)
+    copier.run_update(dst_path=dst, defaults=True, overwrite=True, conflict=conflict)
     assert "_commit: v2" in (dst / ".copier-answers.yml").read_text()
 
     # Assert that the README still exists, and the conflicts were handled
@@ -288,7 +288,7 @@ def test_new_version_changes_subdirectory(
         git_init("hello template")
 
     # Generate the project a first time, assert the README exists
-    copier.copy(str(src), dst, defaults=True, overwrite=True)
+    copier.run_copy(str(src), dst, defaults=True, overwrite=True)
     assert (dst / "README.md").exists()
 
     # Start versioning the generated project
@@ -315,7 +315,7 @@ def test_new_version_changes_subdirectory(
         git("commit", "-m", "changed from subdir1 to subdir2")
 
     # Finally, update the generated project
-    copier.copy(
+    copier.run_copy(
         str(src), dst, defaults=True, overwrite=True, skip_if_exists=["README.md"]
     )
 

--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -5,7 +5,7 @@ import pytest
 from plumbum import local
 from plumbum.cmd import git
 
-from copier import copy, readlink, run_copy, run_update
+from copier import readlink, run_copy, run_update
 from copier.errors import DirtyLocalWarning
 
 from .helpers import build_file_tree
@@ -32,7 +32,7 @@ def test_copy_symlink(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -68,7 +68,7 @@ def test_copy_symlink_templated_name(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -105,7 +105,7 @@ def test_copy_symlink_templated_target(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -144,7 +144,7 @@ def test_copy_symlink_missing_target(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -180,7 +180,7 @@ def test_option_preserve_symlinks_false(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -213,7 +213,7 @@ def test_option_preserve_symlinks_default(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -307,7 +307,7 @@ def test_exclude_symlink(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -340,7 +340,7 @@ def test_pretend_symlink(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,
@@ -374,7 +374,7 @@ def test_copy_symlink_none_path(tmp_path_factory):
         git("add", ".")
         git("commit", "-m", "hello world")
 
-    copy(
+    run_copy(
         str(repo),
         dst,
         defaults=True,

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -35,12 +35,12 @@ def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
 
 
 def test_render_tasks(template_path: str, tmp_path: Path) -> None:
-    copier.copy(template_path, tmp_path, data={"other_file": "custom"})
+    copier.run_copy(template_path, tmp_path, data={"other_file": "custom"})
     assert (tmp_path / "custom").is_file()
 
 
 def test_copy_tasks(template_path: str, tmp_path: Path) -> None:
-    copier.copy(template_path, tmp_path, quiet=True, defaults=True, overwrite=True)
+    copier.run_copy(template_path, tmp_path, quiet=True, defaults=True, overwrite=True)
     assert (tmp_path / "hello").exists()
     assert (tmp_path / "hello").is_dir()
     assert (tmp_path / "hello" / "world").exists()
@@ -60,5 +60,5 @@ def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
             )
         }
     )
-    copier.copy(str(src), dst, pretend=True)
+    copier.run_copy(str(src), dst, pretend=True)
     assert not (dst / "created-by-task.txt").exists()

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -164,7 +164,7 @@ def test_templated_prompt(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + (str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "main", "str")
     tui.expect_exact(main_default)
     tui.sendline()
@@ -354,7 +354,7 @@ def test_templated_prompt_with_conditional_choices(
         }
     )
     tui = spawn(
-        COPIER_PATH + (f"--data=cloud={cloud}", "copy", str(src), str(dst)),
+        COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)),
         timeout=10,
     )
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -404,7 +404,9 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
         git("commit", "-m", "feat: commit 2")
         git("tag", "v2")
     # Update subproject to v2
-    run_update(dst_path=dst1, defaults=True, overwrite=True, conflict="rej")
+    run_update(
+        dst_path=dst1, defaults=True, overwrite=True, conflict="rej", context_lines=1
+    )
     with local.cwd(dst1):
         git("commit", "-am", "feat: copied v2")
         assert life.read_text() == dedent(
@@ -440,7 +442,11 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
     with local.cwd(dst2):
         # Subproject re-updates just to change some values
         run_update(
-            data={"what": "study"}, defaults=True, overwrite=True, conflict="rej"
+            data={"what": "study"},
+            defaults=True,
+            overwrite=True,
+            conflict="rej",
+            context_lines=1,
         )
         git("commit", "-am", "chore: re-updated to change values after evolving")
         # Subproject evolution was respected up to sane possibilities.


### PR DESCRIPTION
# fix(cli): display subcommand args meaning


Use the `decorator` library for decorating `main()` in subcommands. This way, the method signature is properly inspected and explained by plumbum.

Fix #1090.

# feat: add recopy command and function


This new command allows to reapply a template, keeping old answers but discarding subproject evolution.

It is useful when there are bugs replaying an old version of the template, or when the subproject has drifted too much from the template and you need to reset it.

BREAKING CHANGE: All CLI calls to Copier must now include the subcommand as the 1st argument. For example, `copier` must become now `copier update`; also `copier ./tpl ./dst` must become `copier copy ./tpl ./dst`.

BREAKING CHANGE: All flags must go after the subcommand now. For example, `copier -r HEAD update ./dst` must now become `copier update -r HEAD ./dst` or `copier update ./dst -r HEAD`.

BREAKING CHANGE: Automatic mode removed. Since now subcommands are required, the automatic mode is removed.

BREAKING CHANGE: Deprecated `copier.copy` function is removed. Use `copier.run_copy`, `copier.run_update` or `copier.run_recopy` explicitly as needed.

Fix #1081
Close #1082

#  refactor(update): default to inline markers and 3 lines of context


Now that the inline mode is out of experimental, it turns out to provide a better default behavior than the good old rej mode. Mostly when context is increased to 3 lines or more.

BREAKING CHANGE: The default update conflict mode is now `inline` instead of `rej`.

BREAKING CHANGE: By default, updates now consider 3 lines of context instead of just 1.

