### PR TITLE
feat: add `--trust` as a less scary alternative to `--UNSAFE`

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -144,7 +144,7 @@ class _Subcommand(cli.Application):
         help="Use prereleases to compare template VCS tags.",
     )
     unsafe = cli.Flag(
-        ["--UNSAFE"],
+        ["--UNSAFE", "--trust"],
         help=(
             "Allow templates with unsafe features (Jinja extensions, migrations, tasks)"
         ),

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1310,7 +1310,7 @@ templates suffix is _not_ empty, Copier will abort and print an error message.
 ### `unsafe`
 
 -   Format: `bool`
--   CLI flags: `--UNSAFE`
+-   CLI flags: `--UNSAFE`, `--trust`
 -   Default value: `False`
 
 Copier templates can use dangerous features that allow arbitrary code execution:
@@ -1323,7 +1323,7 @@ Therefore, these features are disabled by default and Copier will raise an error
 exit from the CLI with code `2`) when they are found in a template. In this case, please
 verify that no malicious code gets executed by any of the used features. When you're
 sufficiently confident or willing to take the risk, set `unsafe=True` or pass the CLI
-switch `--UNSAFE`.
+switch `--UNSAFE` or `--trust`.
 
 !!! danger
 

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -1,5 +1,5 @@
 from contextlib import nullcontext as does_not_raise
-from typing import ContextManager
+from typing import ContextManager, Union
 
 import pytest
 import yaml

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -318,7 +318,7 @@ def test_update(
 def test_update_cli(
     tmp_path_factory: pytest.TempPathFactory,
     capsys: pytest.CaptureFixture[str],
-    unsafe: bool,
+    unsafe: Union[bool, str],
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
     unsafe_args = [unsafe] if unsafe else []

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -314,13 +314,14 @@ def test_update(
         run_update(dst, overwrite=True, unsafe=unsafe)
 
 
-@pytest.mark.parametrize("unsafe", [False, True])
+@pytest.mark.parametrize("unsafe", [False, "--trust", "--UNSAFE"])
 def test_update_cli(
     tmp_path_factory: pytest.TempPathFactory,
     capsys: pytest.CaptureFixture[str],
     unsafe: bool,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    unsafe_args = [unsafe] if unsafe else []
 
     with local.cwd(src):
         build_file_tree(
@@ -335,7 +336,7 @@ def test_update_cli(
         git("tag", "v1")
 
     _, retcode = CopierApp.run(
-        ["copier", "copy", "--UNSAFE", str(src), str(dst)],
+        ["copier", "copy", str(src), str(dst)] + unsafe_args,
         exit=False,
     )
     assert retcode == 0
@@ -361,9 +362,9 @@ def test_update_cli(
         [
             "copier",
             "update",
-            *(["--UNSAFE"] if unsafe else []),
             str(dst),
-        ],
+        ]
+        + unsafe_args,
         exit=False,
     )
     if unsafe:


### PR DESCRIPTION
See rationale in https://github.com/copier-org/copier/issues/1137#issuecomment-1579304713.