### PR TITLE
build: drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       # HACK https://github.com/actions/cache/issues/315

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A library and CLI app for rendering project templates.
 
 ## Installation
 
-1. Install Python 3.7 or newer (3.8 or newer if you're on Windows).
+1. Install Python 3.8 or newer.
 1. Install Git 2.27 or newer.
 1. To use as a CLI app: `pipx install copier`
 1. To use as a library: `pip install copier` or `conda install -c conda-forge copier`

--- a/copier/main.py
+++ b/copier/main.py
@@ -7,11 +7,22 @@ import sys
 from contextlib import suppress
 from dataclasses import asdict, field, replace
 from filecmp import dircmp
-from functools import partial
+from functools import cached_property, partial
 from itertools import chain
 from pathlib import Path
 from shutil import rmtree
-from typing import Callable, Iterable, Mapping, Optional, Sequence, Set, Union
+from tempfile import TemporaryDirectory
+from typing import (
+    Callable,
+    Iterable,
+    Literal,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Union,
+    get_args,
+)
 from unicodedata import normalize
 
 from jinja2.loaders import FileSystemLoader
@@ -34,44 +45,17 @@ from .errors import (
 )
 from .subproject import Subproject
 from .template import Task, Template
-from .tools import OS, Style, TemporaryDirectory, printf, readlink
+from .tools import OS, Style, printf, readlink
 from .types import (
     MISSING,
     AnyByStrDict,
     JSONSerializable,
-    Literal,
     OptStr,
     RelativePath,
     StrOrPath,
     StrSeq,
 )
 from .user_data import DEFAULT_DATA, AnswersMap, Question
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
-
-# Backport of `shutil.copytree` for python 3.7 to accept `dirs_exist_ok` argument
-if sys.version_info >= (3, 8):
-    from shutil import copytree
-else:
-    from distutils.dir_util import copy_tree
-
-    def copytree(src: Path, dst: Path, dirs_exist_ok: bool = False):
-        """Backport of `shutil.copytree` with `dirs_exist_ok` argument.
-
-        Can be remove once python 3.7 dropped.
-        """
-        copy_tree(str(src), str(dst))
-
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from typing import get_args
-else:
-    from typing_extensions import get_args
 
 
 @dataclass(config=ConfigDict(extra="forbid"))

--- a/copier/subproject.py
+++ b/copier/subproject.py
@@ -3,7 +3,7 @@
 A *subproject* is a project that gets rendered and/or updated with Copier.
 """
 
-import sys
+from functools import cached_property
 from pathlib import Path
 from typing import Optional
 
@@ -15,12 +15,6 @@ from pydantic.dataclasses import dataclass
 from .template import Template
 from .types import AbsolutePath, AnyByStrDict, VCSTypes
 from .vcs import is_in_git_repo
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
 
 
 @dataclass

--- a/copier/template.py
+++ b/copier/template.py
@@ -1,12 +1,12 @@
 """Tools related to template management."""
 import re
-import sys
 from collections import ChainMap, defaultdict
 from contextlib import suppress
 from dataclasses import field
+from functools import cached_property
 from pathlib import Path
 from shutil import rmtree
-from typing import List, Mapping, Optional, Sequence, Set, Tuple
+from typing import List, Literal, Mapping, Optional, Sequence, Set, Tuple
 from warnings import warn
 
 import dunamai
@@ -29,14 +29,6 @@ from .errors import (
 from .tools import copier_version, handle_remove_readonly
 from .types import AnyByStrDict, Env, OptStr, StrSeq, Union, VCSTypes
 from .vcs import checkout_latest_tag, clone, get_repo
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
-
-from .types import Literal
 
 # Default list of files in the template to exclude from the rendered project
 DEFAULT_EXCLUDE: Tuple[str, ...] = (

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -3,27 +3,19 @@
 import errno
 import os
 import platform
-import shutil
 import stat
 import sys
-import tempfile
-import warnings
 from contextlib import suppress
+from importlib.metadata import version
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Optional, TextIO, Tuple, Union, cast
+from typing import Any, Callable, Literal, Optional, TextIO, Tuple, Union, cast
 
 import colorama
 from packaging.version import Version
 from pydantic import StrictBool
 
-from .types import IntSeq, Literal
-
-# TODO Remove condition when dropping python 3.8 support
-if sys.version_info < (3, 8):
-    from importlib_metadata import version
-else:
-    from importlib.metadata import version
+from .types import IntSeq
 
 colorama.init()
 
@@ -142,7 +134,8 @@ def handle_remove_readonly(
 ) -> None:
     """Handle errors when trying to remove read-only files through `shutil.rmtree`.
 
-    This handler makes sure the given file is writable, then re-execute the given removal function.
+    On Windows, `shutil.rmtree` does not handle read-only files very well. This handler
+    makes sure the given file is writable, then re-execute the given removal function.
 
     Arguments:
         func: An OS-dependant function used to remove a file.
@@ -157,41 +150,12 @@ def handle_remove_readonly(
         raise
 
 
-# See https://github.com/copier-org/copier/issues/345
-class TemporaryDirectory(tempfile.TemporaryDirectory):
-    """A custom version of `tempfile.TemporaryDirectory` that handles read-only files better.
-
-    On Windows, before Python 3.8, `shutil.rmtree` does not handle read-only files very well.
-    This custom class makes use of a [special error handler][copier.tools.handle_remove_readonly]
-    to make sure that a temporary directory containing read-only files (typically created
-    when git-cloning a repository) is properly cleaned-up (i.e. removed) after using it
-    in a context manager.
-    """
-
-    @classmethod
-    def _cleanup(cls, name, warn_message):
-        cls._robust_cleanup(name)
-        warnings.warn(warn_message, ResourceWarning)
-
-    def cleanup(self):
-        """Remove directory safely."""
-        if self._finalizer.detach():
-            self._robust_cleanup(self.name)
-
-    @staticmethod
-    def _robust_cleanup(name):
-        shutil.rmtree(name, ignore_errors=False, onerror=handle_remove_readonly)
-
-
 def readlink(link: Path) -> Path:
     """A custom version of os.readlink/pathlib.Path.readlink.
 
     pathlib.Path.readlink is what we ideally would want to use, but it is only available on python>=3.9.
-    os.readlink doesn't support Path and bytes on Windows for python<3.8
     """
     if sys.version_info >= (3, 9):
         return link.readlink()
-    elif sys.version_info >= (3, 8) or os.name != "nt":
-        return Path(os.readlink(link))
     else:
-        return Path(os.readlink(str(link)))
+        return Path(os.readlink(link))

--- a/copier/types.py
+++ b/copier/types.py
@@ -2,15 +2,19 @@
 
 import sys
 from pathlib import Path
-from typing import Any, Dict, Mapping, NewType, Optional, Sequence, TypeVar, Union
+from typing import (
+    Any,
+    Dict,
+    Literal,
+    Mapping,
+    NewType,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+)
 
 from pydantic import AfterValidator
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 if sys.version_info >= (3, 9):
     from typing import Annotated

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -1,24 +1,14 @@
 """Functions used to load user data."""
 import json
-import sys
 import warnings
 from collections import ChainMap
 from dataclasses import field
 from datetime import datetime
+from functools import cached_property
 from hashlib import sha512
 from os import urandom
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Mapping,
-    Optional,
-    Sequence,
-    Set,
-    Union,
-)
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Set, Union
 
 import yaml
 from jinja2 import UndefinedError
@@ -34,15 +24,6 @@ from questionary.prompts.common import Choice
 from .errors import InvalidTypeError, UserMessageError
 from .tools import cast_str_to_bool, force_str_end
 from .types import MISSING, AnyByStrDict, MissingType, OptStr, OptStrOrPath, StrOrPath
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from functools import cached_property
-else:
-    from backports.cached_property import cached_property
-
-if TYPE_CHECKING:
-    pass
 
 
 # TODO Remove these two functions as well as DEFAULT_DATA in a future release

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -4,7 +4,7 @@ import re
 import sys
 from contextlib import suppress
 from pathlib import Path
-from tempfile import mkdtemp
+from tempfile import TemporaryDirectory, mkdtemp
 from warnings import warn
 
 from packaging import version
@@ -13,7 +13,6 @@ from plumbum import TF, ProcessExecutionError, colors, local
 from plumbum.cmd import git
 
 from .errors import DirtyLocalWarning, ShallowCloneWarning
-from .tools import TemporaryDirectory
 from .types import OptBool, OptStr, StrOrPath
 
 GIT_PREFIX = ("git@", "git://", "git+", "https://github.com/", "https://gitlab.com/")

--- a/poetry.lock
+++ b/poetry.lock
@@ -15,28 +15,6 @@ files = [
 typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
 
 [[package]]
-name = "backports-cached-property"
-version = "1.0.2"
-description = "cached_property() - computed once per instance, cached as attribute"
-optional = false
-python-versions = ">=3.6.0"
-files = [
-    {file = "backports.cached-property-1.0.2.tar.gz", hash = "sha256:9306f9eed6ec55fd156ace6bc1094e2c86fae5fb2bf07b6a9c00745c656e75dd"},
-    {file = "backports.cached_property-1.0.2-py3-none-any.whl", hash = "sha256:baeb28e1cd619a3c9ab8941431fe34e8490861fb998c6c4590693d50171db0cc"},
-]
-
-[[package]]
-name = "cached-property"
-version = "1.5.2"
-description = "A decorator for caching properties in classes."
-optional = false
-python-versions = "*"
-files = [
-    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
-    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
-]
-
-[[package]]
 name = "certifi"
 version = "2022.12.7"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -168,7 +146,6 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "colorama"
@@ -281,7 +258,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-metadata = {version = ">=1.6.0", markers = "python_version < \"3.8\""}
 packaging = ">=20.9"
 
 [[package]]
@@ -367,7 +343,6 @@ files = [
 ]
 
 [package.dependencies]
-cached-property = {version = "*", markers = "python_version < \"3.8\""}
 colorama = ">=0.4"
 
 [package.extras]
@@ -410,7 +385,6 @@ files = [
 ]
 
 [package.dependencies]
-typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
@@ -580,7 +554,6 @@ mergedeep = ">=1.3.4"
 packaging = ">=20.5"
 pyyaml = ">=5.1"
 pyyaml-env-tag = ">=0.1"
-typing-extensions = {version = ">=3.10", markers = "python_version < \"3.8\""}
 watchdog = ">=2.0"
 
 [package.extras]
@@ -715,7 +688,6 @@ files = [
 [package.dependencies]
 mypy-extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typed-ast = {version = ">=1.4.0,<2", markers = "python_version < \"3.8\""}
 typing-extensions = ">=4.1.0"
 
 [package.extras]
@@ -807,9 +779,6 @@ files = [
     {file = "platformdirs-2.6.2.tar.gz", hash = "sha256:e1fea1fe471b9ff8332e229df3cb7de4f53eeea4998d3b6bfff542115e998bd2"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.4", markers = "python_version < \"3.8\""}
-
 [package.extras]
 docs = ["furo (>=2022.12.7)", "proselint (>=0.13)", "sphinx (>=5.3)", "sphinx-autodoc-typehints (>=1.19.5)"]
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.2.2)", "pytest (>=7.2)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
@@ -824,9 +793,6 @@ files = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
-
-[package.dependencies]
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
@@ -883,7 +849,6 @@ files = [
 [package.dependencies]
 cfgv = ">=2.0.0"
 identify = ">=1.0.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 nodeenv = ">=0.11.1"
 pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
@@ -1088,7 +1053,6 @@ files = [
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
@@ -1426,39 +1390,6 @@ files = [
 ]
 
 [[package]]
-name = "typed-ast"
-version = "1.5.4"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-optional = false
-python-versions = ">=3.6"
-files = [
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
-    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
-    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
-    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
-    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
-
-[[package]]
 name = "types-backports"
 version = "0.1.3"
 description = "Typing stubs for backports"
@@ -1543,7 +1474,6 @@ files = [
 [package.dependencies]
 distlib = ">=0.3.6,<1"
 filelock = ">=3.4.1,<4"
-importlib-metadata = {version = ">=4.8.3", markers = "python_version < \"3.8\""}
 platformdirs = ">=2.4,<3"
 
 [package.extras]
@@ -1618,5 +1548,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.7,<4.0"
-content-hash = "660d783c7411b0eba69003772ecdcf0a48d4933f209c2eae4d6517d8c2c7eb7e"
+python-versions = ">=3.8,<4.0"
+content-hash = "1cb6185805d4e51024f5354074e3238dfbb660da1e7fb9486eb5ab84b6e5333c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
@@ -27,13 +26,11 @@ copier = "copier.__main__:copier_app_run"
 "Bug Tracker" = "https://github.com/copier-org/copier/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.7,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
-"backports.cached-property" = { version = ">=1.0.0", python = "<3.8" }
+python = ">=3.8,<4.0" # HACK https://github.com/PyCQA/isort/issues/1945
 colorama = ">=0.4.3"
 decorator = ">=5.1.1"
 dunamai = ">=1.7.0"
 funcy = ">=1.17"
-importlib-metadata = { version = ">=3.4,<7.0", python = "<3.8" }
 jinja2 = ">=3.1.1"
 jinja2-ansible-filters = ">=1.3.1"
 packaging = ">=23.0"
@@ -44,7 +41,7 @@ pygments = ">=2.7.1"
 pyyaml = ">=5.3.1"
 pyyaml-include = ">=1.2"
 questionary = ">=1.8.1"
-typing-extensions = { version = ">=3.7.4,<5.0.0", python = "<3.8" }
+typing-extensions = { version = ">=3.7.4,<5.0.0", python = "<3.9" }
 
 [tool.poetry.group.dev]
 optional = true
@@ -104,7 +101,7 @@ style = "pep440"
 vcs = "git"
 
 [tool.black]
-target-version = ["py37"]
+target-version = ["py38"]
 
 [tool.isort]
 profile = "black"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -6,7 +6,7 @@ import textwrap
 from enum import Enum
 from hashlib import sha1
 from pathlib import Path
-from typing import Mapping, Optional, Tuple, Union
+from typing import Mapping, Optional, Protocol, Tuple, Union
 
 from pexpect.popen_spawn import PopenSpawn
 from plumbum import local
@@ -16,12 +16,6 @@ from prompt_toolkit.keys import Keys
 
 import copier
 from copier.types import OptStr, StrOrPath
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol
 
 PROJECT_TEMPLATE = Path(__file__).parent / "demo"
 

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -15,7 +15,6 @@ from .helpers import DATA, PROJECT_TEMPLATE, build_file_tree
 def test_copy(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
-    # dirs_exist_ok not available in Python 3.7
     for item in PROJECT_TEMPLATE.iterdir():
         item_src_path = item
         item_dst_path = src / item.name

--- a/tests/test_subdirectory.py
+++ b/tests/test_subdirectory.py
@@ -1,6 +1,6 @@
-import sys
 from pathlib import Path
 from textwrap import dedent
+from typing import Literal
 
 import pytest
 import yaml
@@ -10,12 +10,6 @@ from plumbum.cmd import git
 import copier
 
 from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
-
-# HACK https://github.com/python/mypy/issues/8520#issuecomment-772081075
-if sys.version_info >= (3, 8):
-    from typing import Literal
-else:
-    from typing_extensions import Literal
 
 
 def git_init(message="hello world"):

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -1,10 +1,9 @@
 from pathlib import Path
-from typing import Optional
+from typing import Literal, Optional
 
 import pytest
 
 import copier
-from copier.types import Literal
 
 from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,10 +1,9 @@
 from pathlib import Path
 from stat import S_IREAD
+from tempfile import TemporaryDirectory
 
 from plumbum.cmd import git
 from poethepoet.app import PoeThePoet
-
-from copier.tools import TemporaryDirectory
 
 
 def test_types() -> None:

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -2,7 +2,7 @@ import platform
 from pathlib import Path
 from shutil import rmtree
 from textwrap import dedent
-from typing import Optional
+from typing import Literal, Optional
 
 import pexpect
 import pytest
@@ -13,7 +13,6 @@ from plumbum.cmd import git
 from copier.cli import CopierApp
 from copier.errors import UserMessageError
 from copier.main import Worker, run_copy, run_update
-from copier.types import Literal
 
 from .helpers import (
     BRACKET_ENVOPS_JSON,


### PR DESCRIPTION
I've dropped support for Python 3.7. Resolves #1251.