### PR TITLE
fix(cli): use return code 4 for unsafe template error

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -71,7 +71,8 @@ def handle_exceptions(method, *args, **kwargs):
         return 1
     except UnsafeTemplateError as error:
         print(colors.red | "\n".join(error.args), file=sys.stderr)
-        return 2
+        # DOCS https://github.com/copier-org/copier/issues/1328#issuecomment-1723214165
+        return 0b100
 
 
 class CopierApp(cli.Application):

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1439,7 +1439,7 @@ Copier templates can use dangerous features that allow arbitrary code execution:
 -   [Tasks][tasks]
 
 Therefore, these features are disabled by default and Copier will raise an error (and
-exit from the CLI with code `2`) when they are found in a template. In this case, please
+exit from the CLI with code `4`) when they are found in a template. In this case, please
 verify that no malicious code gets executed by any of the used features. When you're
 sufficiently confident or willing to take the risk, set `unsafe=True` or pass the CLI
 switch `--UNSAFE` or `--trust`.

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -106,7 +106,7 @@ def test_copy_cli(
     if unsafe:
         assert retcode == 0
     else:
-        assert retcode == 2
+        assert retcode == 4
         _, err = capsys.readouterr()
         assert "Template uses potentially unsafe feature: tasks." in err
 
@@ -377,6 +377,6 @@ def test_update_cli(
     if unsafe:
         assert retcode == 0
     else:
-        assert retcode == 2
+        assert retcode == 4
         _, err = capsys.readouterr()
         assert "Template uses potentially unsafe feature: tasks." in err


### PR DESCRIPTION
I've updated the return code for `UnsafeTemplateError` errors to use 4 (`1 << 2` / `0b100`) instead of 2 which is used by Plumbum already for `SwitchError` type errors.

Technically, this is a breaking change :thinking:, but I anticipate hardly anybody relying on the return code. WDYT, @copier-org/maintainers?

Fixes #1328.