### PR TITLE
fix(actions): swap sha256sum for shasum -a 256

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,19 +48,21 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: generate cache key PY
-        shell: bash
+      - name: Get full Python version
+        id: full-python-version
+        shell: bash # Required for use of $GITHUB_OUTPUT in windows
         run:
-          echo "PY=$((python -VV; pip freeze) | sha256sum | cut -d' ' -f1)" >>
-          $GITHUB_ENV
+          echo version=$(python -c "import sys; print('-'.join(str(v) for v in
+          sys.version_info))") >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: |
             .cache
             .venv
           key:
-            cache|${{ runner.os }}|${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
-            hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+            cache|${{ runner.os }}|${{ steps.full-python-version.outputs.version }}|${{
+            hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{
+            hashFiles('.pre-commit-config.yaml') }}
       - name: Install dependencies
         run: |
           python -m pip install poetry poetry-dynamic-versioning
@@ -139,18 +141,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.10"
-      - name: generate cache key PY
+      - name: Get full Python version
+        id: full-python-version
         run:
-          echo "PY=$((python -VV; pip freeze) | sha256sum | cut -d' ' -f1)" >>
-          $GITHUB_ENV
+          echo version=$(python -c "import sys; print('-'.join(str(v) for v in
+          sys.version_info))") >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: |
             .cache
             .venv
           key:
-            cache|${{ runner.os }}|${{ env.PY }}|${{ hashFiles('pyproject.toml') }}|${{
-            hashFiles('poetry.lock') }}|${{ hashFiles('.pre-commit-config.yaml') }}
+            cache|${{ runner.os }}|${{ steps.full-python-version.outputs.version }}|${{
+            hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{
+            hashFiles('.pre-commit-config.yaml') }}
       - name: Install dependencies
         shell: bash
         run: |


### PR DESCRIPTION
This addresses an issue in macOS builds may be impacting caching. The command `sha256sum` which doesn't exist in `macOS-latest` is replaced with `shasum -a 256` which is present in both `ubuntu-latest` and `macOS-latest`

Closes #1389