### PR TITLE
refactor: assign immutable default value without dataclass `field()` function

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -185,7 +185,7 @@ class Worker:
     """
 
     src_path: Optional[str] = None
-    dst_path: Path = field(default=Path("."))
+    dst_path: Path = Path(".")
     answers_file: Optional[RelativePath] = None
     vcs_ref: OptStr = None
     data: AnyByStrDict = field(default_factory=dict)


### PR DESCRIPTION
Just a minor refactoring which simplifies setting an immutable default value for a dataclass attribute without calling the `field()` function.