### PR TITLE
fix(recopy): never clone old template (even less if it's just for cleanup)

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -196,7 +196,7 @@ class Template:
     use_prereleases: bool = False
 
     def _cleanup(self) -> None:
-        temp_clone = self._temp_clone
+        temp_clone = self._temp_clone()
         if temp_clone:
             rmtree(
                 temp_clone,
@@ -204,8 +204,14 @@ class Template:
                 onerror=handle_remove_readonly,
             )
 
-    @property
     def _temp_clone(self) -> Optional[Path]:
+        """Get the path to the temporary clone of the template.
+
+        If the template hasn't yet been cloned, or if it was a local template,
+        then there's no temporary clone and this will return `None`.
+        """
+        if "local_abspath" not in self.__dict__:
+            return None
         clone_path = self.local_abspath
         original_path = Path(self.url).expanduser()
         with suppress(OSError):  # triggered for URLs on Windows

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -12,12 +12,15 @@ from packaging.version import InvalidVersion, Version
 from plumbum import TF, ProcessExecutionError, colors, local
 
 from .errors import DirtyLocalWarning, ShallowCloneWarning
-from .types import OptBool, OptStr, StrOrPath
+from .types import OptBool, OptStr, OptStrOrPath, StrOrPath
 
 
-def get_git():
+def get_git(context_dir: OptStrOrPath = None):
     """Gets `git` command, or fails if it's not available"""
-    return local["git"]
+    command = local["git"]
+    if context_dir:
+        command = command["-C", context_dir]
+    return command
 
 
 def get_git_version():


### PR DESCRIPTION
Before this patch, when doing a recopy for a subproject previously placed on a git ref that was no longer reachable, the recopy process still tried to clone the old template.

The funniest part is that it was only trying to clone it while doing the process of cleanup. Thus, even if that clone worked, it was a waste.

This should make recopy more resilient and performant.