### PR TITLE
fix: ignore empty YAML documents in `copier.yml`

### DIFF
--- a/copier/template.py
+++ b/copier/template.py
@@ -88,7 +88,7 @@ def load_template_config(conf_path: Path, quiet: bool = False) -> AnyByStrDict:
 
     with conf_path.open("rb") as f:
         try:
-            flattened_result = lflatten(yaml.load_all(f, Loader=_Loader))
+            flattened_result = lflatten(filter(None, yaml.load_all(f, Loader=_Loader)))
         except yaml.parser.ParserError as e:
             raise InvalidConfigFileError(conf_path, quiet) from e
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -191,6 +191,32 @@ def test_valid_multi_section(tmp_path: Path) -> None:
     }
 
 
+def test_empty_section(tmp_path: Path) -> None:
+    """Empty sections are ignored."""
+    build_file_tree(
+        {
+            (tmp_path / "copier.yml"): (
+                """\
+                ---
+                ---
+
+                ---
+                your_age:
+                    type: int
+                your_name:
+                    type: str
+                ---
+                """
+            ),
+        }
+    )
+    template = Template(str(tmp_path))
+    assert template.questions_data == {
+        "your_age": {"type": "int"},
+        "your_name": {"type": "str"},
+    }
+
+
 def test_config_data_empty() -> None:
     template = Template("tests/demo_config_empty")
     assert template.config_data == {}


### PR DESCRIPTION
I've fixed loading `copier.yml` with empty YAML documents. The fix is simple: `yaml.load_all()` returns a sequence of YAML documents, and empty documents are represented by `None`, so I'm filtering `None` items using `filter(None, yaml.load_all(...))`. [`filter(None, <sequence>)` actually filters any falsy items](https://docs.python.org/3/library/functions.html#filter) – not only `None`s –, but that's no problem in this case.

Before, Copier raised an error

```
TypeError: 'NoneType' object is not subscriptable
```

which is not very helpful for debugging. Now, an empty YAML document is simply ignored. Of course, there's little sense in having empty YAML documents, but it's easy to have one unintentionally, e.g. when the file ends with the `---` marker:

```yaml
question:
  type: str
---
!include common.yml
---
```

In this regard, the YAML document syntax is a bit confusing IMO because a leading `---` marker at the beginning of the file does not cause an empty YAML document. I think Copier should not be strict about it and ease template developers' lives. See also the confusion about this in #1496.