### PR TITLE
fix: Address deprecation warning in `shutil.rmtree(onerror=...)`

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -1,6 +1,6 @@
 """Tools related to template management."""
-import sys
 import re
+import sys
 from collections import ChainMap, defaultdict
 from contextlib import suppress
 from dataclasses import field

--- a/copier/template.py
+++ b/copier/template.py
@@ -1,4 +1,5 @@
 """Tools related to template management."""
+import sys
 import re
 from collections import ChainMap, defaultdict
 from contextlib import suppress
@@ -198,11 +199,18 @@ class Template:
     def _cleanup(self) -> None:
         temp_clone = self._temp_clone()
         if temp_clone:
-            rmtree(
-                temp_clone,
-                ignore_errors=False,
-                onerror=handle_remove_readonly,
-            )
+            if sys.version_info >= (3, 12):
+                rmtree(
+                    temp_clone,
+                    ignore_errors=False,
+                    onexc=handle_remove_readonly,
+                )
+            else:
+                rmtree(
+                    temp_clone,
+                    ignore_errors=False,
+                    onerror=handle_remove_readonly,
+                )
 
     def _temp_clone(self) -> Optional[Path]:
         """Get the path to the temporary clone of the template.


### PR DESCRIPTION
Closes https://github.com/copier-org/copier/issues/1402