### PR TITLE
feat: add support for pre-update and post-update messages

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -805,12 +805,14 @@ class Worker:
             # review the diff before committing; so we can safely avoid
             # asking for confirmation
             raise UserMessageError("Enable overwrite to update a subproject.")
+        self._print_message(self.template.message_before_update)
         if not self.quiet:
             # TODO Unify printing tools
             print(
                 f"Updating to template version {self.template.version}", file=sys.stderr
             )
         self._apply_update()
+        self._print_message(self.template.message_after_update)
 
     def _apply_update(self):
         subproject_top = Path(

--- a/copier/template.py
+++ b/copier/template.py
@@ -310,9 +310,19 @@ class Template:
         return self.config_data.get("message_after_copy", "")
 
     @cached_property
+    def message_after_update(self) -> str:
+        """Get message to print after update action specified in the template."""
+        return self.config_data.get("message_after_update", "")
+
+    @cached_property
     def message_before_copy(self) -> str:
         """Get message to print before copy action specified in the template."""
         return self.config_data.get("message_before_copy", "")
+
+    @cached_property
+    def message_before_update(self) -> str:
+        """Get message to print before update action specified in the template."""
+        return self.config_data.get("message_before_update", "")
 
     @cached_property
     def metadata(self) -> AnyByStrDict:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1028,6 +1028,28 @@ The message is suppressed when Copier is run in [quiet mode][quiet].
         2. Read "CONTRIBUING.md" and start coding.
     ```
 
+### `message_after_update`
+
+-   Format: `str`
+-   CLI flags: N/A
+-   Default value: `""`
+
+Like [`message_after_copy`][message_after_copy] but printed after
+[_updating_](updating.md) a project.
+
+!!! example
+
+    ```yaml title="copier.yml"
+    project_name:
+        type: str
+        help: An awesome project needs an awesome name. Tell me yours.
+
+    _message_after_update: |
+        Your project "{{ project_name }}" has been updated successfully!
+        In case there are any conflicts, please resolve them. Then,
+        you're done.
+    ```
+
 ### `message_before_copy`
 
 -   Format: `str`
@@ -1049,6 +1071,29 @@ Like [`message_after_copy`][message_after_copy] but printed _before_
 
         You'll be asked a series of questions whose answers will be used to
         generate a tailored project for you.
+    ```
+
+### `message_before_update`
+
+-   Format: `str`
+-   CLI flags: N/A
+-   Default value: `""`
+
+Like [`message_before_copy`][message_after_copy] but printed before
+[_updating_](updating.md) a project.
+
+!!! example
+
+    ```yaml title="copier.yml"
+    project_name:
+        type: str
+        help: An awesome project needs an awesome name. Tell me yours.
+
+    _message_before_update: |
+        Thanks for updating your project using our template.
+
+        You'll be asked a series of questions whose answers are pre-populated
+        with previously entered values. Feel free to change them as needed.
     ```
 
 ### `migrations`

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -144,15 +144,6 @@ def test_messages_with_inline_text(
     # clear capture output log
     capsys.readouterr()
 
-    copy_pattern = (
-        r"^"
-        r"Thank you for using our template on (linux|macos|windows)"
-        r".+"
-        r"Project {project_name} successfully created"
-        r"\s*"
-        r"$"
-    )
-
     # copy
     if interactive:
         tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)), timeout=10)
