### PR TITLE
fix: require default value for secret question

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -219,6 +219,13 @@ class Question:
             v = default_type_name if default_type_name in CAST_STR_TO_NATIVE else "yaml"
         return v
 
+    @field_validator("secret")
+    @classmethod
+    def _check_secret_question_default_value(cls, v: bool, info: FieldValidationInfo):
+        if v and info.data["default"] is MISSING:
+            raise ValueError("Secret question requires a default value")
+        return v
+
     def cast_answer(self, answer: Any) -> Any:
         """Cast answer to expected type."""
         type_name = self.get_type_name()

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -156,7 +156,8 @@ Supported keys:
     long, you can use
     [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html).
 -   **secret**: When `true`, it hides the prompt displaying asterisks (`*****`) and
-    doesn't save the answer in [the answers file](#the-copier-answersyml-file)
+    doesn't save the answer in [the answers file](#the-copier-answersyml-file). When
+    `true`, a default value is required.
 -   **placeholder**: To provide a visual example for what would be a good value. It is
     only shown while the answer is empty, so maybe it doesn't make much sense to provide
     both `default` and `placeholder`.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -525,3 +525,29 @@ def test_user_defaults_updated(
         data=data_updated,
     )
     assert (dst / "user_data.txt").read_text() == expected_updated
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        """\
+        question:
+            type: str
+            secret: true
+        """,
+        """\
+        question:
+            type: str
+
+        _secret_questions:
+            - question
+        """,
+    ],
+)
+def test_secret_question_requires_default_value(
+    tmp_path_factory: pytest.TempPathFactory, config: str
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree({src / "copier.yml": config})
+    with pytest.raises(ValueError, match="Secret question requires a default value"):
+        copier.run_copy(str(src), dst)


### PR DESCRIPTION
I've added a check that raises an error when a secret question has no default value. A secret question without a default value should have never worked although it did prior to Copier v8 because of some improper/incomplete answer validation. See https://github.com/copier-org/copier/issues/1177#issuecomment-1584879569 for some history on this topic.

As suggested in https://github.com/copier-org/copier/issues/1177#issuecomment-1585556997, the simplest yet effective solution is to require a secret question to have a default value.

Resolves #1177.