### PR TITLE
test: remove useless file in test template tree

### DIFF
--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -352,7 +352,6 @@ def test_templated_prompt_with_conditional_choices(
                             validator: "{% if cloud != 'GCP' %}Requires GCP{% endif %}"
                 """
             ),
-            (src / "result.jinja"): "{{question}}",
         }
     )
     tui = spawn(


### PR DESCRIPTION
Just some minor cleanup: This file in the test template tree is not used. It probably originates from a copy & paste error.