### PR TITLE
ci: add runner architecture to cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,10 +59,15 @@ jobs:
           path: |
             .cache
             .venv
+          # prettier-ignore
           key:
-            cache|${{ runner.os }}|${{ steps.full-python-version.outputs.version }}|${{
-            hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{
-            hashFiles('.pre-commit-config.yaml') }}
+            cache-
+            ${{ runner.os }}-
+            ${{ runner.arch }}-
+            ${{ steps.full-python-version.outputs.version }}-
+            ${{ hashFiles('pyproject.toml') }}-
+            ${{ hashFiles('poetry.lock') }}-
+            ${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install dependencies
         run: |
           python -m pip install poetry poetry-dynamic-versioning
@@ -113,9 +118,12 @@ jobs:
             .devenv
             .direnv
             .venv
+          # prettier-ignore
           key:
-            direnv|${{ runner.os }}|${{ hashFiles('pyproject.toml', '*.lock', '*.nix')
-            }}
+            direnv-
+            ${{ runner.os }}-
+            ${{ runner.arch }}-
+            ${{ hashFiles('pyproject.toml', '*.lock', '*.nix') }}
 
       # Check direnv works as expected
       - uses: JRMurr/direnv-nix-action@v3
@@ -151,10 +159,15 @@ jobs:
           path: |
             .cache
             .venv
+          # prettier-ignore
           key:
-            cache|${{ runner.os }}|${{ steps.full-python-version.outputs.version }}|${{
-            hashFiles('pyproject.toml') }}|${{ hashFiles('poetry.lock') }}|${{
-            hashFiles('.pre-commit-config.yaml') }}
+            cache-
+            ${{ runner.os }}-
+            ${{ runner.arch }}-
+            ${{ steps.full-python-version.outputs.version }}-
+            ${{ hashFiles('pyproject.toml') }}-
+            ${{ hashFiles('poetry.lock') }}-
+            ${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install dependencies
         shell: bash
         run: |


### PR DESCRIPTION
`macos-latest` has been bumped from macOS 12 (x86_64-based) to macOS 14 (ARM-based). Yesterday, macOS 14 didn't offer binaries for Python 3.8 and 3.9, which led to #1604. But it seems GitHub has added those binaries now. Yet our CI checks now run on heterogeneous runner architectures: x86_64 for Linux/Windows and ARM for macOS. Our current cache key does not contain the runner architecture, so  files built for x86_64 might be restored on the ARM runner until that cache gets updated with files built for ARM. So, I've added the architecture of the runner to the cache key which should fix immediate issues and make us more robust against similar changes in the future.

While at it, I took the opportunity to reformat the cache keys to use a - separator, which seems more common according to [GitHub's documentation](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#example-using-the-cache-action). I also took the liberty and added a nasty # prettier-ignore comment above the cache key to format it manually because Prettier's line wrapping is (IMHO) really ugly and difficult to read here.

Supersedes #1604.