### PR TITLE
docs(main): add the missing `skip_answered` docstring

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -159,6 +159,9 @@ class Worker:
             When `True`, allow usage of unsafe templates.
 
             See [unsafe][]
+
+        skip_answered:
+            When `True`, skip questions that have already been answered.
     """
 
     src_path: str | None = None


### PR DESCRIPTION
Just add a missing docstring.

Extracted from #1561