### PR TITLE
feat: add support for validating multi-select choice answers

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -435,7 +435,9 @@ class Worker:
                 answer = question.parse_answer(result.init[var_name])
                 # Try to validate the answer value if the question has a
                 # validator.
-                question.validate_answer(answer)
+                err_msg = question.validate_answer(answer)
+                if err_msg:
+                    raise ValueError(err_msg)
                 # At this point, the answer value is valid. Do not ask the
                 # question again, but set answer as the user's answer instead.
                 result.user[var_name] = answer

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -10,13 +10,12 @@ from functools import cached_property
 from hashlib import sha512
 from os import urandom
 from pathlib import Path
-from typing import Any, Callable, Mapping, Sequence
+from typing import Any, Callable, Literal, Mapping, Sequence
 
 import yaml
 from jinja2 import UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from prompt_toolkit.lexers import PygmentsLexer
-from prompt_toolkit.validation import ValidationError
 from pydantic import ConfigDict, Field, field_validator
 from pydantic.dataclasses import dataclass
 from pydantic_core.core_schema import ValidationInfo
@@ -346,6 +345,14 @@ class Question:
 
     def get_questionary_structure(self) -> AnyByStrDict:
         """Get the question in a format that the questionary lib understands."""
+
+        def _validate(answer: str) -> str | Literal[True]:
+            try:
+                ans = self.parse_answer(answer)
+            except Exception:
+                return "Invalid input"
+            return self.validate_answer(ans) or True
+
         lexer = None
         result: AnyByStrDict = {
             "filter": self.cast_answer,
@@ -381,7 +388,8 @@ class Question:
             placeholder = self.get_placeholder()
             if placeholder:
                 result["placeholder"] = placeholder
-            result["validate"] = self.validate_answer
+        if questionary_type in {"input", "checkbox"}:
+            result["validate"] = _validate
         result.update({"type": questionary_type})
         return result
 
@@ -398,20 +406,15 @@ class Question:
         """Get the value for multiline."""
         return cast_to_bool(self.render_value(self.multiline))
 
-    def validate_answer(self, answer) -> bool:
+    def validate_answer(self, answer: Any) -> str:
         """Validate user answer."""
         try:
-            ans = self.parse_answer(answer)
-        except Exception:
-            return False
-
-        try:
-            err_msg = self.render_value(self.validator, {self.var_name: ans}).strip()
+            err_msg = self.render_value(self.validator, {self.var_name: answer}).strip()
         except Exception as error:
-            raise ValidationError(message=str(error)) from error
+            return str(error)
         if err_msg:
-            raise ValidationError(message=err_msg)
-        return True
+            return err_msg
+        return ""
 
     def get_when(self) -> bool:
         """Get skip condition for question."""


### PR DESCRIPTION
I've added support for validating answers of multi-select choice questions. While `select` prompts (Copier single-select choice questions) only support per-choice validation, [`checkbox` prompts support answer validation](https://github.com/tmbo/questionary/blob/c894eeffbeb2f1448a108163998ba95b72a8e32a/questionary/prompts/checkbox.py#L32) similar to `text` prompts. Implementation-wise, there's a difference between `text` prompt validation and `checkbox` prompt validation, as `text` prompt validation supports raising `prompt_toolkit.validation.ValidationError` exceptions in the `validate` callable while `checkbox` prompt validation requires the `validate` callable to return an error message string or `True` when the answer is valid. Fortunately, also `text` prompt validation supports this signature, so there's a unified `validate` callable for both prompt types now.