### PR TITLE
build(deps): bump jinja

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -438,13 +438,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.2"
+version = "3.1.3"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
-    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
 ]
 
 [package.dependencies]
@@ -1675,5 +1675,5 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8,<4.0"
-content-hash = "556f16b27c42c9c318bbb8717b435b753013f1c4c706657ec683aceba0389f90"
+python-versions = ">=3.8"
+content-hash = "68ae53c03a93971c92d62fdd18a7635f2b9a7d2a42317b781777412020227e01"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ copier = "copier.__main__:copier_app_run"
 python = ">=3.8"
 colorama = ">=0.4.6"
 decorator = ">=5.1.1"
-dunamai = ">=1.7.0"
+# HACK Remove markers when https://github.com/mtkennerly/dunamai/issues/74 is fixed
+dunamai = { version = ">=1.7.0", markers = "python_version < '4'" }
 funcy = ">=1.17"
-jinja2 = ">=3.1.1"
+jinja2 = ">=3.1.3"
 jinja2-ansible-filters = ">=1.3.1"
 packaging = ">=23.0"
 pathspec = ">=0.9.0"
@@ -74,7 +75,7 @@ mkdocstrings = { version = ">=0.19.0", extras = ["python"] }
 optional = true
 
 [tool.poetry.group.build.dependencies]
-poetry-dynamic-versioning = ">=1.1.0"
+poetry-dynamic-versioning = { version = ">=1.1.0", markers = "python_version < '4'" }
 
 [tool.poe.tasks.clean]
 script = "devtasks:clean"


### PR DESCRIPTION
To do so, it required to add the `python_version < 4` marker to dependencies that still use upper bound markers.

I opened https://github.com/mtkennerly/dunamai/issues/74 to the only relevant one. In the case of poetry-dynamic-versioning, it's just a build-time dependency, so I don't really care it has that marker, as long as I build using Python 3.