### PR TITLE
use correct vcs-ref syntax

### DIFF
--- a/docs/generating.md
+++ b/docs/generating.md
@@ -54,14 +54,14 @@ to use.
 For example to use the latest master branch from a public repository:
 
 ```shell
-copier copy --vcs-ref master https://github.com/foo/copier-template.git ./path/to/destination
+copier --vcs-ref master copy https://github.com/foo/copier-template.git ./path/to/destination
 ```
 
 Or to work from the current checked out revision of a local template (including dirty
 changes):
 
 ```shell
-copier copy --vcs-ref HEAD path/to/project/template path/to/destination
+copier --vcs-ref HEAD copy path/to/project/template path/to/destination
 ```
 
 ## Regenerating a project


### PR DESCRIPTION
I wanted to use a specific version of my template but I was not able to select it using vcs-ref option. Looking at the doc: https://copier.readthedocs.io/en/latest/generating/#copying-dirty-changes, I was trying to run: 

```
copier copy --vcs-ref master https://github.com/foo/copier-template.git ./path/to/destination
```

leading me to the following error: 
```
Error: Unknown switch --vcs-ref
```

According to this thread: https://github.com/copier-org/copier/issues/857, it seems the option is not for `copy` but `copier`. I updated the code in the doc to reflect that. 