### PR TITLE
feat: add support for computed values via skipped questions

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -429,11 +429,12 @@ class Worker:
                 var_name=var_name,
                 **details,
             )
-            # Skip a question when the skip condition is met and it has no
-            # default value, and remove any data from the answers map, so no
-            # answer for this question is recorded in the answers file.
+            # Skip a question when the skip condition is met.
             if not question.get_when():
+                # Omit its answer from the answers file.
                 result.hide(var_name)
+                # Skip immediately to the next question when it has no default
+                # value.
                 if question.default is MISSING:
                     continue
             if var_name in result.init:

--- a/copier/template.py
+++ b/copier/template.py
@@ -282,11 +282,6 @@ class Template:
         return result
 
     @cached_property
-    def default_answers(self) -> AnyByStrDict:
-        """Get default answers for template's questions."""
-        return {key: value.get("default") for key, value in self.questions_data.items()}
-
-    @cached_property
     def envops(self) -> Mapping:
         """Get the Jinja configuration specified in the template, or default values.
 

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -103,11 +103,6 @@ class AnswersMap:
         last:
             Data from [the answers file][the-copier-answersyml-file].
 
-        default:
-            Default data from the template.
-
-            See [copier.template.Template.default_answers][].
-
         user_defaults:
             Default data from the user e.g. previously completed and restored data.
 
@@ -115,7 +110,7 @@ class AnswersMap:
     """
 
     # Private
-    removed: Set[str] = field(default_factory=set, init=False)
+    hidden: Set[str] = field(default_factory=set, init=False)
 
     # Public
     user: AnyByStrDict = field(default_factory=dict)
@@ -123,34 +118,28 @@ class AnswersMap:
     metadata: AnyByStrDict = field(default_factory=dict)
     last: AnyByStrDict = field(default_factory=dict)
     user_defaults: AnyByStrDict = field(default_factory=dict)
-    default: AnyByStrDict = field(default_factory=dict)
 
     @property
     def combined(self) -> Mapping[str, Any]:
         """Answers combined from different sources, sorted by priority."""
