### PR TITLE
refactor: clean up secret questions management

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -191,7 +191,7 @@ def test_valid_multi_section(tmp_path: Path) -> None:
 
 def test_config_data_empty() -> None:
     template = Template("tests/demo_config_empty")
-    assert template.config_data == {"secret_questions": set()}
+    assert template.config_data == {}
     assert template.questions_data == {}
 
 


### PR DESCRIPTION
I've cleaned up the internal bookkeeping logic for secret questions. The new structure will simplify raising an error when a secret question has no default value, which we discussed in https://github.com/copier-org/copier/issues/1177#issuecomment-1585556997.

There are two ways to declare a question as secret:

1. By setting `secret: true` in the config of a question.
2. By adding the variable name of a question to the `_secret_questions` list. This option is needed when a question that uses the `<name>: <default value>` syntax shall be secret.

Internally, [Copier uses the a secret questions list to omit answers to secret questions from the answers file](https://github.com/copier-org/copier/blob/1b351bc8560d19d70e927cdb2fafb4f7ce41092d/copier/main.py#L258). This list contains the variable names of all secret questions independent of how they are declared as secret, so questions with `secret: true` are added to this list internally.

Before, adding questions with the `secret: true` setting to the `_secret_questions` list took place both in [`template.py:filter_config()`](https://github.com/copier-org/copier/blob/1b351bc8560d19d70e927cdb2fafb4f7ce41092d/copier/template.py#L70-L71) and in [`template.py:Template.secret_questions`](https://github.com/copier-org/copier/blob/1b351bc8560d19d70e927cdb2fafb4f7ce41092d/copier/template.py#L399-L400) which was redundant and also a bit error-prone because there was no clear separation of concerns where this information shall be synced.

I've decided to let `template.py:filter_config()` only handle separating config and questions data as its docstring suggests, and sync the secret information in [`template.py:Template.secret_questions`](https://github.com/copier-org/copier/blob/1b351bc8560d19d70e927cdb2fafb4f7ce41092d/copier/template.py#L399-L400) (as it has been done already, so no change) and [`template.py:Template.questions_data`](https://github.com/sisp/copier/blob/708eac9828242a53bddad8ed0bf23db4ef9205f0/copier/template.py#L386-L388).

In addition, I've fixed some minor oddities:

- A literal dict `{}` was used as a default value for getting the `_secret_questions` list, which should be a `list`.
- The empty config data was `{"secret_questions": set()}` which makes not much sense (or is at least unnecessary).

Those changes are purely internal though.