### PR TITLE
fix: preserve choices order in answers to multi-select choice questions

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -439,7 +439,11 @@ class Question:
     def parse_answer(self, answer: Any) -> Any:
         """Parse the answer according to the question's type."""
         if self.multiselect:
-            return [self._parse_answer(a) for a in answer]
+            answer = [self._parse_answer(a) for a in answer]
+            choices = (
+                self.cast_answer(choice.value) for choice in self._formatted_choices
+            )
+            return [choice for choice in choices if choice in answer]
         return self._parse_answer(answer)
 
     def _parse_answer(self, answer: Any) -> Any:


### PR DESCRIPTION
I've fixed &ndash; because I consider it a bug &ndash; the order of choice items in answers to multi-select choice questions.

Consider this `copier.yml` example:

```yaml
python_versions:
  type: str
  help: Which Python versions would you like your project to support?
  choices:
    - "3.8"
    - "3.9"
    - "3.10"
    - "3.11"
    - "3.12"
  multiselect: true
```

When passing the answer via API, e.g.

```python
copier.run_copy(src, dst, data={"python_versions": ["3.12", "3.10", "3.11"]})
```

then the answer is currently recorded as `["3.12", "3.10", "3.11"]`. IMHO, the recorded answer should be `["3.10", "3.11", "3.12"]` though. When using interactive prompting, then the answer is guaranteed to preserve the order from the `choices` list in `copier.yml`, so interactive prompting and API may not lead to identical results. I don't think that's good.

My motivation is this: I have a template file `pyproject.toml.jinja` where I need to specify the minimum Python version, ideally like this:

```toml
[tool.poetry.dependencies]
python = ">={{ python_versions | first }}"
```

It's only this simple (i.e., by simply using the `first` filter) when I can rely on the order of the `choices` list items in `copier.yml` though. If I can't rely on it, then I need to do some not too trivial sorting &ndash; simple string sorting is insufficient.

WDYT, @copier-org/maintainers?