### PR TITLE
docs: unify terminology

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1404,8 +1404,8 @@ templates suffix is _not_ empty, Copier will abort and print an error message.
     _templates_suffix: ""
     ```
 
-If there is a file with the template extension next to another one without it, the one
-without extension will be ignored.
+If there is a file with the template suffix next to another one without it, the one
+without suffix will be ignored.
 
 !!! example
 


### PR DESCRIPTION
A minor follow-up of 448455239ffb5c28ce48c07c70d50e1abf5fc215 that unifies terminology regarding the templates suffix (vs. "extension", which might be confused with Jinja _extensions_).