### PR TITLE
feat: add support for pre-copy and post-copy messages

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -243,6 +243,10 @@ class Worker:
         if features:
             raise UnsafeTemplateError(sorted(features))
 
+    def _print_message(self, message: str) -> None:
+        if message and not self.quiet:
+            print(self._render_string(message), file=sys.stderr)
+
     def _answers_to_remember(self) -> Mapping:
         """Get only answers that will be remembered in the copier answers file."""
         # All internal values must appear first
@@ -727,6 +731,7 @@ class Worker:
         See [generating a project][generating-a-project].
         """
         self._check_unsafe("copy")
+        self._print_message(self.template.message_before_copy)
         self._ask()
         was_existing = self.subproject.local_abspath.exists()
         src_abspath = self.template_copy_root
@@ -746,6 +751,7 @@ class Worker:
             if not was_existing and self.cleanup_on_error:
                 rmtree(self.subproject.local_abspath)
             raise
+        self._print_message(self.template.message_after_copy)
         if not self.quiet:
             # TODO Unify printing tools
             print("")  # padding space

--- a/copier/template.py
+++ b/copier/template.py
@@ -322,6 +322,16 @@ class Template:
         return tuple(self.config_data.get("jinja_extensions", ()))
 
     @cached_property
+    def message_after_copy(self) -> str:
+        """Get message to print after copy action specified in the template."""
+        return self.config_data.get("message_after_copy", "")
+
+    @cached_property
+    def message_before_copy(self) -> str:
+        """Get message to print before copy action specified in the template."""
+        return self.config_data.get("message_before_copy", "")
+
+    @cached_property
     def metadata(self) -> AnyByStrDict:
         """Get template metadata.
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -996,6 +996,64 @@ on them, so they are always installed when Copier is installed.
     [other Jinja2 topics](https://github.com/search?q=jinja&type=topics), or
     [on PyPI using the jinja + extension keywords](https://pypi.org/search/?q=jinja+extension).
 
+### `message_after_copy`
+
+-   Format: `str`
+-   CLI flags: N/A
+-   Default value: `""`
+
+A message to be printed after [generating](../generating) or
+[regenerating](../generating#regenerating-a-project) a project _successfully_.
+
+If the message contains Jinja code, it will be rendered with the same context as the
+rest of the template. A [Jinja include](#importing-jinja-templates-and-macros)
+expression may be used to import a message from a file.
+
+The message is suppressed when Copier is run in [quiet mode](#quiet).
+
+!!! example
+
+    ```yaml title="copier.yml"
+    project_name:
+        type: str
+        help: An awesome project needs an awesome name. Tell me yours.
+
+    _message_after_copy: |
+        Your project "{{ project_name }}" has been created successfully!
+
+        Next steps:
+
+        1. Change directory to the project root:
+
+           $ cd {{ _copier_conf.dst_path }}
+
+        2. Read "CONTRIBUING.md" and start coding.
+    ```
+
+### `message_before_copy`
+
+-   Format: `str`
+-   CLI flags: N/A
+-   Default value: `""`
+
+Like [`message_after_copy`](#message_after_copy) but printed _before_
+[generating](../generating) or [regenerating](../generating#regenerating-a-project) a
+project.
+
+!!! example
+
+    ```yaml title="copier.yml"
+    project_name:
+        type: str
+        help: An awesome project needs an awesome name. Tell me yours.
+
+    _message_before_copy: |
+        Thanks for generating a project using our template.
+
+        You'll be asked a series of questions whose answers will be used to
+        generate a tailored project for you.
+    ```
+
 ### `migrations`
 
 -   Format: `List[dict]`

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,12 +1,13 @@
 import re
 from pathlib import Path
 
+import pexpect
 import pytest
 
 from copier.errors import InvalidTypeError
-from copier.main import run_copy
+from copier.main import run_copy, run_recopy
 
-from .helpers import build_file_tree, render
+from .helpers import COPIER_PATH, Spawn, build_file_tree, expect_prompt, render
 
 
 def test_output(capsys: pytest.CaptureFixture[str], tmp_path: Path) -> None:
@@ -89,3 +90,193 @@ def test_answer_with_invalid_type(tmp_path_factory: pytest.TempPathFactory) -> N
         match='Invalid answer "None" of type "<class \'NoneType\'>" to question "bad" of type "int"',
     ):
         run_copy(str(src), dst, defaults=True, overwrite=True)
+
+
+@pytest.mark.parametrize("interactive", [False, True])
+def test_message_copy_with_inline_text(
+    tmp_path_factory: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+    spawn: Spawn,
+    interactive: bool,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    build_file_tree(
+        {
+            (src / "copier.yaml"): (
+                """\
+                project_name:
+                    type: str
+
+                _message_before_copy: Thank you for using our template on {{ _copier_conf.os }}
+                _message_after_copy: Project {{ project_name }} successfully created
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+        }
+    )
+
+    pattern = (
+        r"^"
+        r"Thank you for using our template on (linux|macos|windows)"
+        r".+"
+        r"Project {project_name} successfully created"
+        r"\s*"
+        r"$"
+    )
+
+    # copy
+    if interactive:
+        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("myproj")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_copy(str(src), dst, data={"project_name": "myproj"})
+
+    _, err = capsys.readouterr()
+    assert re.search(pattern.format(project_name="myproj"), err, flags=re.S)
+
+    # recopy
+    if interactive:
+        tui = spawn(COPIER_PATH + ("recopy", str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("_new")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_recopy(dst, data={"project_name": "myproj_new"})
+
+    _, err = capsys.readouterr()
+    assert re.search(pattern.format(project_name="myproj_new"), err, flags=re.S)
+
+
+@pytest.mark.parametrize("interactive", [False, True])
+def test_message_copy_with_included_text(
+    tmp_path_factory: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+    spawn: Spawn,
+    interactive: bool,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    build_file_tree(
+        {
+            (src / "copier.yaml"): (
+                """\
+                project_name:
+                    type: str
+
+                _exclude: ["*.md"]
+                _message_before_copy: "{% include 'message_before_copy.md.jinja' %}"
+                _message_after_copy: "{% include 'message_after_copy.md.jinja' %}"
+                """
+            ),
+            (src / "message_before_copy.md.jinja"): (
+                """\
+                Thank you for using our template on {{ _copier_conf.os }}
+                """
+            ),
+            (src / "message_after_copy.md.jinja"): (
+                """\
+                Project {{ project_name }} successfully created
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+        }
+    )
+
+    pattern = (
+        r"^"
+        r"Thank you for using our template on (linux|macos|windows)"
+        r".+"
+        r"Project {project_name} successfully created"
+        r"\s*"
+        r"$"
+    )
+
+    # copy
+    if interactive:
+        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("myproj")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_copy(str(src), dst, data={"project_name": "myproj"})
+
+    _, err = capsys.readouterr()
+    assert re.search(pattern.format(project_name="myproj"), err, flags=re.S)
+
+    # recopy
+    if interactive:
+        tui = spawn(COPIER_PATH + ("recopy", str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("_new")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_recopy(dst, data={"project_name": "myproj_new"})
+
+    _, err = capsys.readouterr()
+    assert re.search(pattern.format(project_name="myproj_new"), err, flags=re.S)
+
+
+@pytest.mark.parametrize("interactive", [False, True])
+def test_message_copy_quiet(
+    tmp_path_factory: pytest.TempPathFactory,
+    capsys: pytest.CaptureFixture[str],
+    spawn: Spawn,
+    interactive: bool,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    build_file_tree(
+        {
+            (src / "copier.yaml"): (
+                """\
+                project_name:
+                    type: str
+
+                _message_before_copy: Thank you for using our template on {{ _copier_conf.os }}
+                _message_after_copy: Project {{ project_name }} successfully created
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+        }
+    )
+
+    # copy
+    if interactive:
+        tui = spawn(COPIER_PATH + ("copy", "--quiet", str(src), str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("myproj")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_copy(str(src), dst, data={"project_name": "myproj"}, quiet=True)
+
+    _, err = capsys.readouterr()
+    assert "Thank you for using our template" not in err
+    assert "Project myproj successfully created" not in err
+
+    # recopy
+    if interactive:
+        tui = spawn(COPIER_PATH + ("recopy", "--quiet", str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("_new")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_recopy(dst, data={"project_name": "myproj_new"}, quiet=True)
+
+    _, err = capsys.readouterr()
+    assert "Thank you for using our template" not in err
+    assert "Project myproj_new successfully created" not in err


### PR DESCRIPTION
I've added support for pre-copy and post-copy messages that can be written in plain text or markdown. Messages can be written inline or included via Jinja includes, and messages are rendered.

I'll work on pre-update and post-update messages in a separate PR once we've clarified whether the implementation in this PR is good.

Closes #723.