### PR TITLE
docs: update CLI usage examples to conform with v8

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ To generate a project from the template:
 -   On the command-line:
 
     ```shell
-    copier path/to/project/template path/to/destination
+    copier copy path/to/project/template path/to/destination
     ```
 
 -   Or in Python code, programmatically:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -757,7 +757,7 @@ questions with default answers.
     which is overridden, and don't ask user anything else:
 
     ```shell
-    copier -fd 'user_name=Manuel Calavera' copy template destination
+    copier copy -fd 'user_name=Manuel Calavera' template destination
     ```
 
 ### `envops`
@@ -844,7 +844,7 @@ The CLI option can be passed several times to add several patterns.
     !!! example "Example CLI usage to copy only a single file from the template"
 
         ```shell
-        copier --exclude '*' --exclude '!file-i-want' copy ./template ./destination
+        copier copy --exclude '*' --exclude '!file-i-want' ./template ./destination
         ```
 
 ### `force`
@@ -1477,16 +1477,16 @@ mkdir my-project
 cd my-project
 git init
 # Apply framework template
-copier -a .copier-answers.main.yml copy https://github.com/example-framework/framework-template.git .
+copier copy -a .copier-answers.main.yml https://github.com/example-framework/framework-template.git .
 git add .
 git commit -m 'Start project based on framework template'
 # Apply pre-commit template
-copier -a .copier-answers.pre-commit.yml copy https://gitlab.com/my-stuff/pre-commit-template.git .
+copier copy -a .copier-answers.pre-commit.yml https://gitlab.com/my-stuff/pre-commit-template.git .
 git add .
 pre-commit run -a  # Just in case 😉
 git commit -am 'Apply pre-commit template'
 # Apply internal CI template
-copier -a .copier-answers.ci.yml copy git@gitlab.example.com:my-company/ci-template.git .
+copier copy -a .copier-answers.ci.yml git@gitlab.example.com:my-company/ci-template.git .
 git add .
 git commit -m 'Apply internal CI template'
 ```
@@ -1497,7 +1497,7 @@ After a while, when templates get new releases, updates are handled separately f
 template:
 
 ```shell
-copier -a .copier-answers.main.yml update
-copier -a .copier-answers.pre-commit.yml update
-copier -a .copier-answers.ci.yml update
+copier update -a .copier-answers.main.yml
+copier update -a .copier-answers.pre-commit.yml
+copier update -a .copier-answers.ci.yml
 ```

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -175,7 +175,7 @@ Well, Copier indeed included that into the `HEAD` ref. However, it still selecte
 However, if you do this:
 
 ```shell
-$ copier -r HEAD copy ./src ./dst
+$ copier copy -r HEAD ./src ./dst
 ```
 
 ... then you'll notice `new-file.txt` does exist. You passed a specific ref to copy, so

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -9,7 +9,7 @@ As seen in the quick usage section, you can generate a project from a template u
 `copier` command-line tool:
 
 ```shell
-copier path/to/project/template path/to/destination
+copier copy path/to/project/template path/to/destination
 ```
 
 Or within Python code:
@@ -54,14 +54,14 @@ other reference to use.
 For example to use the latest master branch from a public repository:
 
 ```shell
-copier --vcs-ref master https://github.com/foo/copier-template.git ./path/to/destination
+copier copy --vcs-ref master https://github.com/foo/copier-template.git ./path/to/destination
 ```
 
 Or to work from the current checked out revision of a local template (including dirty
 changes):
 
 ```shell
-copier --vcs-ref HEAD path/to/project/template path/to/destination
+copier copy --vcs-ref HEAD path/to/project/template path/to/destination
 ```
 
 ## Regenerating a project

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -87,14 +87,14 @@ repos:
 If you want to just reuse all previous answers:
 
 ```shell
-copier --force update
+copier update --force
 ```
 
 If you want to change just one question, and leave all others untouched, and don't want
 to go through the whole questionary again:
 
 ```shell
-copier --force --data updated_question="my new answer" update
+copier update --force --data updated_question="my new answer"
 ```
 
 ## How the update works


### PR DESCRIPTION
I've updated the CLI usage examples in the docs to conform with the breaking changes in v8.0.0 introduced by #1143 regarding required subcommands and subcommand flags.

Resolves https://github.com/copier-org/copier/discussions/1174#discussioncomment-6182689.