### PR TITLE
docs: update outdated `copier update --force` examples

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -848,7 +848,7 @@ The CLI option can be passed several times to add several patterns.
 ### `force`
 
 -   Format: `bool`
--   CLI flags: `-f`, `--force`
+-   CLI flags: `-f`, `--force` (N/A in `copier update`)
 -   Default value: `False`
 
 Overwrite files that already exist, without asking.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -87,14 +87,14 @@ repos:
 If you want to just reuse all previous answers:
 
 ```shell
-copier update --force
+copier update --defaults
 ```
 
 If you want to change just one question, and leave all others untouched, and don't want
 to go through the whole questionary again:
 
 ```shell
-copier update --force --data updated_question="my new answer"
+copier update --defaults --data updated_question="my new answer"
 ```
 
 ## How the update works


### PR DESCRIPTION
I've updated some outdated examples showing `copier update --force` which isn't available anymore since v8.0.0.

Fixes #1299.