### PR TITLE
Link to Poetry dependency in CONTRIBUTING local dev env setup guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,7 @@ your host environment:
 -   [Nix](https://nixos.org/download.html) to provide a reproducible development
     environment.
 -   [Direnv](https://direnv.net/) to load that environment automatically in your shell.
+-   [Poetry](https://python-poetry.org/) to test and lint the code.
 
 ## Get Started!
 


### PR DESCRIPTION
Poetry is a required dependency for the local environment setup, so it would be good to link
Without it, step 3 (`direnv allow`) and step 5 (`poe test`) will fail.

This PR adds a link to Poetry https://python-poetry.org/ to the CONTRIBUTING guide, next to the links for Nix and Direnv.

