### PR TITLE
docs: enable automatic light/dark mode

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,10 @@ theme:
     - navigation.top
     - navigation.tracking
   palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
     - media: "(prefers-color-scheme: light)"
       scheme: default
       primary: deep orange
@@ -46,7 +50,7 @@ theme:
       accent: orange
       toggle:
         icon: material/weather-night
-        name: Switch to light mode
+        name: Switch to system preference
 
 extra_css:
   - css/mkdocstrings.css


### PR DESCRIPTION
Material for MkDocs v9.5.0 released [automatic light/dark mode](https://squidfunk.github.io/mkdocs-material/setup/changing-the-colors/#automatic-light-dark-mode) for everybody. I've enabled it in our docs. WDYT?