### PR TITLE
docs: Use `pymdownx.highlight` instead of `codehilite`

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,8 +53,8 @@ extra_css:
 
 markdown_extensions:
   - admonition
-  - codehilite:
-      guess_lang: false
+  - pymdownx.highlight:
+      use_pygments: true
   - pymdownx.superfences:
       custom_fences:
         - name: mermaid


### PR DESCRIPTION
Closes #1364.

I preferred explicitness.