### PR TITLE
refactor: overwrite always on updates

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -129,18 +129,6 @@ class _Subcommand(cli.Application):
         ),
     )
     pretend = cli.Flag(["-n", "--pretend"], help="Run but do not make any changes")
-    force = cli.Flag(
-        ["-f", "--force"],
-        help="Same as `--defaults --overwrite`.",
-    )
-    defaults = cli.Flag(
-        ["-l", "--defaults"],
-        help="Use default answers to questions, which might be null if not specified.",
-    )
-    overwrite = cli.Flag(
-        ["-w", "--overwrite"],
-        help="Overwrite files that already exist, without asking.",
-    )
     skip = cli.SwitchAttr(
         ["-s", "--skip"],
         str,
@@ -185,8 +173,6 @@ class _Subcommand(cli.Application):
             dst_path=Path(dst_path),
             answers_file=self.answers_file,
             exclude=self.exclude,
-            defaults=self.force or self.defaults,
-            overwrite=self.force or self.overwrite,
             pretend=self.pretend,
             skip_if_exists=self.skip,
             quiet=self.quiet,
@@ -212,6 +198,18 @@ class CopierCopySubApp(_Subcommand):
         default=True,
         help="On error, do not delete destination if it was created by Copier.",
     )
+    defaults = cli.Flag(
+        ["-l", "--defaults"],
+        help="Use default answers to questions, which might be null if not specified.",
+    )
+    force = cli.Flag(
+        ["-f", "--force"],
+        help="Same as `--defaults --overwrite`.",
+    )
+    overwrite = cli.Flag(
+        ["-w", "--overwrite"],
+        help="Overwrite files that already exist, without asking.",
+    )
 
     @handle_exceptions
     def main(self, template_src: str, destination_path: str) -> int:
@@ -230,6 +228,8 @@ class CopierCopySubApp(_Subcommand):
             template_src,
             destination_path,
             cleanup_on_error=self.cleanup_on_error,
+            defaults=self.force or self.defaults,
+            overwrite=self.force or self.overwrite,
         ).run_copy()
         return 0
 
@@ -260,6 +260,19 @@ class CopierRecopySubApp(_Subcommand):
         """
     )
 
+    defaults = cli.Flag(
+        ["-l", "--defaults"],
+        help="Use default answers to questions, which might be null if not specified.",
+    )
+    force = cli.Flag(
+        ["-f", "--force"],
+        help="Same as `--defaults --overwrite`.",
+    )
+    overwrite = cli.Flag(
+        ["-w", "--overwrite"],
+        help="Overwrite files that already exist, without asking.",
+    )
+
     @handle_exceptions
     def main(self, destination_path: cli.ExistingDirectory = ".") -> int:
         """Call [run_recopy][copier.main.Worker.run_recopy].
@@ -274,6 +287,8 @@ class CopierRecopySubApp(_Subcommand):
         """
         self._worker(
             dst_path=destination_path,
+            defaults=self.force or self.defaults,
+            overwrite=self.force or self.overwrite,
         ).run_recopy()
         return 0
 
@@ -318,6 +333,10 @@ class CopierUpdateSubApp(_Subcommand):
             "accuracy, decrease for resilience."
         ),
     )
+    defaults = cli.Flag(
+        ["-l", "-f", "--defaults"],
+        help="Use default answers to questions, which might be null if not specified.",
+    )
 
     @handle_exceptions
     def main(self, destination_path: cli.ExistingDirectory = ".") -> int:
@@ -335,6 +354,8 @@ class CopierUpdateSubApp(_Subcommand):
             dst_path=destination_path,
             conflict=self.conflict,
             context_lines=self.context_lines,
+            defaults=self.defaults,
+            overwrite=True,
         ).run_update()
         return 0
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -755,6 +755,11 @@ class Worker:
                 f"Your are downgrading from {self.subproject.template.version} to {self.template.version}. "
                 "Downgrades are not supported."
             )
+        if not self.overwrite:
+            # Only git-tracked subprojects can be updated, so the user can
+            # review the diff before committing; so we can safely avoid
+            # asking for confirmation
+            raise UserMessageError("Enable overwrite to update a subproject.")
         if not self.quiet:
             # TODO Unify printing tools
             print(

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -882,7 +882,7 @@ Use default answers to questions.
 ### `overwrite`
 
 -   Format: `bool`
--   CLI flags: `--overwrite`
+-   CLI flags: `--overwrite` (N/A in `copier update` because it's implicit)
 -   Default value: `False`
 
 Overwrite files that already exist, without asking.
@@ -892,6 +892,8 @@ Overwrite files that already exist, without asking.
 !!! info
 
     Not supported in `copier.yml`.
+
+    Required when updating from API.
 
 ### `jinja_extensions`
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -154,15 +154,6 @@ As you can see here, `copier` does several things:
 -   Finally, it re-applies the previously obtained diff and then runs the
     post-migrations.
 
-!!! important
-
-    The diff obtained by comparing the fresh, regenerated project to your
-    current project can cancel the modifications applied by the update from the latest
-    template version. During the process, `copier` will ask for your confirmation to
-    overwrite or skip modifications, but in the end, it is possible that nothing has
-    changed (except for the version in `.copier-answers.yml` of course). This is not a
-    bug: although it can be quite surprising, this behavior is correct.
-
 ## Migration across Copier major versions
 
 When there's a new major release of Copier (for example from Copier 5.x to 6.x), there

--- a/tests/test_conditional_file_name.py
+++ b/tests/test_conditional_file_name.py
@@ -101,7 +101,7 @@ def test_answer_changes(
         git("commit", "-mv1")
 
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", "--overwrite", str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
         expect_prompt(tui, "condition", "bool")
         tui.expect_exact("(Y/n)")
         tui.sendline("n")


### PR DESCRIPTION
Updates not only overwrite files when actually updating, but also when applying the git diff.

Since only git-tracked subprojects can be updated, in reality there's no problem when overwriting. I find myself always overwriting and later fixing stuff with git tools.

BREAKING CHANGE: Updates will overwrite existing files always. If you need to select only some files, just use `git mergetool` or `git difftool` after updating.

BREAKING CHANGE: Flag `--overwrite/-w` disappeared from `copier update`. It is now implicit.

BREAKING CHANGE: To update via API, `overwrite=True` is now required.

Fix https://github.com/copier-org/copier/issues/741.