### PR TITLE
fix: restore behavior for skipped question with default value

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -415,7 +415,6 @@ class Worker:
         It asks the user the 1st time it is called, if running interactively.
         """
         result = AnswersMap(
-            default=self.template.default_answers,
             user_defaults=self.user_defaults,
             init=self.data,
             last=self.subproject.last_answers,
@@ -429,10 +428,10 @@ class Worker:
                 var_name=var_name,
                 **details,
             )
-            # Skip a question when the skip condition is met and remove any data
-            # from the answers map, so no answer for this question is recorded
-            # in the answers file.
-            if not question.get_when():
+            # Skip a question when the skip condition is met and it has no
+            # default value, and remove any data from the answers map, so no
+            # answer for this question is recorded in the answers file.
+            if not question.get_when() and question.default is MISSING:
                 result.remove(var_name)
                 continue
             if var_name in result.init:
@@ -454,7 +453,8 @@ class Worker:
                         raise ValueError(f'Question "{var_name}" is required')
                 else:
                     new_answer = unsafe_prompt(
-                        [question.get_questionary_structure()], answers=result.combined
+                        [question.get_questionary_structure()],
+                        answers={question.var_name: question.get_default()},
                     )[question.var_name]
             except KeyboardInterrupt as err:
                 raise CopierAnswersInterrupt(result, question, self.template) from err

--- a/copier/template.py
+++ b/copier/template.py
@@ -282,11 +282,6 @@ class Template:
         return result
 
     @cached_property
-    def default_answers(self) -> AnyByStrDict:
-        """Get default answers for template's questions."""
-        return {key: value.get("default") for key, value in self.questions_data.items()}
-
-    @cached_property
     def envops(self) -> Mapping:
         """Get the Jinja configuration specified in the template, or default values.
 

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -103,11 +103,6 @@ class AnswersMap:
         last:
             Data from [the answers file][the-copier-answersyml-file].
 
-        default:
-            Default data from the template.
-
-            See [copier.template.Template.default_answers][].
-
         user_defaults:
             Default data from the user e.g. previously completed and restored data.
 
@@ -123,7 +118,6 @@ class AnswersMap:
     metadata: AnyByStrDict = field(default_factory=dict)
     last: AnyByStrDict = field(default_factory=dict)
     user_defaults: AnyByStrDict = field(default_factory=dict)
-    default: AnyByStrDict = field(default_factory=dict)
 
     @property
     def combined(self) -> Mapping[str, Any]:
@@ -135,7 +129,6 @@ class AnswersMap:
                 self.metadata,
                 self.last,
                 self.user_defaults,
-                self.default,
                 DEFAULT_DATA,
             )
         )

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -182,10 +182,12 @@ Supported keys:
 
     This is most useful when [templated](#prompt-templating).
 
-    If a question is skipped, its answer will be:
+    If a question _with_ a default value is skipped, its answer will be:
 
     -   The default value, if you're generating the project for the 1st time.
     -   The last answer recorded, if you're updating the project.
+
+    If a question _without_ a default value is skipped, no answer will be recorded.
 
     !!! example
 

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -420,7 +420,7 @@ def test_tui_inherited_default(
         "_src_path": str(src),
         "has_2_owners": has_2_owners,
         "owner1": "example",
-        **({"owner2": owner2} if has_2_owners else {}),
+        "owner2": owner2,
     }
     assert json.loads((dst / "answers.json").read_text()) == result
     with local.cwd(dst):
@@ -430,6 +430,40 @@ def test_tui_inherited_default(
     # After a forced update, answers stay the same
     run_update(dst, defaults=True, overwrite=True)
     assert json.loads((dst / "answers.json").read_text()) == result
+
+
+def test_tui_typed_default(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+) -> None:
+    """Make sure a template defaults are typed as expected."""
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yaml"): (
+                """\
+                test1:
+                    type: bool
+                    default: false
+                    when: false
+                test2:
+                    type: bool
+                    default: "{{ 'a' == 'b' }}"
+                    when: false
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
+            (src / "answers.json.jinja"): "{{ _copier_answers|to_nice_json }}",
+        }
+    )
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui.expect_exact(pexpect.EOF)
+    assert json.loads((dst / "answers.json").read_text()) == {
+        "_src_path": str(src),
+        "test1": False,
+        "test2": False,
+    }
 
 
 def test_selection_type_cast(
@@ -538,7 +572,7 @@ def test_multi_template_answers(tmp_path_factory: pytest.TempPathFactory) -> Non
         assert "q1" not in answers2
 
 
-def test_omit_answer_for_skipped_question(
+def test_answer_for_skipped_question(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -563,4 +597,4 @@ def test_omit_answer_for_skipped_question(
     )
     run_copy(str(src), dst, defaults=True, data={"disabled": "hello"})
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
-    assert answers == {"_src_path": str(src)}
+    assert answers == {"_src_path": str(src), "disabled_with_default": "hello"}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -196,7 +196,7 @@ def test_when(
     assert answers == {
         "_src_path": str(src),
         "question_1": question_1,
-        **({"question_2": "something"} if asks else {}),
+        "question_2": "something",
     }
 
 


### PR DESCRIPTION
I've partially reverted #1126 and restored the behavior for a skipped question with a default value such that its answer is recorded in the answers file. This behavior is well-documented

> If a question is skipped, its answer will be:
>
> - The default value, if you're generating the project for the 1st time.
> - The last answer recorded, if you're updating the project.

and was incompatibly changed in #1126.

Resolves #1204. See https://github.com/copier-org/copier/discussions/1204#discussioncomment-6211104 for a detailed explanation of the history that led to this regression.