### PR TITLE
docs: update default conflict mode

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -167,7 +167,7 @@ class Worker:
             See [quiet][].
 
         conflict:
-            One of "rej" (default), "inline" (still experimental).
+            One of "inline" (default), "rej".
 
         context_lines:
             Lines of context to consider when solving conflicts in updates.
@@ -881,7 +881,6 @@ class Worker:
                 ):
                     apply_cmd = apply_cmd["--exclude", skip_pattern]
                 (apply_cmd << diff)(retcode=None)
-                # TODO Test more, remove from experimental, make default
                 if self.conflict == "inline":
                     status = git("status", "--porcelain").strip().splitlines()
                     for line in status:


### PR DESCRIPTION
I've updated the docstring in the `Worker` class to state the new default conflict mode `inline` since v8.0.0. I've also removed a line comment about `inline` being still experimental.

Follow-up of #1143.