### PR TITLE
fix: skip excluded paths before rendering

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -371,8 +371,6 @@ class Worker:
         assert not dst_relpath.is_absolute()
         assert not expected_contents or not is_dir, "Dirs cannot have expected content"
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
-        if dst_relpath != Path(".") and self.match_exclude(dst_relpath):
-            return False
         previous_is_symlink = dst_abspath.is_symlink()
         try:
             previous_content: Union[bytes, Path]
@@ -676,6 +674,9 @@ class Worker:
                 part = Path(part).name
             rendered_parts.append(part)
         result = Path(*rendered_parts)
+        # Skip excluded paths.
+        if result != Path(".") and self.match_exclude(relpath):
+            return None
         if not is_template:
             templated_sibling = (
                 self.template.local_abspath


### PR DESCRIPTION
I've fixed a bug related to skipping excluded files, which may even contain malformed Jinja syntax. Before, Copier determined whether a file is skipped _after_ rendering it, which failed when the file contained malformed template syntax. Since the file should have been skipped, rendering should not have been attempted at all, so even malformed template syntax should not have mattered. Now, skipping excluded files happens _before_ a rendering attempt, so even malformed template syntax in excluded files is allowed.

This problem came up in a slightly different scenario where `copier.yml` contained `_envops` settings with Jinja statement markers, `_templates_suffix: ""`, and no subdirectory was configured, so that `copier.yml` was attempted to be rendered before the exclusion logic would have ignored it, which led to the reported problem in #1410. But it turned out that the root cause was more fundamental, which I've been able to fix with a simple change.

Fixes #1410.