-        combined = dict(
+        return dict(
             ChainMap(
                 self.user,
                 self.init,
                 self.metadata,
                 self.last,
                 self.user_defaults,
-                self.default,
                 DEFAULT_DATA,
             )
         )
-        for key in self.removed:
-            if key in combined:
-                del combined[key]
-        return combined
 
     def old_commit(self) -> OptStr:
         """Commit when the project was updated from this template the last time."""
         return self.last.get("_commit")
 
-    def remove(self, key: str) -> None:
+    def hide(self, key: str) -> None:
         """Remove an answer by key."""
-        self.removed.add(key)
+        self.hidden.add(key)
 
 
 @dataclass(config=AllowArbitraryTypes)

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -181,8 +181,8 @@ Supported keys:
     If it is a string, it is converted to boolean using a parser similar to YAML, but
     only for boolean values. The string can be [templated][prompt-templating].
 
-    If a question is skipped, its answer is not recorded, but its default value is available
-    in the render context.
+    If a question is skipped, its answer is not recorded, but its default value is
+    available in the render context.
 
     !!! example
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -179,9 +179,9 @@ Supported keys:
     creating a computed value.
 
     If it is a string, it is converted to boolean using a parser similar to YAML, but
-    only for boolean values. The string can be [templated](#prompt-templating).
+    only for boolean values. The string can be [templated][prompt-templating].
 
-    If a question is skipped, no answer is recorded, but its default value is available
+    If a question is skipped, its answer is not recorded, but its default value is available
     in the render context.
 
     !!! example

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -175,17 +175,14 @@ Supported keys:
 
 -   **when**: Condition that, if `false`, skips the question.
 
-    If it is a boolean, it is used directly, but it's a bit absurd in that case.
+    If it is a boolean, it is used directly. Setting it to `false` is useful for
+    creating a computed value.
 
     If it is a string, it is converted to boolean using a parser similar to YAML, but
-    only for boolean values.
+    only for boolean values. The string can be [templated](#prompt-templating).
 
-    This is most useful when [templated](#prompt-templating).
-
-    If a question is skipped, its answer will be:
-
-    -   The default value, if you're generating the project for the 1st time.
-    -   The last answer recorded, if you're updating the project.
+    If a question is skipped, no answer is recorded, but its default value is available
+    in the render context.
 
     !!! example
 

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -397,6 +397,7 @@ def test_tui_inherited_default(
                 "{{ _copier_answers|to_nice_yaml }}"
             ),
             (src / "answers.json.jinja"): "{{ _copier_answers|to_nice_json }}",
+            (src / "context.json.jinja"): '{"owner2": "{{ owner2 }}"}',
         }
     )
     with local.cwd(src):
@@ -423,6 +424,7 @@ def test_tui_inherited_default(
         **({"owner2": owner2} if has_2_owners else {}),
     }
     assert json.loads((dst / "answers.json").read_text()) == result
+    assert json.loads((dst / "context.json").read_text()) == {"owner2": owner2}
     with local.cwd(dst):
         git("init")
         git("add", "--all")
@@ -430,6 +432,45 @@ def test_tui_inherited_default(
     # After a forced update, answers stay the same
     run_update(dst, defaults=True, overwrite=True)
     assert json.loads((dst / "answers.json").read_text()) == result
+
+
+def test_tui_typed_default(
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+) -> None:
+    """Make sure a template defaults are typed as expected."""
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yaml"): (
+                """\
+                test1:
+                    type: bool
+                    default: false
+                    when: false
+                test2:
+                    type: bool
+                    default: "{{ 'a' == 'b' }}"
+                    when: false
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
+            (src / "answers.json.jinja"): "{{ _copier_answers|to_nice_json }}",
+            (src / "context.json.jinja"): (
+                """\
+                {"test1": "{{ test1 }}", "test2": "{{ test2 }}"}
+                """
+            ),
+        }
+    )
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui.expect_exact(pexpect.EOF)
+    assert json.loads((dst / "answers.json").read_text()) == {"_src_path": str(src)}
+    assert json.loads((dst / "context.json").read_text()) == {
+        "test1": "False",
+        "test2": "False",
+    }
 
 
 def test_selection_type_cast(
@@ -559,8 +600,16 @@ def test_omit_answer_for_skipped_question(
             (src / "{{ _copier_conf.answers_file }}.jinja"): (
                 "{{ _copier_answers|to_nice_yaml }}"
             ),
+            (src / "context.yml.jinja"): yaml.safe_dump(
+                {
+                    "disabled": "{{ disabled }}",
+                    "disabled_with_default": "{{ disabled_with_default }}",
+                }
+            ),
         }
     )
     run_copy(str(src), dst, defaults=True, data={"disabled": "hello"})
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers == {"_src_path": str(src)}
+    context = yaml.safe_load((dst / "context.yml").read_text())
+    assert context == {"disabled": "hello", "disabled_with_default": "hello"}

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -183,6 +183,11 @@ def test_when(
             (src / "[[ _copier_conf.answers_file ]].tmpl"): (
                 "[[ _copier_answers|to_nice_yaml ]]"
             ),
+            (src / "context.yml.tmpl"): (
+                """\
+                question_2: [[ question_2 ]]
+                """
+            ),
         }
     )
     tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
@@ -198,6 +203,8 @@ def test_when(
         "question_1": question_1,
         **({"question_2": "something"} if asks else {}),
     }
+    context = yaml.safe_load((dst / "context.yml").read_text())
+    assert context == {"question_2": "something"}
 
 
 def test_placeholder(tmp_path_factory: pytest.TempPathFactory, spawn: Spawn) -> None:


### PR DESCRIPTION
I've added support for a long awaited feature: computed values via skipped questions (`when: false`). :tada: See https://github.com/copier-org/copier/pull/1206#issuecomment-1605892551 for more details.

Supersedes #1206. Resolves #1204 #1205. Resolves (I guess ...) #1203. :stuck_out_tongue_winking_eye: