### PR TITLE
feat: allow overriding data file with CLI arguments

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -47,7 +47,6 @@ import sys
 from io import StringIO
 from pathlib import Path
 from textwrap import dedent
-from typing import Set
 from unittest.mock import patch
 
 import yaml
@@ -106,10 +105,8 @@ class _Subcommand(cli.Application):
     """Base class for Copier subcommands."""
 
     def __init__(self, executable):
-        self.cli_data_args: Set[str] = set()
+        self.data: AnyByStrDict = {}
         super().__init__(executable)
-
-    data: AnyByStrDict = {}
 
     answers_file = cli.SwitchAttr(
         ["-a", "--answers-file"],
@@ -174,7 +171,6 @@ class _Subcommand(cli.Application):
         for arg in values:
             key, value = arg.split("=", 1)
             self.data[key] = value
-            self.cli_data_args.add(key)
 
     @cli.switch(
         ["--data-file"],
@@ -191,7 +187,7 @@ class _Subcommand(cli.Application):
             file_updates: AnyByStrDict = yaml.safe_load(f)
 
         updates_without_cli_overrides = {
-            k: v for k, v in file_updates.items() if k not in self.cli_data_args
+            k: v for k, v in file_updates.items() if k not in self.data
         }
         self.data.update(updates_without_cli_overrides)
 

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -104,7 +104,9 @@ class CopierApp(cli.Application):
 class _Subcommand(cli.Application):
     """Base class for Copier subcommands."""
 
-    data: AnyByStrDict = {}
+    def __init__(self, executable):
+        self.data: AnyByStrDict = {}
+        super().__init__(executable)
 
     answers_file = cli.SwitchAttr(
         ["-a", "--answers-file"],

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -104,9 +104,7 @@ class CopierApp(cli.Application):
 class _Subcommand(cli.Application):
     """Base class for Copier subcommands."""
 
-    def __init__(self, executable):
-        self.data: AnyByStrDict = {}
-        super().__init__(executable)
+    data: AnyByStrDict = {}
 
     answers_file = cli.SwitchAttr(
         ["-a", "--answers-file"],

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -758,10 +758,6 @@ questions with default answers.
     copier copy -fd 'user_name=Manuel Calavera' template destination
     ```
 
-!!! info
-
-    The `-d, --data` flags are mutually exclusive with the [`--data-file`][data_file] flag.
-
 ### `data_file`
 
 -   Format: `str`
@@ -797,9 +793,16 @@ contains your data.
     copier copy -d 'user_name=Manuel Calavera' -d 'age=7' -d 'height=1.83' template destination
     ```
 
+    if you'd like to override some of the answers in the file, `--data` flags always take
+    precedence
+
+    ```shell
+    copier copy -d 'user_name=Bilbo Baggins' --data-file input.yml template destination
+    ```
+
 !!! info
 
-    The `--data-file` flag is mutually exclusive with the [`-d, --data`][data] flags.
+    command line arguments passed via `--data` will always take precedence over the answers file
 
 ### `envops`
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -223,13 +223,7 @@ def test_data_cli_takes_precedence_over_data_file(
         "another_question": "another answer!",
         "yet_another_question": "sure, one more for you!",
     }
-    assert actual_answers["_src_path"] == expected_answers["_src_path"]
-    assert actual_answers["question"] == expected_answers["question"]
-    assert actual_answers["another_question"] == expected_answers["another_question"]
-    assert (
-        actual_answers["yet_another_question"]
-        == expected_answers["yet_another_question"]
-    )
+    assert actual_answers == expected_answers
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

Users should be able to pass CLI data arguments and use a `--data-file` at the same time.  Let's just take inspiration from the [helm values file](https://helm.sh/docs/chart_template_guide/values_files/) and give highest priority to data values passed at the command line.

from the helm doc site:
>The list above is in order of specificity: values.yaml is the default, which can be overridden by a parent chart's values.yaml, which can in turn be overridden by a user-supplied values file, which can in turn be overridden by --set parameters.