### PR TITLE
feat: disable unsafe features by default and add `--UNSAFE` switch

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -52,7 +52,7 @@ from unittest.mock import patch
 from decorator import decorator
 from plumbum import cli, colors
 
-from .errors import UserMessageError
+from .errors import UnsafeTemplateError, UserMessageError
 from .main import Worker
 from .tools import copier_version
 from .types import AnyByStrDict, OptStr, StrSeq
@@ -69,6 +69,9 @@ def handle_exceptions(method, *args, **kwargs):
     except UserMessageError as error:
         print(colors.red | "\n".join(error.args), file=sys.stderr)
         return 1
+    except UnsafeTemplateError as error:
+        print(colors.red | "\n".join(error.args), file=sys.stderr)
+        return 2
 
 
 class CopierApp(cli.Application):

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -140,6 +140,12 @@ class _Subcommand(cli.Application):
         ["-g", "--prereleases"],
         help="Use prereleases to compare template VCS tags.",
     )
+    unsafe = cli.Flag(
+        ["--UNSAFE"],
+        help=(
+            "Allow templates with unsafe features (Jinja extensions, migrations, tasks)"
+        ),
+    )
 
     @cli.switch(
         ["-d", "--data"],
@@ -179,6 +185,7 @@ class _Subcommand(cli.Application):
             src_path=src_path,
             vcs_ref=self.vcs_ref,
             use_prereleases=self.prereleases,
+            unsafe=self.unsafe,
             **kwargs,
         )
 

--- a/copier/errors.py
+++ b/copier/errors.py
@@ -1,7 +1,7 @@
 """Custom exceptions used by Copier."""
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Sequence
 
 from pydantic.errors import _PathValueError
 
@@ -96,6 +96,15 @@ class CopierAnswersInterrupt(CopierError, KeyboardInterrupt):
         self.answers = answers
         self.last_question = last_question
         self.template = template
+
+
+class UnsafeTemplateError(CopierError):
+    """Unsafe Copier template features are used without explicit consent."""
+
+    def __init__(self, features: Sequence[str]):
+        assert features
+        s = "s" if len(features) > 1 else ""
+        super().__init__(f"Template uses unsafe feature{s}: {', '.join(features)}")
 
 
 # Warnings

--- a/copier/main.py
+++ b/copier/main.py
@@ -11,7 +11,7 @@ from functools import partial
 from itertools import chain
 from pathlib import Path
 from shutil import rmtree
-from typing import Callable, Iterable, Mapping, Optional, Sequence, Set, Union, get_args
+from typing import Callable, Iterable, Mapping, Optional, Sequence, Set, Union
 from unicodedata import normalize
 
 from jinja2.loaders import FileSystemLoader