@@ -164,7 +155,14 @@ def test_messages_with_inline_text(
 
     assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(copy_pattern.format(project_name="myproj"), err, flags=re.S)
+    assert re.search(
+        r"""
+        ^Thank\ you\ for\ using\ our\ template\ on\ (linux|macos|windows).+
+        Project\ myproj\ successfully\ created\s*$
+        """,
+        err,
+        flags=re.S | re.X,
+    )
 
     # recopy
     if interactive:
@@ -177,7 +175,14 @@ def test_messages_with_inline_text(
 
     assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(copy_pattern.format(project_name="myproj_new"), err, flags=re.S)
+    assert re.search(
+        r"""
+        ^Thank\ you\ for\ using\ our\ template\ on\ (linux|macos|windows).+
+        Project\ myproj_new\ successfully\ created\s*$
+        """,
+        err,
+        flags=re.S | re.X,
+    )
 
     with local.cwd(dst):
         git("init")
@@ -199,16 +204,12 @@ def test_messages_with_inline_text(
     assert (dst / "version.txt").read_text() == "v2"
     _, err = capsys.readouterr()
     assert re.search(
-        (
-            r"^"
-            r"Updating on (linux|macos|windows)"
-            r".+"
-            r"Project {project_name} successfully updated"
-            r"\s*"
-            r"$"
-        ).format(project_name="myproj_new_update"),
+        r"""
+        ^Updating\ on\ (linux|macos|windows).+
+        Project\ myproj_new_update\ successfully\ updated\s*$
+        """,
         err,
-        flags=re.S,
+        flags=re.S | re.X,
     )
 
 
@@ -283,15 +284,6 @@ def test_messages_with_included_text(
     # clear capture output log
     capsys.readouterr()
 
-    copy_pattern = (
-        r"^"
-        r"Thank you for using our template on (linux|macos|windows)"
-        r".+"
-        r"Project {project_name} successfully created"
-        r"\s*"
-        r"$"
-    )
-
     # copy
     if interactive:
         tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)), timeout=10)
@@ -303,7 +295,14 @@ def test_messages_with_included_text(
 
     assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(copy_pattern.format(project_name="myproj"), err, flags=re.S)
+    assert re.search(
+        r"""
+        ^Thank\ you\ for\ using\ our\ template\ on\ (linux|macos|windows).+
+        Project\ myproj\ successfully\ created\s*$
+        """,
+        err,
+        flags=re.S | re.X,
+    )
 
     # recopy
     if interactive:
@@ -316,7 +315,14 @@ def test_messages_with_included_text(
 
     assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(copy_pattern.format(project_name="myproj_new"), err, flags=re.S)
+    assert re.search(
+        r"""
+        ^Thank\ you\ for\ using\ our\ template\ on\ (linux|macos|windows).+
+        Project\ myproj_new\ successfully\ created\s*$
+        """,
+        err,
+        flags=re.S | re.X,
+    )
 
     with local.cwd(dst):
         git("init")
@@ -338,16 +344,12 @@ def test_messages_with_included_text(
     assert (dst / "version.txt").read_text() == "v2"
     _, err = capsys.readouterr()
     assert re.search(
-        (
-            r"^"
-            r"Updating on (linux|macos|windows)"
-            r".+"
-            r"Project {project_name} successfully updated"
-            r"\s*"
-            r"$"
-        ).format(project_name="myproj_new_update"),
+        r"""
+        ^Updating\ on\ (linux|macos|windows).+
+        Project\ myproj_new_update\ successfully\ updated\s*$
+        """,
         err,
-        flags=re.S,
+        flags=re.S | re.X,
     )
 
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3,9 +3,11 @@ from pathlib import Path
 
 import pexpect
 import pytest
+from plumbum import local
+from plumbum.cmd import git
 
 from copier.errors import InvalidTypeError
-from copier.main import run_copy, run_recopy
+from copier.main import run_copy, run_recopy, run_update
 
 from .helpers import COPIER_PATH, Spawn, build_file_tree, expect_prompt, render
 
@@ -93,13 +95,14 @@ def test_answer_with_invalid_type(tmp_path_factory: pytest.TempPathFactory) -> N
 
 
 @pytest.mark.parametrize("interactive", [False, True])
-def test_message_copy_with_inline_text(
+def test_messages_with_inline_text(
     tmp_path_factory: pytest.TempPathFactory,
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+
     build_file_tree(
         {
             (src / "copier.yaml"): (
@@ -109,6 +112,8 @@ def test_message_copy_with_inline_text(
 
                 _message_before_copy: Thank you for using our template on {{ _copier_conf.os }}
                 _message_after_copy: Project {{ project_name }} successfully created
+                _message_before_update: Updating on {{ _copier_conf.os }}
+                _message_after_update: Project {{ project_name }} successfully updated
                 """
             ),
             (src / "{{ _copier_conf.answers_file }}.jinja"): (
@@ -117,10 +122,29 @@ def test_message_copy_with_inline_text(
                 {{ _copier_answers|to_nice_yaml }}
                 """
             ),
+            (src / "version.txt"): "v1",
         }
     )
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
 
-    pattern = (
+    build_file_tree(
+        {
+            (src / "version.txt"): "v2",
+        }
+    )
+    with local.cwd(src):
+        git("add", ".")
+        git("commit", "-m2")
+        git("tag", "v2")
+
+    # clear capture output log
+    capsys.readouterr()
+
+    copy_pattern = (
         r"^"
         r"Thank you for using our template on (linux|macos|windows)"
         r".+"
@@ -131,37 +155,72 @@ def test_message_copy_with_inline_text(
 
     # copy
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)), timeout=10)
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
     else:
-        run_copy(str(src), dst, data={"project_name": "myproj"})
+        run_copy(str(src), dst, data={"project_name": "myproj"}, vcs_ref="v1")
 
+    assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(pattern.format(project_name="myproj"), err, flags=re.S)
+    assert re.search(copy_pattern.format(project_name="myproj"), err, flags=re.S)
 
     # recopy
     if interactive:
-        tui = spawn(COPIER_PATH + ("recopy", str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=10)
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)
     else:
-        run_recopy(dst, data={"project_name": "myproj_new"})
+        run_recopy(dst, data={"project_name": "myproj_new"}, vcs_ref="v1")
 
+    assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(pattern.format(project_name="myproj_new"), err, flags=re.S)
+    assert re.search(copy_pattern.format(project_name="myproj_new"), err, flags=re.S)
+
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+
+    # clear capture output log
+    capsys.readouterr()
+
+    # update
+    if interactive:
+        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("_update")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_update(dst, data={"project_name": "myproj_new_update"}, overwrite=True)
+
+    assert (dst / "version.txt").read_text() == "v2"
+    _, err = capsys.readouterr()
+    assert re.search(
+        (
+            r"^"
+            r"Updating on (linux|macos|windows)"
+            r".+"
+            r"Project {project_name} successfully updated"
+            r"\s*"
+            r"$"
+        ).format(project_name="myproj_new_update"),
+        err,
+        flags=re.S,
+    )
 
 
 @pytest.mark.parametrize("interactive", [False, True])
-def test_message_copy_with_included_text(
+def test_messages_with_included_text(
     tmp_path_factory: pytest.TempPathFactory,
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+
     build_file_tree(
         {
             (src / "copier.yaml"): (
@@ -169,9 +228,11 @@ def test_message_copy_with_included_text(
                 project_name:
                     type: str
 
-                _exclude: ["*.md"]
+                _exclude: [".git", "*.md"]
                 _message_before_copy: "{% include 'message_before_copy.md.jinja' %}"
                 _message_after_copy: "{% include 'message_after_copy.md.jinja' %}"
+                _message_before_update: "{% include 'message_before_update.md.jinja' %}"
+                _message_after_update: "{% include 'message_after_update.md.jinja' %}"
                 """
             ),
             (src / "message_before_copy.md.jinja"): (
@@ -184,16 +245,45 @@ def test_message_copy_with_included_text(
                 Project {{ project_name }} successfully created
                 """
             ),
+            (src / "message_before_update.md.jinja"): (
+                """\
+                Updating on {{ _copier_conf.os }}
+                """
+            ),
+            (src / "message_after_update.md.jinja"): (
+                """\
+                Project {{ project_name }} successfully updated
+                """
+            ),
             (src / "{{ _copier_conf.answers_file }}.jinja"): (
                 """\
                 # Changes here will be overwritten by Copier
                 {{ _copier_answers|to_nice_yaml }}
                 """
             ),
+            (src / "version.txt"): "v1",
         }
     )
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
 
-    pattern = (
+    build_file_tree(
+        {
+            (src / "version.txt"): "v2",
+        }
+    )
+    with local.cwd(src):
+        git("add", ".")
+        git("commit", "-m2")
+        git("tag", "v2")
+
+    # clear capture output log
+    capsys.readouterr()
+
+    copy_pattern = (
         r"^"
         r"Thank you for using our template on (linux|macos|windows)"
         r".+"
@@ -204,37 +294,72 @@ def test_message_copy_with_included_text(
 
     # copy
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)), timeout=10)
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
     else:
-        run_copy(str(src), dst, data={"project_name": "myproj"})
+        run_copy(str(src), dst, data={"project_name": "myproj"}, vcs_ref="v1")
 
+    assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(pattern.format(project_name="myproj"), err, flags=re.S)
+    assert re.search(copy_pattern.format(project_name="myproj"), err, flags=re.S)
 
     # recopy
     if interactive:
-        tui = spawn(COPIER_PATH + ("recopy", str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=10)
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)
     else:
-        run_recopy(dst, data={"project_name": "myproj_new"})
+        run_recopy(dst, data={"project_name": "myproj_new"}, vcs_ref="v1")
 
+    assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
-    assert re.search(pattern.format(project_name="myproj_new"), err, flags=re.S)
+    assert re.search(copy_pattern.format(project_name="myproj_new"), err, flags=re.S)
+
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+
+    # clear capture output log
+    capsys.readouterr()
+
+    # update
+    if interactive:
+        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("_update")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_update(dst, data={"project_name": "myproj_new_update"}, overwrite=True)
+
+    assert (dst / "version.txt").read_text() == "v2"
+    _, err = capsys.readouterr()
+    assert re.search(
+        (
+            r"^"
+            r"Updating on (linux|macos|windows)"
+            r".+"
+            r"Project {project_name} successfully updated"
+            r"\s*"
+            r"$"
+        ).format(project_name="myproj_new_update"),
+        err,
+        flags=re.S,
+    )
 
 
 @pytest.mark.parametrize("interactive", [False, True])
-def test_message_copy_quiet(
+def test_messages_quiet(
     tmp_path_factory: pytest.TempPathFactory,
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+
     build_file_tree(
         {
             (src / "copier.yaml"): (
@@ -244,6 +369,8 @@ def test_message_copy_quiet(
 
                 _message_before_copy: Thank you for using our template on {{ _copier_conf.os }}
                 _message_after_copy: Project {{ project_name }} successfully created
+                _message_before_update: Updating on {{ _copier_conf.os }}
+                _message_after_update: Project {{ project_name }} successfully updated
                 """
             ),
             (src / "{{ _copier_conf.answers_file }}.jinja"): (
@@ -252,31 +379,83 @@ def test_message_copy_quiet(
                 {{ _copier_answers|to_nice_yaml }}
                 """
             ),
+            (src / "version.txt"): "v1",
         }
     )
+    with local.cwd(src):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+        git("tag", "v1")
+
+    build_file_tree(
+        {
+            (src / "version.txt"): "v2",
+        }
+    )
+    with local.cwd(src):
+        git("add", ".")
+        git("commit", "-m2")
+        git("tag", "v2")
+
+    # clear capture output log
+    capsys.readouterr()
 
     # copy
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", "--quiet", str(src), str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("copy", "--quiet", "-r", "v1", str(src), str(dst)),
+            timeout=10,
+        )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
     else:
-        run_copy(str(src), dst, data={"project_name": "myproj"}, quiet=True)
+        run_copy(
+            str(src), dst, data={"project_name": "myproj"}, vcs_ref="v1", quiet=True
+        )
 
+    assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
     assert "Thank you for using our template" not in err
     assert "Project myproj successfully created" not in err
 
     # recopy
     if interactive:
-        tui = spawn(COPIER_PATH + ("recopy", "--quiet", str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("recopy", "--quiet", "-r", "v1", str(dst)), timeout=10
+        )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)
     else:
-        run_recopy(dst, data={"project_name": "myproj_new"}, quiet=True)
+        run_recopy(dst, data={"project_name": "myproj_new"}, vcs_ref="v1", quiet=True)
 
+    assert (dst / "version.txt").read_text() == "v1"
     _, err = capsys.readouterr()
     assert "Thank you for using our template" not in err
     assert "Project myproj_new successfully created" not in err
+
+    with local.cwd(dst):
+        git("init")
+        git("add", ".")
+        git("commit", "-m1")
+
+    # clear capture output log
+    capsys.readouterr()
+
+    # update
+    if interactive:
+        tui = spawn(COPIER_PATH + ("update", "--quiet", str(dst)), timeout=10)
+        expect_prompt(tui, "project_name", "str")
+        tui.sendline("_update")
+        tui.expect_exact(pexpect.EOF)
+    else:
+        run_update(
+            dst, data={"project_name": "myproj_new_update"}, overwrite=True, quiet=True
+        )
+
+    assert (dst / "version.txt").read_text() == "v2"
+    _, err = capsys.readouterr()
+    assert "Updating on" not in err
+    assert "Project myproj_new_update successfully updated" not in err


### PR DESCRIPTION
I've added support for pre-update and post-update messages that can be written in plain text. Messages can be written inline or included via Jinja includes, and messages are rendered.

This (simple) implementation became possible due to #1156 since there's no output of an internal copy call of the update algorithm anymore. Without this copy call output suppression, the internal copy call would print the pre-copy/post-copy messages in case they are configured which we wouldn't want to see when running an update.

Related to #723. Follow-up of #1194.