### PR TITLE
docs: fix Read the Docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,4 +11,4 @@ build:
     post_install:
       - pip install poetry
       - poetry config virtualenvs.create false
-      - poetry install --only docs
+      - poetry install --with docs


### PR DESCRIPTION
I've (hopefully) fixed the recent Read the Docs build error introduced by #1349. :crossed_fingers:

Fixes #1357.