### PR TITLE
refactor(typing): use `Literal` type hint for `conflict` attribute

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -198,7 +198,7 @@ class Worker:
     overwrite: bool = False
     pretend: bool = False
     quiet: bool = False
-    conflict: str = "inline"
+    conflict: Literal["inline", "rej"] = "inline"
     context_lines: PositiveInt = 3
     unsafe: bool = False
 


### PR DESCRIPTION
I've made the type hint for the `conflict` attribute more precise by using `Literal["rej", "inline"]` instead of `str`.

@yajo Is `refactor(typing)` the correct change type in your opinion? It seemed the most appropriate to me, but I couldn't find a guideline for committing only typing changes.