@@ -60,6 +60,13 @@ else:
         Can be remove once python 3.7 dropped.
         """
         copy_tree(str(src), str(dst))
+
+
+# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
+if sys.version_info >= (3, 8):
+    from typing import get_args
+else:
+    from typing_extensions import get_args
 
 
 @dataclass(config=ConfigDict(extra=Extra.forbid))

--- a/copier/main.py
+++ b/copier/main.py
@@ -26,7 +26,12 @@ from pydantic.dataclasses import dataclass
 from pydantic.json import pydantic_encoder
 from questionary import unsafe_prompt
 
-from .errors import CopierAnswersInterrupt, ExtensionNotFoundError, UserMessageError
+from .errors import (
+    CopierAnswersInterrupt,
+    ExtensionNotFoundError,
+    UnsafeTemplateError,
+    UserMessageError,
+)
 from .subproject import Subproject
 from .template import Task, Template
 from .tools import Style, TemporaryDirectory, printf, readlink
@@ -234,10 +239,7 @@ class Worker:
                     features.add("migrations")
                     break
         if features:
-            s = "s" if len(features) > 1 else ""
-            raise UserMessageError(
-                f"Template uses unsafe feature{s}: {', '.join(sorted(features))}"
-            )
+            raise UnsafeTemplateError(sorted(features))
 
     def _answers_to_remember(self) -> Mapping:
         """Get only answers that will be remembered in the copier answers file."""

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1319,10 +1319,11 @@ Copier templates can use dangerous features that allow arbitrary code execution:
 -   [Migrations](#migrations)
 -   [Tasks](#tasks)
 
-Therefore, these features are disabled by default and Copier will raise an error when
-they are found in a template. In this case, please verify that no malicious code gets
-executed by any of the used features. When you're sufficiently confident or willing to
-take the risk, set `unsafe=True` or pass the CLI switch `--UNSAFE`.
+Therefore, these features are disabled by default and Copier will raise an error (and
+exit from the CLI with code `2`) when they are found in a template. In this case, please
+verify that no malicious code gets executed by any of the used features. When you're
+sufficiently confident or willing to take the risk, set `unsafe=True` or pass the CLI
+switch `--UNSAFE`.
 
 !!! danger
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1307,6 +1307,31 @@ templates suffix is _not_ empty, Copier will abort and print an error message.
 
     Copier 7+ no longer uses the old default independent of [min_copier_version][].
 
+### `unsafe`
+
+-   Format: `bool`
+-   CLI flags: `--UNSAFE`
+-   Default value: `False`
+
+Copier templates can use dangerous features that allow arbitrary code execution:
+
+-   [Jinja extensions](#jinja_extensions)
+-   [Migrations](#migrations)
+-   [Tasks](#tasks)
+
+Therefore, these features are disabled by default and Copier will raise an error when
+they are found in a template. In this case, please verify that no malicious code gets
+executed by any of the used features. When you're sufficiently confident or willing to
+take the risk, set `unsafe=True` or pass the CLI switch `--UNSAFE`.
+
+!!! danger
+
+    Please be sure you understand the risks when allowing unsafe features!
+
+!!! info
+
+    Not supported in `copier.yml`.
+
 ### `use_prereleases`
 
 -   Format: `bool`

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -49,6 +49,7 @@ def test_answersfile_templating(
         answers_file=answers_file,
         defaults=True,
         overwrite=True,
+        unsafe=True,
     )
     first_answers_file = (
         ".copier-answers-mymodule.yml"
@@ -65,6 +66,7 @@ def test_answersfile_templating(
         {"module_name": "anothermodule"},
         defaults=True,
         overwrite=True,
+        unsafe=True,
     )
 
     # Assert second one created

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -11,7 +11,7 @@ def test_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and removes it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.run_copy("./tests/demo_cleanup", dst, quiet=True)
+        copier.run_copy("./tests/demo_cleanup", dst, quiet=True, unsafe=True)
     assert not dst.exists()
 
 
@@ -19,7 +19,9 @@ def test_do_not_cleanup(tmp_path: Path) -> None:
     """Copier creates dst_path, fails to copy and keeps it."""
     dst = tmp_path / "new_folder"
     with pytest.raises(CalledProcessError):
-        copier.run_copy("./tests/demo_cleanup", dst, quiet=True, cleanup_on_error=False)
+        copier.run_copy(
+            "./tests/demo_cleanup", dst, quiet=True, unsafe=True, cleanup_on_error=False
+        )
     assert dst.exists()
 
 
@@ -29,7 +31,11 @@ def test_no_cleanup_when_folder_existed(tmp_path: Path) -> None:
     preexisting_file.touch()
     with pytest.raises(CalledProcessError):
         copier.run_copy(
-            "./tests/demo_cleanup", tmp_path, quiet=True, cleanup_on_error=True
+            "./tests/demo_cleanup",
+            tmp_path,
+            quiet=True,
+            unsafe=True,
+            cleanup_on_error=True,
         )
     assert tmp_path.exists()
     assert preexisting_file.exists()

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -64,6 +64,7 @@ def test_copy_with_non_version_tags(tmp_path_factory: pytest.TempPathFactory) ->
         dst,
         defaults=True,
         overwrite=True,
+        unsafe=True,
         vcs_ref="HEAD",
     )
 
@@ -100,6 +101,7 @@ def test_copy_with_non_version_tags_and_vcs_ref(
         dst,
         defaults=True,
         overwrite=True,
+        unsafe=True,
         vcs_ref="test_tag.post23+deadbeef",
     )
 

--- a/tests/test_demo_update_tasks.py
+++ b/tests/test_demo_update_tasks.py
@@ -54,7 +54,7 @@ def test_update_tasks(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("tag", "v2")
         git("bundle", "create", bundle, "--all")
     # Copy the 1st version
-    run_copy(str(bundle), dst, defaults=True, overwrite=True, vcs_ref="v1")
+    run_copy(str(bundle), dst, defaults=True, overwrite=True, vcs_ref="v1", unsafe=True)
     # Init destination as a new independent git repo
     with local.cwd(dst):
         git("init")
@@ -65,4 +65,4 @@ def test_update_tasks(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("add", ".")
         git("commit", "-m", "hello world")
     # Update target to v2
-    run_update(dst_path=dst, defaults=True, overwrite=True)
+    run_update(dst_path=dst, defaults=True, overwrite=True, unsafe=True)

--- a/tests/test_jinja2_extensions.py
+++ b/tests/test_jinja2_extensions.py
@@ -43,7 +43,9 @@ def test_default_jinja2_extensions(tmp_path: Path) -> None:
 
 
 def test_additional_jinja2_extensions(tmp_path: Path) -> None:
-    copier.run_copy(str(PROJECT_TEMPLATE) + "_extensions_additional", tmp_path)
+    copier.run_copy(
+        str(PROJECT_TEMPLATE) + "_extensions_additional", tmp_path, unsafe=True
+    )
     super_file = tmp_path / "super_file.md"
     assert super_file.exists()
     assert super_file.read_text() == "super var! super func! super filter!\n"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -41,7 +41,7 @@ def test_migrations_and_tasks(tmp_path: Path) -> None:
         git("commit", "--allow-empty", "-m2")
         git("tag", "v2.0")
     # Copy it in v1
-    run_copy(src_path=str(src), dst_path=dst, vcs_ref="v1.0.0")
+    run_copy(src_path=str(src), dst_path=dst, vcs_ref="v1.0.0", unsafe=True)
     # Check copy was OK
     assert (dst / "created-with-tasks.txt").read_text() == "task 1\ntask 2\n"
     assert not (dst / "delete-in-tasks.txt").exists()
@@ -59,7 +59,7 @@ def test_migrations_and_tasks(tmp_path: Path) -> None:
         git("config", "user.email", "test@copier")
         git("commit", "-m1")
     # Update it to v2
-    run_update(dst_path=dst, defaults=True, overwrite=True)
+    run_update(dst_path=dst, defaults=True, overwrite=True, unsafe=True)
     # Check update was OK
     assert (dst / "created-with-tasks.txt").read_text() == "task 1\ntask 2\n" * 2
     assert not (dst / "delete-in-tasks.txt").exists()
@@ -143,7 +143,7 @@ def test_pre_migration_modifies_answers(
         git("tag", "v2")
     # User updates subproject to v2 template
     with local.cwd(dst):
-        run_update(defaults=True, overwrite=True)
+        run_update(defaults=True, overwrite=True, unsafe=True)
         answers = json.loads(Path(".copier-answers.yml").read_text())
         assert answers["_commit"] == "v2"
         assert "best_song" not in answers
@@ -219,7 +219,9 @@ def test_prereleases(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert not (dst / "v2.a1").exists()
     assert not (dst / "v2.a2").exists()
     # Update it with prereleases
-    run_update(dst_path=dst, defaults=True, overwrite=True, use_prereleases=True)
+    run_update(
+        dst_path=dst, defaults=True, overwrite=True, use_prereleases=True, unsafe=True
+    )
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["_commit"] == "v2.0.0.alpha1"
     assert (dst / "version.txt").read_text() == "v2.0.0.alpha1"
@@ -284,7 +286,7 @@ def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
         git("commit", "-mv2")
         git("tag", "v2")
 
-    run_update(dst_path=dst, overwrite=True, pretend=True)
+    run_update(dst_path=dst, overwrite=True, pretend=True, unsafe=True)
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["_commit"] == "v1"
     assert not (dst / "v2-before.txt").exists()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -35,12 +35,14 @@ def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
 
 
 def test_render_tasks(template_path: str, tmp_path: Path) -> None:
-    copier.run_copy(template_path, tmp_path, data={"other_file": "custom"})
+    copier.run_copy(template_path, tmp_path, data={"other_file": "custom"}, unsafe=True)
     assert (tmp_path / "custom").is_file()
 
 
 def test_copy_tasks(template_path: str, tmp_path: Path) -> None:
-    copier.run_copy(template_path, tmp_path, quiet=True, defaults=True, overwrite=True)
+    copier.run_copy(
+        template_path, tmp_path, quiet=True, defaults=True, overwrite=True, unsafe=True
+    )
     assert (tmp_path / "hello").exists()
     assert (tmp_path / "hello").is_dir()
     assert (tmp_path / "hello" / "world").exists()
@@ -60,5 +62,5 @@ def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
             )
         }
     )
-    copier.run_copy(str(src), dst, pretend=True)
+    copier.run_copy(str(src), dst, pretend=True, unsafe=True)
     assert not (dst / "created-by-task.txt").exists()

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -8,7 +8,7 @@ from plumbum import local
 from plumbum.cmd import git
 
 from copier.cli import CopierApp
-from copier.errors import UserMessageError
+from copier.errors import UnsafeTemplateError
 from copier.main import run_copy, run_update
 from copier.types import AnyByStrDict
 
@@ -33,7 +33,7 @@ class JinjaExtension(Extension):
         (
             {"_tasks": ["touch task.txt"]},
             pytest.raises(
-                UserMessageError, match="Template uses unsafe feature: tasks"
+                UnsafeTemplateError, match="Template uses unsafe feature: tasks"
             ),
         ),
         (
@@ -59,7 +59,7 @@ class JinjaExtension(Extension):
         (
             {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
             pytest.raises(
-                UserMessageError,
+                UnsafeTemplateError,
                 match="Template uses unsafe feature: jinja_extensions",
             ),
         ),
@@ -69,7 +69,7 @@ class JinjaExtension(Extension):
                 "_jinja_extensions": ["tests.test_unsafe.JinjaExtension"],
             },
             pytest.raises(
-                UserMessageError,
+                UnsafeTemplateError,
                 match="Template uses unsafe features: jinja_extensions, tasks",
             ),
         ),
@@ -105,7 +105,7 @@ def test_copy_cli(
     if unsafe:
         assert retcode == 0
     else:
-        assert retcode == 1
+        assert retcode == 2
         _, err = capsys.readouterr()
         assert "Template uses unsafe feature: tasks" in err
 
@@ -127,21 +127,21 @@ def test_copy_cli(
             {"_tasks": ["touch task-old.txt"]},
             {},
             pytest.raises(
-                UserMessageError, match="Template uses unsafe feature: tasks"
+                UnsafeTemplateError, match="Template uses unsafe feature: tasks"
             ),
         ),
         (
             {},
             {"_tasks": ["touch task-new.txt"]},
             pytest.raises(
-                UserMessageError, match="Template uses unsafe feature: tasks"
+                UnsafeTemplateError, match="Template uses unsafe feature: tasks"
             ),
         ),
         (
             {"_tasks": ["touch task-old.txt"]},
             {"_tasks": ["touch task-new.txt"]},
             pytest.raises(
-                UserMessageError, match="Template uses unsafe feature: tasks"
+                UnsafeTemplateError, match="Template uses unsafe feature: tasks"
             ),
         ),
         (
@@ -186,7 +186,7 @@ def test_copy_cli(
                 ]
             },
             pytest.raises(
-                UserMessageError, match="Template uses unsafe feature: migrations"
+                UnsafeTemplateError, match="Template uses unsafe feature: migrations"
             ),
         ),
         (
@@ -200,7 +200,7 @@ def test_copy_cli(
                 ]
             },
             pytest.raises(
-                UserMessageError, match="Template uses unsafe feature: migrations"
+                UnsafeTemplateError, match="Template uses unsafe feature: migrations"
             ),
         ),
         (
@@ -215,7 +215,7 @@ def test_copy_cli(
                 ]
             },
             pytest.raises(
-                UserMessageError, match="Template uses unsafe feature: migrations"
+                UnsafeTemplateError, match="Template uses unsafe feature: migrations"
             ),
         ),
         (
@@ -227,7 +227,7 @@ def test_copy_cli(
             {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
             {},
             pytest.raises(
-                UserMessageError,
+                UnsafeTemplateError,
                 match="Template uses unsafe feature: jinja_extensions",
             ),
         ),
@@ -235,7 +235,7 @@ def test_copy_cli(
             {},
             {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
             pytest.raises(
-                UserMessageError,
+                UnsafeTemplateError,
                 match="Template uses unsafe feature: jinja_extensions",
             ),
         ),
@@ -243,7 +243,7 @@ def test_copy_cli(
             {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
             {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
             pytest.raises(
-                UserMessageError,
+                UnsafeTemplateError,
                 match="Template uses unsafe feature: jinja_extensions",
             ),
         ),
@@ -261,7 +261,7 @@ def test_copy_cli(
                 "_jinja_extensions": ["tests.test_unsafe.JinjaExtension"],
             },
             pytest.raises(
-                UserMessageError,
+                UnsafeTemplateError,
                 match=(
                     "Template uses unsafe features: "
                     "jinja_extensions, migrations, tasks"
@@ -369,6 +369,6 @@ def test_update_cli(
     if unsafe:
         assert retcode == 0
     else:
-        assert retcode == 1
+        assert retcode == 2
         _, err = capsys.readouterr()
         assert "Template uses unsafe feature: tasks" in err

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -1,0 +1,374 @@
+from contextlib import nullcontext as does_not_raise
+from typing import ContextManager
+
+import pytest
+import yaml
+from jinja2.ext import Extension
+from plumbum import local
+from plumbum.cmd import git
+
+from copier.cli import CopierApp
+from copier.errors import UserMessageError
+from copier.main import run_copy, run_update
+from copier.types import AnyByStrDict
+
+from .helpers import build_file_tree
+
+
+class JinjaExtension(Extension):
+    ...
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        (
+            {},
+            does_not_raise(),
+        ),
+        (
+            {"_tasks": []},
+            does_not_raise(),
+        ),
+        (
+            {"_tasks": ["touch task.txt"]},
+            pytest.raises(
+                UserMessageError, match="Template uses unsafe feature: tasks"
+            ),
+        ),
+        (
+            {"_migrations": []},
+            does_not_raise(),
+        ),
+        (
+            {
+                "_migrations": [
+                    {
+                        "version": "v1",
+                        "before": ["touch v1-before.txt"],
+                        "after": ["touch v1-after.txt"],
+                    }
+                ]
+            },
+            does_not_raise(),
+        ),
+        (
+            {"_jinja_extensions": []},
+            does_not_raise(),
+        ),
+        (
+            {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
+            pytest.raises(
+                UserMessageError,
+                match="Template uses unsafe feature: jinja_extensions",
+            ),
+        ),
+        (
+            {
+                "_tasks": ["touch task.txt"],
+                "_jinja_extensions": ["tests.test_unsafe.JinjaExtension"],
+            },
+            pytest.raises(
+                UserMessageError,
+                match="Template uses unsafe features: jinja_extensions, tasks",
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("unsafe", [False, True])
+def test_copy(
+    tmp_path_factory: pytest.TempPathFactory,
+    unsafe: bool,
+    spec: AnyByStrDict,
+    expected: ContextManager[None],
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    build_file_tree({(src / "copier.yaml"): yaml.safe_dump(spec)})
+    with does_not_raise() if unsafe else expected:
+        run_copy(str(src), dst, unsafe=unsafe)
+
+
+@pytest.mark.parametrize("unsafe", [False, True])
+def test_copy_cli(
+    tmp_path_factory: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+    unsafe: bool,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    build_file_tree(
+        {(src / "copier.yaml"): yaml.safe_dump({"_tasks": ["touch task.txt"]})}
+    )
+    _, retcode = CopierApp.run(
+        ["copier", "copy", *(["--UNSAFE"] if unsafe else []), str(src), str(dst)],
+        exit=False,
+    )
+    if unsafe:
+        assert retcode == 0
+    else:
+        assert retcode == 1
+        _, err = capsys.readouterr()
+        assert "Template uses unsafe feature: tasks" in err
+
+
+@pytest.mark.parametrize(
+    ("spec_old", "spec_new", "expected"),
+    [
+        (
+            {},
+            {},
+            does_not_raise(),
+        ),
+        (
+            {"_tasks": []},
+            {"_tasks": []},
+            does_not_raise(),
+        ),
+        (
+            {"_tasks": ["touch task-old.txt"]},
+            {},
+            pytest.raises(
+                UserMessageError, match="Template uses unsafe feature: tasks"
+            ),
+        ),
+        (
+            {},
+            {"_tasks": ["touch task-new.txt"]},
+            pytest.raises(
+                UserMessageError, match="Template uses unsafe feature: tasks"
+            ),
+        ),
+        (
+            {"_tasks": ["touch task-old.txt"]},
+            {"_tasks": ["touch task-new.txt"]},
+            pytest.raises(
+                UserMessageError, match="Template uses unsafe feature: tasks"
+            ),
+        ),
+        (
+            {"_migrations": []},
+            {"_migrations": []},
+            does_not_raise(),
+        ),
+        (
+            {},
+            {
+                "_migrations": [
+                    {
+                        "version": "v0",
+                        "before": ["touch v0-before.txt"],
+                        "after": ["touch v0-after.txt"],
+                    }
+                ]
+            },
+            does_not_raise(),
+        ),
+        (
+            {},
+            {
+                "_migrations": [
+                    {
+                        "version": "v2",
+                        "before": [],
+                        "after": [],
+                    }
+                ]
+            },
+            does_not_raise(),
+        ),
+        (
+            {},
+            {
+                "_migrations": [
+                    {
+                        "version": "v2",
+                        "before": ["touch v2-before.txt"],
+                    }
+                ]
+            },
+            pytest.raises(
+                UserMessageError, match="Template uses unsafe feature: migrations"
+            ),
+        ),
+        (
+            {},
+            {
+                "_migrations": [
+                    {
+                        "version": "v2",
+                        "after": ["touch v2-after.txt"],
+                    }
+                ]
+            },
+            pytest.raises(
+                UserMessageError, match="Template uses unsafe feature: migrations"
+            ),
+        ),
+        (
+            {},
+            {
+                "_migrations": [
+                    {
+                        "version": "v2",
+                        "before": ["touch v2-before.txt"],
+                        "after": ["touch v2-after.txt"],
+                    }
+                ]
+            },
+            pytest.raises(
+                UserMessageError, match="Template uses unsafe feature: migrations"
+            ),
+        ),
+        (
+            {"_jinja_extensions": []},
+            {"_jinja_extensions": []},
+            does_not_raise(),
+        ),
+        (
+            {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
+            {},
+            pytest.raises(
+                UserMessageError,
+                match="Template uses unsafe feature: jinja_extensions",
+            ),
+        ),
+        (
+            {},
+            {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
+            pytest.raises(
+                UserMessageError,
+                match="Template uses unsafe feature: jinja_extensions",
+            ),
+        ),
+        (
+            {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
+            {"_jinja_extensions": ["tests.test_unsafe.JinjaExtension"]},
+            pytest.raises(
+                UserMessageError,
+                match="Template uses unsafe feature: jinja_extensions",
+            ),
+        ),
+        (
+            {},
+            {
+                "_tasks": ["touch task-new.txt"],
+                "_migrations": [
+                    {
+                        "version": "v2",
+                        "before": ["touch v2-before.txt"],
+                        "after": ["touch v2-after.txt"],
+                    }
+                ],
+                "_jinja_extensions": ["tests.test_unsafe.JinjaExtension"],
+            },
+            pytest.raises(
+                UserMessageError,
+                match=(
+                    "Template uses unsafe features: "
+                    "jinja_extensions, migrations, tasks"
+                ),
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize("unsafe", [False, True])
+def test_update(
+    tmp_path_factory: pytest.TempPathFactory,
+    unsafe: bool,
+    spec_old: AnyByStrDict,
+    spec_new: AnyByStrDict,
+    expected: ContextManager[None],
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers | to_nice_yaml }}",
+                "copier.yaml": yaml.safe_dump(spec_old),
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
+
+    run_copy(str(src), dst, unsafe=True)
+    assert "_commit: v1" in (dst / ".copier-answers.yml").read_text()
+
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "copier.yaml": yaml.safe_dump(spec_new),
+            }
+        )
+        git("add", ".")
+        git("commit", "-m2", "--allow-empty")
+        git("tag", "v2")
+
+    with does_not_raise() if unsafe else expected:
+        run_update(dst, overwrite=True, unsafe=unsafe)
+
+
+@pytest.mark.parametrize("unsafe", [False, True])
+def test_update_cli(
+    tmp_path_factory: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+    unsafe: bool,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers | to_nice_yaml }}",
+                "copier.yaml": "",
+            }
+        )
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
+
+    _, retcode = CopierApp.run(
+        ["copier", "copy", "--UNSAFE", str(src), str(dst)],
+        exit=False,
+    )
+    assert retcode == 0
+    assert "_commit: v1" in (dst / ".copier-answers.yml").read_text()
+    capsys.readouterr()
+
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "copier.yaml": yaml.safe_dump({"_tasks": ["touch task-new.txt"]}),
+            }
+        )
+        git("add", ".")
+        git("commit", "-m2")
+        git("tag", "v2")
+
+    _, retcode = CopierApp.run(
+        [
+            "copier",
+            "update",
+            *(["--UNSAFE"] if unsafe else []),
+            str(dst),
+        ],
+        exit=False,
+    )
+    if unsafe:
+        assert retcode == 0
+    else:
+        assert retcode == 1
+        _, err = capsys.readouterr()
+        assert "Template uses unsafe feature: tasks" in err

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -202,7 +202,7 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
         )
         commit("-m", "I prefer grog")
         # Update target to latest tag and check it's updated in answers file
-        CopierApp.run(["copier", "update", "--defaults"], exit=False)
+        CopierApp.run(["copier", "update", "--defaults", "--UNSAFE"], exit=False)
         assert answers.read_text() == dedent(
             f"""\
             # Changes here will be overwritten by Copier
