### PR TITLE
docs: use relative path to Markdown file for page linking

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -724,7 +724,7 @@ code hunk in the file itself, similar to the behavior of `git merge`.
 
 During a project update, Copier needs to compare the template evolution with the
 subproject evolution. This way, it can detect what changed, where and how to merge those
-changes. [Refer here for more details on this process](./updating.md).
+changes. [Refer here for more details on this process](updating.md).
 
 The more lines you use, the more accurate Copier will be when detecting conflicts. But
 you will also have more conflicts to solve by yourself. FWIW, Git uses 3 lines by
@@ -977,7 +977,7 @@ on them, so they are always installed when Copier is installed.
         enhances the extension loading mechanism to allow templates writers to put their
         extensions directly in their templates. It also allows to modify the rendering context
         (the Jinja variables that you can use in your templates) before
-        rendering templates, see [using a context hook](../faq#how-can-i-alter-the-context-before-rendering-the-project).
+        rendering templates, see [using a context hook](faq.md#how-can-i-alter-the-context-before-rendering-the-project).
     -   [`jinja_markdown.MarkdownExtension`](https://github.com/jpsca/jinja-markdown):
         provides a `markdown` tag that will render Markdown to HTML using
         [PyMdown extensions](https://facelessuser.github.io/pymdown-extensions/).
@@ -1000,8 +1000,8 @@ on them, so they are always installed when Copier is installed.
 -   CLI flags: N/A
 -   Default value: `""`
 
-A message to be printed after [generating](../generating) or
-[regenerating](../generating#regenerating-a-project) a project _successfully_.
+A message to be printed after [generating](generating.md) or
+[regenerating](generating.md#regenerating-a-project) a project _successfully_.
 
 If the message contains Jinja code, it will be rendered with the same context as the
 rest of the template. A [Jinja include](#importing-jinja-templates-and-macros)
@@ -1035,7 +1035,7 @@ The message is suppressed when Copier is run in [quiet mode](#quiet).
 -   Default value: `""`
 
 Like [`message_after_copy`](#message_after_copy) but printed _before_
-[generating](../generating) or [regenerating](../generating#regenerating-a-project) a
+[generating](generating.md) or [regenerating](generating.md#regenerating-a-project) a
 project.
 
 !!! example

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -68,7 +68,7 @@ module_name: world
 ```
 
 Copier allows much more advanced templating: see the next chapter,
-[configuring a template](../configuring/), to see all the configurations options and
+[configuring a template](configuring.md), to see all the configurations options and
 their usage.
 
 ## Template helpers

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,8 +3,8 @@
 ## Can Copier be applied over a preexisting project?
 
 Yes, of course. Copier understands this use case out of the box. That's actually what
-powers features such as [updating](../updating) or the ability of
-[applying multiple templates to the same subproject](../configuring#applying-multiple-templates-to-the-same-subproject).
+powers features such as [updating](updating.md) or the ability of
+[applying multiple templates to the same subproject](configuring.md#applying-multiple-templates-to-the-same-subproject).
 
 !!! example
 
@@ -57,7 +57,7 @@ templates, so that you can add, change or remove variables.
 
 In order for Copier to be able to load and use the extension when generating a project,
 it must be installed alongside Copier itself. More details in the
-[`jinja_extensions` docs](../configuring#jinja_extensions).
+[`jinja_extensions` docs](configuring.md#jinja_extensions).
 
 You can then configure your Jinja extensions in Copier's configuration file:
 
@@ -144,9 +144,9 @@ repository.
 
 ## While developing, why the template doesn't include dirty changes?
 
-Copier follows [a specific algorithm](./configuring.md#templates-versions) to choose
-what reference to use from the template. It also
-[includes dirty changes in the `HEAD` ref while developing locally](./configuring.md#copying-dirty-changes).
+Copier follows [a specific algorithm](configuring.md#templates-versions) to choose what
+reference to use from the template. It also
+[includes dirty changes in the `HEAD` ref while developing locally](configuring.md#copying-dirty-changes).
 
 However, did you make sure you are selecting the `HEAD` ref for copying?
 

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -48,7 +48,7 @@ modifications made, Copier will use this modified working copy of the template t
 development of new template features.
 
 If you would like to override the version of template being installed, the
-[`--vcs-ref`](../configuring/#vcs_ref) argument can be used to specify a branch, tag or
+[`--vcs-ref`](configuring.md/#vcs_ref) argument can be used to specify a branch, tag or
 other reference to use.
 
 For example to use the latest master branch from a public repository:


### PR DESCRIPTION
I've unified the linking to pages to [use relative paths to Markdown files](https://www.mkdocs.org/user-guide/writing-your-docs/#linking-to-pages) instead of relative URL paths like `../<page name>` which is quite unintuitive because of the leading `../` that is needed as MkDocs page URLs have a trailing `/`.