### PR TITLE
fix: don't lie about updated files

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -823,6 +823,7 @@ class Worker:
                 quiet=True,
             )
             current_worker.run_copy()
+            self.answers = current_worker.answers
             # Render with the same answers in an empty dir to avoid pollution
             new_worker = replace(
                 self,

--- a/copier/main.py
+++ b/copier/main.py
@@ -814,7 +814,15 @@ class Worker:
             with suppress(AttributeError):
                 del self.subproject.last_answers
             # Do a normal update in final destination
-            self.run_copy()
+            current_worker = replace(
+                self,
+                # Files can change due to the historical diff, and those
+                # changes are not detected in this process, so it's better to
+                # say nothing than lie.
+                # TODO
+                quiet=True,
+            )
+            current_worker.run_copy()
             # Render with the same answers in an empty dir to avoid pollution
             new_worker = replace(
                 self,


### PR DESCRIPTION
Updating involves some low-level git-fu. This can cause unpredicted files to get updated, and the report to the user sometimes is fake.

It'd be great to tell the truth, but for now at least let's just not lie.

Fix https://github.com/copier-org/copier/issues/943.