### PR TITLE
fix: fix answer validation for `type: str` questions

### DIFF
--- a/copier/tools.py
+++ b/copier/tools.py
@@ -6,6 +6,8 @@ import platform
 import stat
 import sys
 from contextlib import suppress
+from decimal import Decimal
+from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
 from types import TracebackType
@@ -90,7 +92,23 @@ def printf_exception(
         print(HLINE, file=sys.stderr)
 
 
-def cast_str_to_bool(value: Any) -> bool:
+def cast_to_str(value: Any) -> str:
+    """Parse anything to str.
+
+    Params:
+        value:
+            Anything to be casted to a str.
+    """
+    if isinstance(value, str):
+        return value.value if isinstance(value, Enum) else value
+    if isinstance(value, (float, int, Decimal)):
+        return str(value)
+    if isinstance(value, (bytes, bytearray)):
+        return value.decode()
+    raise ValueError(f"Could not convert {value} to string")
+
+
+def cast_to_bool(value: Any) -> bool:
     """Parse anything to bool.
 
     Params:

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -22,7 +22,7 @@ from pygments.lexers.data import JsonLexer, YamlLexer
 from questionary.prompts.common import Choice
 
 from .errors import InvalidTypeError, UserMessageError
-from .tools import cast_str_to_bool, force_str_end
+from .tools import cast_to_bool, cast_to_str, force_str_end
 from .types import MISSING, AnyByStrDict, MissingType, OptStr, OptStrOrPath, StrOrPath
 
 
@@ -377,7 +377,7 @@ class Question:
 
     def get_multiline(self) -> bool:
         """Get the value for multiline."""
-        return cast_str_to_bool(self.render_value(self.multiline))
+        return cast_to_bool(self.render_value(self.multiline))
 
     def validate_answer(self, answer) -> bool:
         """Validate user answer."""
@@ -396,7 +396,7 @@ class Question:
 
     def get_when(self) -> bool:
         """Get skip condition for question."""
-        return cast_str_to_bool(self.render_value(self.when))
+        return cast_to_bool(self.render_value(self.when))
 
     def render_value(
         self, value: Any, extra_answers: Optional[AnyByStrDict] = None
@@ -460,10 +460,10 @@ def load_answersfile_data(
 
 
 CAST_STR_TO_NATIVE: Mapping[str, Callable] = {
-    "bool": cast_str_to_bool,
+    "bool": cast_to_bool,
     "float": float,
     "int": int,
     "json": json.loads,
-    "str": str,
+    "str": cast_to_str,
     "yaml": parse_yaml_string,
 }

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -2,6 +2,8 @@ import platform
 import stat
 import sys
 from contextlib import nullcontext as does_not_raise
+from decimal import Decimal
+from enum import Enum
 from pathlib import Path
 from typing import Any, ContextManager, List
 
@@ -407,6 +409,19 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
             "1",
             does_not_raise(),
         ),
+        ({"type": "str"}, "string", does_not_raise()),
+        ({"type": "str"}, b"bytes", does_not_raise()),
+        ({"type": "str"}, bytearray("abc", "utf-8"), does_not_raise()),
+        ({"type": "str"}, 1, does_not_raise()),
+        ({"type": "str"}, 1.1, does_not_raise()),
+        ({"type": "str"}, True, does_not_raise()),
+        ({"type": "str"}, False, does_not_raise()),
+        ({"type": "str"}, Decimal(1.1), does_not_raise()),
+        ({"type": "str"}, Enum("A", ["a", "b"], type=str).a, does_not_raise()),  # type: ignore
+        ({"type": "str"}, Enum("A", ["a", "b"]).a, pytest.raises(ValueError)),  # type: ignore
+        ({"type": "str"}, object(), pytest.raises(ValueError)),
+        ({"type": "str"}, {}, pytest.raises(ValueError)),
+        ({"type": "str"}, [], pytest.raises(ValueError)),
         (
             {
                 "type": "str",


### PR DESCRIPTION
I've fixed the answer validation for `type: str` questions. Copier does loose parsing/validation, i.e. non-string values that can be interpreted as strings are valid, but the loose parsing/validation has been too loose. For instance, values such as `object()` or `{}` or `[]` were considered valid.

I've created a custom validator/parser inspired by [Pydantic's `str_validator`](https://github.com/pydantic/pydantic/blob/3b297adf6132636646f36e77a5cd2aacd6b4f03b/pydantic/v1/validators.py#L59-L77) which makes more sense IMO.

WDYT?