### PR TITLE
feat(choices): support questionary checkbox for multiple choices using `multiple: true`

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -150,6 +150,8 @@ Supported keys:
                 Some array: "[str, keeps, this, as, a, str]"
         ```
 
+-   **multiselect**: When set to `true`, allows multiple choices. The answer will be a
+    `list[T]` instead of a `T` where `T` is of type `type`.
 -   **default**: Leave empty to force the user to answer. Provide a default to save them
     from typing it if it's quite common. When using `choices`, the default must be the
     choice _value_, not its _key_, and it must match its _type_. If values are quite


### PR DESCRIPTION
This PR is a sequel to https://github.com/copier-org/copier/pull/1049, taking into account review comments and https://github.com/copier-org/copier/issues/750 design proposal.

This PR only include the `multiple: true` form as the advanced form needs more specification and design I think, and it mostly relies on https://github.com/RhetTbull/questionary-superprompt#multiple-option which is not part of questionary.
However, it remains compatible as it is possible to add the advanced part later.

WDYT ?