@@ -368,7 +368,9 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
         git("commit", "-m", "feat: commit 1")
         git("tag", "v1")
     # Copy source template
-    run_copy(src_path=str(src), dst_path=dst1, defaults=True, overwrite=True)
+    run_copy(
+        src_path=str(src), dst_path=dst1, defaults=True, overwrite=True, unsafe=True
+    )
     with local.cwd(dst1):
         life = Path("life.yml")
         git("add", ".")
@@ -406,7 +408,12 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
         git("tag", "v2")
     # Update subproject to v2
     run_update(
-        dst_path=dst1, defaults=True, overwrite=True, conflict="rej", context_lines=1
+        dst_path=dst1,
+        defaults=True,
+        overwrite=True,
+        conflict="rej",
+        context_lines=1,
+        unsafe=True,
     )
     with local.cwd(dst1):
         git("commit", "-am", "feat: copied v2")
@@ -448,6 +455,7 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
             overwrite=True,
             conflict="rej",
             context_lines=1,
+            unsafe=True,
         )
         git("commit", "-am", "chore: re-updated to change values after evolving")
         # Subproject evolution was respected up to sane possibilities.

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -106,7 +106,9 @@ def test_shallow_clone(tmp_path: Path, recwarn: pytest.WarningsRecorder) -> None
 @pytest.mark.impure
 def test_removes_temporary_clone(tmp_path: Path) -> None:
     src_path = "https://github.com/copier-org/autopretty.git"
