### PR TITLE
fix: render `default` list items for multi-select choice questions

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -432,7 +432,11 @@ class Question:
             template = self.jinja_env.from_string(value)
         except TypeError:
             # value was not a string
-            return value
+            return (
+                [self.render_value(item) for item in value]
+                if isinstance(value, list)
+                else value
+            )
         try:
             return template.render({**self.answers.combined, **(extra_answers or {})})
         except UndefinedError as error:


### PR DESCRIPTION
I've fixed a bug related to rendering templated list items which was discovered when trying to template an item in the default value list of a multi-select choice question (see #1594). The root cause was not directly related to rendering the default value but rather caused by the `Question.render_value()` method passing any non-string value through. To resolve this problem fundamentally, I've extended the `Question.render_value()` method to recurse into a list and render each list item individually. I think we should add support for recursing into a `dict` in a follow-up PR and, thus, add support for rendering even deeply nested value in YAML data (e.g. actual, i.e. non-string, YAML choice items and default values to `type: yaml` questions).

Fixes #1594.