### PR TITLE
docs: mention Cruft for Cookiecutter in comparison on template updates

### DIFF
--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -29,7 +29,7 @@ docs! We don't want to be biased, but it's easy that we tend to be:
 | Context hooks                            | Yes[^5]                          | Yes                             | ?             |
 | Template in a subfolder                  | Not required, but you choose     | Yes, required                   | Yes, required |
 | Template package format                  | Git repo[^2], Git bundle, folder | Git or Mercurial repo, Zip file | NPM package   |
-| Template updates                         | **Yes**[^4]                      | No                              | No            |
+| Template updates                         | **Yes**[^4]                      | No[^6]                          | No            |
 | Templating engine                        | [Jinja][]                        | [Jinja][]                       | [EJS][]       |
 
 [jinja]: https://jinja.palletsprojects.com/
@@ -49,6 +49,8 @@ docs! We don't want to be biased, but it's easy that we tend to be:
     and extract smart diffs between them.
 
 [^5]: Context hooks are provided through the [`ContextHook` extension][context-hook].
+[^6]: Updates are possible through [Cruft][cruft].
 
 [context-hook]:
     https://github.com/copier-org/copier-templates-extensions#context-hook-extension
+[cruft]: https://github.com/cruft/cruft


### PR DESCRIPTION
I've added a footnote in the comparison on template updates for Cookiecutter that refers to [Cruft](https://github.com/cruft/cruft) as a tool that uses Cookiecutter to enable updates. I think Cruft should be mentioned for a fair comparison.