### PR TITLE
docs: replace `run_auto()` by `run_copy()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ To generate a project from the template:
 -   Or in Python code, programmatically:
 
     ```python
-    from copier import run_auto
+    from copier import run_copy
 
     # Create a project from a local path
-    run_auto("path/to/project/template", "path/to/destination")
+    run_copy("path/to/project/template", "path/to/destination")
 
     # Or from a Git URL.
-    run_auto("https://github.com/copier-org/copier.git", "path/to/destination")
+    run_copy("https://github.com/copier-org/copier.git", "path/to/destination")
 
     # You can also use "gh:" as a shortcut of "https://github.com/"
-    run_auto("gh:copier-org/copier.git", "path/to/destination")
+    run_copy("gh:copier-org/copier.git", "path/to/destination")
 
     # Or "gl:" as a shortcut of "https://gitlab.com/"
-    run_auto("gl:copier-org/copier.git", "path/to/destination")
+    run_copy("gl:copier-org/copier.git", "path/to/destination")
     ```
 
 ## Basic concepts

--- a/copier/main.py
+++ b/copier/main.py
@@ -74,9 +74,8 @@ class Worker:
     Then, execute one of its main methods, which are prefixed with `run_`:
 
     -   [run_copy][copier.main.Worker.run_copy] to copy a subproject.
+    -   [run_recopy][copier.main.Worker.run_recopy] to recopy a subproject.
     -   [run_update][copier.main.Worker.run_update] to update a subproject.
-    -   [run_auto][copier.main.Worker.run_auto] to let it choose whether you
-        want to copy or update the subproject.
 
     Example:
         ```python

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -15,7 +15,7 @@ copier path/to/project/template path/to/destination
 Or within Python code:
 
 ```python
-copier.run_auto("path/to/project/template", "path/to/destination")
+copier.run_copy("path/to/project/template", "path/to/destination")
 ```
 
 The "template" parameter can be a local path, an URL, or a shortcut URL:
@@ -27,7 +27,7 @@ If Copier doesn't detect your remote URL as a Git repository, make sure it start
 one of `git+https://`, `git+ssh://`, `git@` or `git://`, or it ends with `.git`.
 
 Use the `--data` command-line argument or the `data` parameter of the
-`copier.run_auto()` function to pass whatever extra context you want to be available in
+`copier.run_copy()` function to pass whatever extra context you want to be available in
 the templates. The arguments can be any valid Python value, even a function.
 
 Use the `--vcs-ref` command-line argument to checkout a particular Git ref before


### PR DESCRIPTION
Fantastic changes in #1143! :bow: :star_struck: :rocket:

I just updated the docs to fix a few leftovers from the past regarding usage of `copier.run_auto()`.