### PR TITLE
style: add 'complexity' lint group to ruff config

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -823,7 +823,7 @@ class Worker:
         self._apply_update()
         self._print_message(self.template.message_after_update)
 
-    def _apply_update(self):
+    def _apply_update(self):  # noqa: C901
         git = get_git()
         subproject_top = Path(
             git(

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -344,7 +344,7 @@ class Question:
         """Render and obtain the placeholder."""
         return self.render_value(self.placeholder)
 
-    def get_questionary_structure(self) -> AnyByStrDict:
+    def get_questionary_structure(self) -> AnyByStrDict:  # noqa: C901
         """Get the question in a format that the questionary lib understands."""
         lexer = None
         result: AnyByStrDict = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ style = "pep440"
 vcs = "git"
 
 [tool.ruff.lint]
-extend-select = ["B", "D", "E", "F", "FA", "I", "PGH", "UP"]
+extend-select = ["B", "C90", "D", "E", "F", "FA", "I", "PGH", "UP"]
 extend-ignore = ['B028', "B904", "D105", "D107", "E501"]
 
 [tool.ruff.lint.per-file-ignores]


### PR DESCRIPTION
adds the 'complexity' lint group to the ruff config.

I believe this brings the ruff config inline with the flake8 config, and therefore makes the flake8 linting redundant.

for reference, the flake8 config is:

```ini
[flake8]
ignore = E203, E501, W503, B950
max-line-length = 88
select = C,E,F,W,B
per-file-ignores=
    __init__.py:F401

```