### PR TITLE
feat(tasks): allow skipping tasks with the  flag

### DIFF
--- a/copier/cli.py
+++ b/copier/cli.py
@@ -157,6 +157,11 @@ class _Subcommand(cli.Application):  # type: ignore[misc]
             "Allow templates with unsafe features (Jinja extensions, migrations, tasks)"
         ),
     )
+    skip_tasks = cli.Flag(
+        ["-T", "--skip-tasks"],
+        default=False,
+        help="Skip template tasks execution",
+    )
 
     @cli.switch(  # type: ignore[misc]
         ["-d", "--data"],

--- a/copier/main.py
+++ b/copier/main.py
@@ -162,6 +162,9 @@ class Worker:
 
         skip_answered:
             When `True`, skip questions that have already been answered.
+
+        skip_tasks:
+            When `True`, skip template tasks execution.
     """
 
     src_path: str | None = None
@@ -182,6 +185,7 @@ class Worker:
     context_lines: PositiveInt = 3
     unsafe: bool = False
     skip_answered: bool = False
+    skip_tasks: bool = False
 
     answers: AnswersMap = field(default_factory=AnswersMap, init=False)
     _cleanup_hooks: list[Callable[[], None]] = field(default_factory=list, init=False)
@@ -766,7 +770,8 @@ class Worker:
             if not self.quiet:
                 # TODO Unify printing tools
                 print("")  # padding space
-            self._execute_tasks(self.template.tasks)
+            if not self.skip_tasks:
+                self._execute_tasks(self.template.tasks)
         except Exception:
             if not was_existing and self.cleanup_on_error:
                 rmtree(self.subproject.local_abspath)

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1317,7 +1317,7 @@ Skip template [tasks][tasks] execution, if set to `True`.
 
 !!! question "Does it imply `--trust`?"
 
-    This flag does not imply `--trust`, and will do nothing if not used with.
+    This flag does not imply [`--trust`][unsafe], and will do nothing if not used with.
 
 ### `subdirectory`
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1313,7 +1313,7 @@ Skip template [tasks][tasks] execution, if set to `True`.
 
 !!! note
 
-    It only skips tasks, not migration tasks.
+    It only skips [tasks][tasks], not [migration tasks][migrations].
 
 !!! question "Does it imply `--trust`?"
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1303,6 +1303,22 @@ exist.
     {{999999999999999999999999999999999|ans_random|hash('sha512')}}
     ```
 
+### `skip_tasks`
+
+-   Format: `bool`
+-   CLI Flags: `-T`, `--skip-tasks`
+-   Default value: `False`
+
+Skip template tasks execution, if set to `True`.
+
+!!! note
+
+    It only skip tasks, not migration tasks.
+
+!!! question "Does it imply `--trust` ?"
+
+    This flag does not imply `--trust`, and will do nothing if not used with.
+
 ### `subdirectory`
 
 -   Format: `str`

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1313,7 +1313,7 @@ Skip template tasks execution, if set to `True`.
 
 !!! note
 
-    It only skip tasks, not migration tasks.
+    It only skips tasks, not migration tasks.
 
 !!! question "Does it imply `--trust` ?"
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1309,7 +1309,7 @@ exist.
 -   CLI Flags: `-T`, `--skip-tasks`
 -   Default value: `False`
 
-Skip template tasks execution, if set to `True`.
+Skip template [tasks][tasks] execution, if set to `True`.
 
 !!! note
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1315,7 +1315,7 @@ Skip template tasks execution, if set to `True`.
 
     It only skips tasks, not migration tasks.
 
-!!! question "Does it imply `--trust` ?"
+!!! question "Does it imply `--trust`?"
 
     This flag does not imply `--trust`, and will do nothing if not used with.
 

--- a/tests/demo_migrations/tasks.py
+++ b/tests/demo_migrations/tasks.py
@@ -3,10 +3,8 @@ import os
 import os.path
 import sys
 from contextlib import suppress
-from subprocess import check_call
 
 with open("created-with-tasks.txt", "a", newline="\n") as cwt:
     cwt.write(" ".join([os.environ["STAGE"]] + sys.argv[1:]) + "\n")
-    check_call(["git", "init"])
     with suppress(FileNotFoundError):
         os.unlink("delete-in-tasks.txt")

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -53,6 +53,23 @@ def test_copy_tasks(template_path: str, tmp_path: Path) -> None:
     assert (tmp_path / "pyfile").is_file()
 
 
+def test_copy_skip_tasks(template_path: str, tmp_path: Path) -> None:
+    copier.run_copy(
+        template_path,
+        tmp_path,
+        quiet=True,
+        defaults=True,
+        overwrite=True,
+        unsafe=True,
+        skip_tasks=True,
+    )
+    assert not (tmp_path / "hello").exists()
+    assert not (tmp_path / "hello").is_dir()
+    assert not (tmp_path / "hello" / "world").exists()
+    assert not (tmp_path / "bye").is_file()
+    assert not (tmp_path / "pyfile").is_file()
+
+
 def test_pretend_mode(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(


### PR DESCRIPTION
This PR add a `-T/--skip-tasks` flag allowing to skip template tasks execution.

Some known use cases I have:
- while testing my template, I want to be able to perform multiple rendering with the extensions actives but without running tasks (which may be slow or depending on connection...)
- when applying a template with some bootstrap tasks on an existing project, I want to be able to skip the bootstrap tasks because I know they will fail
- when applying a third party template that I trust, I want to only skip tasks for some reason (known to break, not compatible with the environment...)

Should fix #1415
