### PR TITLE
style: prefer imports from modules

### DIFF
--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -5,8 +5,9 @@ import pytest
 from plumbum import local
 from plumbum.cmd import git
 
-from copier import readlink, run_copy, run_update
+from copier import run_copy, run_update
 from copier.errors import DirtyLocalWarning
+from copier.tools import readlink
 
 from .helpers import build_file_tree
 


### PR DESCRIPTION
Just some minor consistency improvement regarding imports. I think it's preferable to import things like exceptions and utilities from their corresponding modules and not from the root module, and only import `run_copy`/`run_recopy`/`run_update` (and perhaps `Worker`, although I think that should be hidden long-term) from the root module.

This is a minor initial effort towards #1250.