### PR TITLE
add 'pygrep' lint group

### DIFF
--- a/copier/tools.py
+++ b/copier/tools.py
@@ -76,7 +76,7 @@ def printf(
     if not style:
         return action + _msg
 
-    out = style + [action] + Style.RESET + [INDENT, _msg]  # type: ignore
+    out = style + [action] + Style.RESET + [INDENT, _msg]  # type: ignore[operator]
     print(*out, sep="", file=file_)
     return None  # HACK: Satisfy MyPy
 

--- a/devtasks.py
+++ b/devtasks.py
@@ -60,7 +60,7 @@ def lint(recycle_container=False):
     try:
         local["nix"].with_cwd(HERE)[args] & TEE
     except CommandNotFound:
-        _logger.warn("Nix not found; fallback to a container")
+        _logger.warning("Nix not found; fallback to a container")
         runner = local.get("podman", "docker")
         try:
             (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ style = "pep440"
 vcs = "git"
 
 [tool.ruff.lint]
-extend-select = ["B", "D", "E", "F", "I", "UP"]
+extend-select = ["B", "D", "E", "F", "I", "PGH", "UP"]
 extend-ignore = ['B028', "B904", "D105", "D107", "E501"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -465,8 +465,8 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
         ({"type": "str"}, True, does_not_raise()),
         ({"type": "str"}, False, does_not_raise()),
         ({"type": "str"}, Decimal(1.1), does_not_raise()),
-        ({"type": "str"}, Enum("A", ["a", "b"], type=str).a, does_not_raise()),  # type: ignore
-        ({"type": "str"}, Enum("A", ["a", "b"]).a, pytest.raises(ValueError)),  # type: ignore
+        ({"type": "str"}, Enum("A", ["a", "b"], type=str).a, does_not_raise()),  # type: ignore[attr-defined]
+        ({"type": "str"}, Enum("A", ["a", "b"]).a, pytest.raises(ValueError)),  # type: ignore[attr-defined]
         ({"type": "str"}, object(), pytest.raises(ValueError)),
         ({"type": "str"}, {}, pytest.raises(ValueError)),
         ({"type": "str"}, [], pytest.raises(ValueError)),


### PR DESCRIPTION
what is says on the tin

- reduces the scope of mypy errors
- prevents accidentally 'hiding' new errors due to blanket lint suppression