### PR TITLE
Do not overwrite identical files

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -415,7 +415,7 @@ class Worker:
                 quiet=self.quiet,
                 file_=sys.stderr,
             )
-            return True
+            return is_dir
         return self._solve_render_conflict(dst_relpath)
 
     def _ask(self) -> None:

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -307,8 +307,8 @@ def test_timestamp_identical(tmp_path: Path) -> None:
     modification_time_after = os.path.getmtime(tmp_path / "a.noeof.txt")
 
     assert modification_time_before == modification_time_after
-    
-    
+
+
 def test_skip_if_exists_rendered_patterns(tmp_path: Path) -> None:
     copier.run_copy("tests/demo_skip_dst", tmp_path)
     copier.run_copy(

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import filecmp
 import platform
 import stat
@@ -297,6 +298,16 @@ def test_skip_if_exists(tmp_path: Path) -> None:
     assert (tmp_path / "meh" / "c.noeof.txt").read_text() == "SKIPPED"
 
 
+def test_timestamp_identical(tmp_path: Path) -> None:
+    copier.run_copy(str(Path("tests", "demo_skip_dst")), tmp_path)
+    modification_time_before = os.path.getmtime(tmp_path / "a.noeof.txt")
+    sleep(2)
+    copier.run_copy(str(Path("tests", "demo_skip_dst")), tmp_path)
+    modification_time_after = os.path.getmtime(tmp_path / "a.noeof.txt")
+
+    assert modification_time_before == modification_time_after
+    
+    
 def test_skip_if_exists_rendered_patterns(tmp_path: Path) -> None:
     copier.run_copy("tests/demo_skip_dst", tmp_path)
     copier.run_copy(

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import os
 import filecmp
+import os
 import platform
 import stat
 import sys

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -9,6 +9,7 @@ from contextlib import nullcontext as does_not_raise
 from decimal import Decimal
 from enum import Enum
 from pathlib import Path
+from time import sleep
 from typing import Any, ContextManager
 
 import pytest


### PR DESCRIPTION
If _render_allowed identifies identical source and target, then only returns True if the path refers to a directory, not a file.