-    with Worker(src_path=src_path, dst_path=tmp_path, defaults=True) as worker:
+    with Worker(
+        src_path=src_path, dst_path=tmp_path, defaults=True, unsafe=True
+    ) as worker:
         worker.run_copy()
         temp_clone = worker.template.local_abspath
     assert not temp_clone.exists()
@@ -116,7 +118,9 @@ def test_removes_temporary_clone(tmp_path: Path) -> None:
 def test_dont_remove_local_clone(tmp_path: Path) -> None:
     src_path = str(tmp_path / "autopretty")
     git("clone", "https://github.com/copier-org/autopretty.git", src_path)
-    with Worker(src_path=src_path, dst_path=tmp_path, defaults=True) as worker:
+    with Worker(
+        src_path=src_path, dst_path=tmp_path, defaults=True, unsafe=True
+    ) as worker:
         worker.run_copy()
     assert Path(src_path).exists()
 
@@ -138,7 +142,9 @@ def test_update_using_local_source_path_with_tilde(tmp_path: Path) -> None:
         user_src_path = f"~/{'/'.join(['..'] * len(Path.home().parts))}{src_path}"
 
     # generate project and assert correct path in answers
-    worker = run_copy(src_path=user_src_path, dst_path=tmp_path, defaults=True)
+    worker = run_copy(
+        src_path=user_src_path, dst_path=tmp_path, defaults=True, unsafe=True
+    )
     assert worker.answers.combined["_src_path"] == user_src_path
 
     # assert project update works and correct path again
@@ -151,6 +157,7 @@ def test_update_using_local_source_path_with_tilde(tmp_path: Path) -> None:
         defaults=True,
         overwrite=True,
         answers_file=".copier-answers.autopretty.yml",
+        unsafe=True,
     )
     assert worker.answers.combined["_src_path"] == user_src_path
 


### PR DESCRIPTION
I've disabled the use of unsafe features (Jinja extensions, migrations, and tasks) by default and added a new CLI switch `--UNSAFE` which enables them. Templates that don't use unsafe features are unaffected by this change. But Copier will raise an error for templates that do use unsafe features unless the `--UNSAFE` flag is passed.

I've not added an interactive prompt that asks for consent for using unsafe features because I think it's not clear how to distinguish between interactive prompting and raising an error when `--UNSAFE` is not passed. For this, I think Copier would need a switch that clearly states whether interactive or non-interactive mode is desired. Currently, `--defaults` implies this for questions.

We could add an interactive prompt in a follow-up PR ones the path forward is clear. I'd also add a dedicated page to the docs regarding Copier's security architecture and threat model in a separate PR.

Resolves partially #1137.