### PR TITLE
docs: improve updating pre-commit documentation

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -61,7 +61,9 @@ setting you use.
 
 ## Preventing Commit of Merge Conflicts
 
-If you use `--conflict inline` (the default) then you need to check for conflicts marks in your files: 
+If you use `--conflict inline` (the default) then you need to check for conflicts
+markers in your files:
+
 ```yaml title=".pre-commit-config.yaml"
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -61,7 +61,18 @@ setting you use.
 
 ## Preventing Commit of Merge Conflicts
 
-If you use `--conflict rej` (the default):
+If you use `--conflict inline` (the default) then you need to check for conflicts marks in your files: 
+```yaml title=".pre-commit-config.yaml"
+repos:
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v4.3.0
+      hooks:
+          # Prevent committing inline conflict markers
+          - id: check-merge-conflict
+            args: [--assume-in-merge]
+```
+
+If you use `--conflict rej` Then you need to reject all the generated `.rej` files:
 
 ```yaml title=".pre-commit-config.yaml"
 repos:
@@ -70,15 +81,9 @@ repos:
           # Prevent committing .rej files
           - id: forbidden-files
             name: forbidden files
-            entry: found Copier update rejection files; review them and remove them
+            entry: found Copier update rejection files; review and remove them before merging.
             language: fail
             files: "\\.rej$"
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.3.0
-      hooks:
-          # Prevent committing inline conflict markers
-          - id: check-merge-conflict
-            args: [--assume-in-merge]
 ```
 
 ## Never change the answers file manually

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -89,6 +89,12 @@ repos:
             files: "\\.rej$"
 ```
 
+!!! note
+
+    For shared project that use both "rej" and "inline" depending on the user,
+    you can add both repo to you `pre-commit-config.yaml` file, making sure that none
+    of these files are committed.
+
 ## Never change the answers file manually
 
 !!! important

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -84,16 +84,18 @@ repos:
           # Prevent committing .rej files
           - id: forbidden-files
             name: forbidden files
-            entry: found Copier update rejection files; review and remove them before merging.
+            description:
+                found Copier update rejection files; review and remove them before
+                merging.
             language: fail
             files: "\\.rej$"
 ```
 
 !!! note
 
-    For shared project that use both "rej" and "inline" depending on the user,
-    you can add both repo to you `pre-commit-config.yaml` file, making sure that none
-    of these files are committed.
+    For projects that use both `rej` and `inline` depending on each user's preference,
+    you can add both hooks to your `pre-commit-config.yaml` file, making sure that no
+    unresolved merge conflicts are committed.
 
 ## Never change the answers file manually
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -72,7 +72,8 @@ repos:
             args: [--assume-in-merge]
 ```
 
-If you use `--conflict rej` Then you need to reject all the generated `.rej` files:
+If you use `--conflict rej` then you need to review and remove all generated `.rej`
+files:
 
 ```yaml title=".pre-commit-config.yaml"
 repos:


### PR DESCRIPTION
- there was a inconsistence between the inline and rej default. as it's inline I changed the value in the corrected section
- as users won't need the 2 options at once, I split the 2 hooks.