### PR TITLE
fix: Fixes documentation for pre-commit update rule for '.rej' files

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -84,7 +84,7 @@ repos:
           # Prevent committing .rej files
           - id: forbidden-files
             name: forbidden files
-            description:
+            entry:
                 found Copier update rejection files; review and remove them before
                 merging.
             language: fail


### PR DESCRIPTION
## Description of the problem

I've followed the [official documentation _Preventing Commit of Merge Conflicts_](https://copier.readthedocs.io/en/stable/updating/#preventing-commit-of-merge-conflicts).

When I've tried to commit a `.rej` file, `pre-commit` complains that a key is missing:

```
❯ git commit                                                                                                           
An error has occurred: InvalidConfigError:                                                                          
==> File .pre-commit-config.yaml                                                                                    
==> At Config()                                                                                                     
==> At key: repos                                                                                                   
==> At Repository(repo='local')                                                                                     
==> At key: hooks                                                                                                   
==> At Hook(id='forbidden-files')                                                                                                                                                                                                       
=====> Missing required key: entry
Check the log at ~/.cache/pre-commit/pre-commit.log
```

## Solution proposed

The [official documentation of `pre-commit` `fail` language](https://pre-commit.com/#fail) refers to the `entry` key instead of the `description` key. This has fixed the problem previously raised by `pre-commit`.

This P.R only fixes the documentation related to `pre-commit` rule.

## Software versions

### Python

```
❯ python -V
Python 3.10.12
```

### `pre-commit`

Problem encountered with `pre-commit` `3.3.3` and `3.7.0`