### PR TITLE
fix: fix answer validation against conditional choices with duplicate values

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -451,12 +451,16 @@ class Question:
         choices = self._formatted_choices
         if not choices:
             return ans
+        choice_error = ""
         for choice in choices:
             if ans == self.cast_answer(choice.value):
-                if choice.disabled:
-                    raise ValueError(f"Invalid choice: {choice.disabled}")
-                return ans
-        raise ValueError("Invalid choice")
+                if not choice.disabled:
+                    return ans
+                if not choice_error:
+                    choice_error = choice.disabled
+        raise ValueError(
+            f"Invalid choice: {choice_error}" if choice_error else "Invalid choice"
+        )
 
 
 def parse_yaml_string(string: str) -> Any:

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -509,6 +509,17 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
             pytest.raises(ValueError),
         ),
         (
+            {
+                "type": "str",
+                "choices": {
+                    "banana": {"value": "yellow", "validator": "invalid"},
+                    "tshirt": {"value": "yellow", "validator": ""},
+                },
+            },
+            "yellow",
+            does_not_raise(),
+        ),
+        (
             {"type": "yaml", "choices": {"one": None, "two": 2, "three": "null"}},
             "one",
             does_not_raise(),


### PR DESCRIPTION
I've fixed a bug related to validating an answer against conditional choices where multiple choices have the same value. Before, an error was raised immediately when the first choice that matched the provided answer was disabled even though another choice with the same value was enabled. Now, all choices are checked and an error is raised only when none of the matching choices are enabled.

Fixes #1233.