### PR TITLE
Fix repository name collision

### DIFF
--- a/tests/demo/doc/mañana.txt
+++ b/tests/demo/doc/mañana.txt
@@ -1,0 +1,2 @@
+UTF-8（ユーティーエフはち、ユーティーエフエイト）はISO/IEC 10646(UCS)とUnicodeで使える8ビット符号単位の文字符号化形式及び文字符号化スキーム。
+正式名称は、ISO/IEC 10646では‘UCS Transformation Format 8’、Unicodeでは‘Unicode Transformation Format-8’という。両者はISO/IEC 10646とUnicodeのコード重複範囲で互換性がある。RFCにも仕様がある[1]。


### PR DESCRIPTION
Two versions of `tests/demo/doc/mañana.txt` existed in the repository at the same time, each of them with unique filename.

This was possible because of git ill-formed approach utilizing filesystem-dependent filename representations by default.

It's likely that the mentioned file was added twice: both on Linux and macOS, and due to filename encoding differences between the systems, git permitted it.

This PR fixes #1595 by:
- first removing the affected file
- changing faulty git defaults ( basically - enabling UTF-8 support)
- re-adding the file