### PR TITLE
feat: add OS identifier to render context

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -34,7 +34,7 @@ from .errors import (
 )
 from .subproject import Subproject
 from .template import Task, Template
-from .tools import Style, TemporaryDirectory, printf, readlink
+from .tools import OS, Style, TemporaryDirectory, printf, readlink
 from .types import (
     MISSING,
     AnyByStrDict,
@@ -298,6 +298,7 @@ class Worker:
                 "src_path": self.template.local_abspath,
                 "vcs_ref_hash": self.template.commit_hash,
                 "sep": os.sep,
+                "os": OS,
             }
         )
 

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+import platform
 import shutil
 import stat
 import sys
@@ -10,13 +11,13 @@ import warnings
 from contextlib import suppress
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Optional, TextIO, Tuple, Union
+from typing import Any, Callable, Optional, TextIO, Tuple, Union, cast
 
 import colorama
 from packaging.version import Version
 from pydantic import StrictBool
 
-from .types import IntSeq
+from .types import IntSeq, Literal
 
 # TODO Remove condition when dropping python 3.8 support
 if sys.version_info < (3, 8):
@@ -39,6 +40,15 @@ class Style:
 
 INDENT = " " * 2
 HLINE = "-" * 42
+
+OS: Optional[Literal["linux", "macos", "windows"]] = cast(
+    Any,
+    {
+        "Linux": "linux",
+        "Darwin": "macos",
+        "Windows": "windows",
+    }.get(platform.system()),
+)
 
 
 def copier_version() -> Version:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1265,6 +1265,13 @@ They run ordered, and with the `$STAGE=task` variable in their environment.
         - [invoke, end-process, "--full-conf={{ _copier_conf|to_json }}"]
         # Your script can be run by the same Python environment used to run Copier
         - ["{{ _copier_python }}", task.py]
+        # OS-specific task (supported values are "linux", "macos", "windows" and `None`)
+        - >-
+          {% if _copier_conf.os in ['linux', 'macos'] %}
+          rm {{ name_of_the_project }}/README.md
+          {% elif _copier_conf.os == 'windows' %}
+          Remove-Item {{ name_of_the_project }}/README.md
+          {% endif %}
     ```
 
     Note: the example assumes you use [Invoke](https://www.pyinvoke.org/) as


### PR DESCRIPTION
I've added a new property `os` to the `_copier_conf` variable that is provided to the render context which holds operating system identifiers for Linux (`linux`), macOS (`macos`) and Windows (`windows`). Any other operating system type is represented by `None`.

Knowing the operating system is useful, e.g., for rendering OS-specific tasks.

That said, knowing the operating system might not be enough, e.g. it might be necessary to even differentiate between Windows CMD and Windows PowerShell. We might consider providing also shell information, e.g. using [`shellingham`](https://github.com/sarugaku/shellingham). But I'd leave this to a potential follow-up PR.

WDYT, @copier-org/maintainers?