### PR TITLE
docs: prefer "questionnaire" over "questionary"

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -108,7 +108,7 @@ class Worker:
             Specify the VCS tag/commit to use in the template.
 
         data:
-            Answers to the questionary defined in the template.
+            Answers to the questionnaire defined in the template.
 
         exclude:
             User-chosen additional [file exclusion patterns][exclude].
@@ -407,7 +407,7 @@ class Worker:
         return self._solve_render_conflict(dst_relpath)
 
     def _ask(self) -> None:
-        """Ask the questions of the questionary and record their answers."""
+        """Ask the questions of the questionnaire and record their answers."""
         result = AnswersMap(
             user_defaults=self.user_defaults,
             init=self.data,

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -55,7 +55,7 @@ they become available to the project template.
     your_email: ""
     ```
 
-    Will result in a questionary similar to:
+    Will result in a questionnaire similar to:
 
     <pre style="font-weight: bold">
     🎤 name_of_the_project
@@ -1357,7 +1357,7 @@ This allows you to keep separate the template metadata and the template code.
         1.  Ignore instructions for projects generated with the template.
 
     However, it is true that the value of this option can itself be templated. This would
-    let you have different templates that all use the same questionary, and the used
+    let you have different templates that all use the same questionnaire, and the used
     template would be saved as an answer. It would let the user update safely and change
     that option in the future.
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -107,7 +107,7 @@ copier update --defaults
 ```
 
 If you want to change just one question, and leave all others untouched, and don't want
-to go through the whole questionary again:
+to go through the whole questionnaire again:
 
 ```shell
 copier update --defaults --data updated_question="my new answer"


### PR DESCRIPTION
I've replaced all non-code occurrences of the word "questionary" by "questionnaire" except in `CHANGELOG.md`.

Follow-up of #1430 for consistency.