### PR TITLE
build(lint): use local `ruff` executable

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,17 +1,1 @@
-# SEE https://github.com/direnv/direnv/wiki/Python#poetry
-layout_poetry() {
-    VIRTUAL_ENV=$(poetry env info --path 2>/dev/null ; true)
-
-    if [[ -z $VIRTUAL_ENV || ! -d $VIRTUAL_ENV ]]; then
-        log_status "No virtual environment exists. Executing \`poetry install\` to create one."
-        poetry install --with dev,docs
-        VIRTUAL_ENV=$(poetry env info --path)
-    fi
-
-    PATH_add "$VIRTUAL_ENV/bin"
-    export POETRY_ACTIVE=1
-    export VIRTUAL_ENV
-}
-
 use flake . --impure --accept-flake-config --extra-experimental-features 'nix-command flakes'
-layout_poetry

--- a/copier/__main__.py
+++ b/copier/__main__.py
@@ -1,4 +1,5 @@
 """Copier CLI entrypoint."""
+
 from .cli import CopierApp
 
 # HACK https://github.com/nix-community/poetry2nix/issues/504

--- a/copier/cli.py
+++ b/copier/cli.py
@@ -84,21 +84,18 @@ class CopierApp(cli.Application):  # type: ignore[misc]
     """The Copier CLI application."""
 
     DESCRIPTION = "Create a new project from a template."
-    DESCRIPTION_MORE = (
-        dedent(
-            """\
+    DESCRIPTION_MORE = dedent(
+        """\
             Docs in https://copier.readthedocs.io/
 
             """
-        )
-        + (
-            colors.yellow
-            | dedent(
-                """\
+    ) + (
+        colors.yellow
+        | dedent(
+            """\
                 WARNING! Use only trusted project templates, as they might
                 execute code with the same level of access as your user.\n
                 """
-            )
         )
     )
     VERSION = copier_version()
@@ -201,7 +198,10 @@ class _Subcommand(cli.Application):  # type: ignore[misc]
         self.data.update(updates_without_cli_overrides)
 
     def _worker(
-        self, src_path: Optional[str] = None, dst_path: str = ".", **kwargs: Any  # noqa: FA100
+        self,
+        src_path: Optional[str] = None,
+        dst_path: str = ".",
+        **kwargs: Any,  # noqa: FA100
     ) -> Worker:
         """Run Copier's internal API using CLI switches.
 

--- a/copier/main.py
+++ b/copier/main.py
@@ -1,4 +1,5 @@
 """Main functions and classes, used to generate or update projects."""
+
 from __future__ import annotations
 
 import os
@@ -204,14 +205,12 @@ class Worker:
         return self
 
     @overload
-    def __exit__(self, type: None, value: None, traceback: None) -> None:
-        ...
+    def __exit__(self, type: None, value: None, traceback: None) -> None: ...
 
     @overload
     def __exit__(
         self, type: type[BaseException], value: BaseException, traceback: TracebackType
-    ) -> None:
-        ...
+    ) -> None: ...
 
     def __exit__(
         self,
@@ -488,7 +487,9 @@ class Worker:
                 # Try to validate the answer value if the question has a
                 # validator.
                 if err_msg := question.validate_answer(answer):
-                    raise ValueError(f"Validation error for question '{var_name}': {err_msg}")
+                    raise ValueError(
+                        f"Validation error for question '{var_name}': {err_msg}"
+                    )
                 # At this point, the answer value is valid. Do not ask the
                 # question again, but set answer as the user's answer instead.
                 result.user[var_name] = answer

--- a/copier/subproject.py
+++ b/copier/subproject.py
@@ -2,6 +2,7 @@
 
 A *subproject* is a project that gets rendered and/or updated with Copier.
 """
+
 from __future__ import annotations
 
 from dataclasses import field

--- a/copier/template.py
+++ b/copier/template.py
@@ -1,4 +1,5 @@
 """Tools related to template management."""
+
 from __future__ import annotations
 
 import re

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -1,4 +1,5 @@
 """Some utility functions."""
+
 from __future__ import annotations
 
 import errno

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -1,4 +1,5 @@
 """Functions used to load user data."""
+
 from __future__ import annotations
 
 import json

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -1,4 +1,5 @@
 """Utilities related to VCS."""
+
 from __future__ import annotations
 
 import os

--- a/devtasks.py
+++ b/devtasks.py
@@ -1,4 +1,5 @@
 """Development helper tasks."""
+
 import logging
 import shutil
 from pathlib import Path

--- a/flake.nix
+++ b/flake.nix
@@ -98,6 +98,19 @@
                 taplo
               ];
               difftastic.enable = true;
+              languages.python = {
+                enable = true;
+                poetry = {
+                  enable = true;
+                  install = {
+                    enable = true;
+                    installRootPackage = true;
+                    groups = ["dev" "docs"];
+                  };
+                  activate.enable = true;
+                  package = pkgs.poetry;
+                };
+              };
               pre-commit.hooks = {
                 alejandra.enable = true;
                 commitizen.enable = true;

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,15 @@
                   types_or = ["python" "pyi"];
                   require_serial = true;
                 };
+                poetry-ruff-format = {
+                  enable = true;
+                  name = "ruff-format";
+                  description = "Run 'ruff format' for extremely fast Python formatting";
+                  entry = "''${pkgs.poetry}/bin/poetry run -C $DEVENV_ROOT ruff format --force-exclude";
+                  language = "system";
+                  types_or = ["python" "pyi"];
+                  require_serial = true;
+                };
                 taplo.enable = true;
               };
             }

--- a/flake.nix
+++ b/flake.nix
@@ -47,6 +47,12 @@
             inherit python version;
             name = "copier-${version}";
             projectDir = ./.;
+            overrides = pkgs.poetry2nix.overrides.withDefaults (final: prev: {
+              # Use official `ruff` package from pypi.org
+              ruff = prev.ruff.override {
+                preferWheel = true;
+              };
+            });
 
             # Trick poetry-dynamic-versioning into using our version
             POETRY_DYNAMIC_VERSIONING_BYPASS = version;
@@ -94,7 +100,6 @@
                 commitizen
                 mypy
                 nodePackages.prettier
-                ruff
                 taplo
               ];
               difftastic.enable = true;
@@ -128,7 +133,15 @@
                   # HACK https://github.com/prettier/prettier/issues/9430
                   "^tests/demo"
                 ];
-                ruff.enable = true;
+                poetry-ruff = {
+                  enable = true;
+                  name = "ruff";
+                  description = "Run 'ruff' for extremely fast Python linting";
+                  entry = "''${pkgs.poetry}/bin/poetry run -C $DEVENV_ROOT ruff check --force-exclude --fix --exit-non-zero-on-fix";
+                  language = "system";
+                  types_or = ["python" "pyi"];
+                  require_serial = true;
+                };
                 taplo.enable = true;
               };
             }

--- a/poetry.lock
+++ b/poetry.lock
@@ -1446,6 +1446,32 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "ruff"
+version = "0.4.4"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "ruff-0.4.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:29d44ef5bb6a08e235c8249294fa8d431adc1426bfda99ed493119e6f9ea1bf6"},
+    {file = "ruff-0.4.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c4efe62b5bbb24178c950732ddd40712b878a9b96b1d02b0ff0b08a090cbd891"},
+    {file = "ruff-0.4.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c8e2f1e8fc12d07ab521a9005d68a969e167b589cbcaee354cb61e9d9de9c15"},
+    {file = "ruff-0.4.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:60ed88b636a463214905c002fa3eaab19795679ed55529f91e488db3fe8976ab"},
+    {file = "ruff-0.4.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b90fc5e170fc71c712cc4d9ab0e24ea505c6a9e4ebf346787a67e691dfb72e85"},
+    {file = "ruff-0.4.4-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:8e7e6ebc10ef16dcdc77fd5557ee60647512b400e4a60bdc4849468f076f6eef"},
+    {file = "ruff-0.4.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9ddb2c494fb79fc208cd15ffe08f32b7682519e067413dbaf5f4b01a6087bcd"},
+    {file = "ruff-0.4.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c51c928a14f9f0a871082603e25a1588059b7e08a920f2f9fa7157b5bf08cfe9"},
+    {file = "ruff-0.4.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b5eb0a4bfd6400b7d07c09a7725e1a98c3b838be557fee229ac0f84d9aa49c36"},
+    {file = "ruff-0.4.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:b1867ee9bf3acc21778dcb293db504692eda5f7a11a6e6cc40890182a9f9e595"},
+    {file = "ruff-0.4.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1aecced1269481ef2894cc495647392a34b0bf3e28ff53ed95a385b13aa45768"},
+    {file = "ruff-0.4.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9da73eb616b3241a307b837f32756dc20a0b07e2bcb694fec73699c93d04a69e"},
+    {file = "ruff-0.4.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:958b4ea5589706a81065e2a776237de2ecc3e763342e5cc8e02a4a4d8a5e6f95"},
+    {file = "ruff-0.4.4-py3-none-win32.whl", hash = "sha256:cb53473849f011bca6e754f2cdf47cafc9c4f4ff4570003a0dad0b9b6890e876"},
+    {file = "ruff-0.4.4-py3-none-win_amd64.whl", hash = "sha256:424e5b72597482543b684c11def82669cc6b395aa8cc69acc1858b5ef3e5daae"},
+    {file = "ruff-0.4.4-py3-none-win_arm64.whl", hash = "sha256:39df0537b47d3b597293edbb95baf54ff5b49589eb7ff41926d8243caa995ea6"},
+    {file = "ruff-0.4.4.tar.gz", hash = "sha256:f87ea42d5cdebdc6a69761a9d0bc83ae9b3b30d0ad78952005ba6568d6c022af"},
+]
+
+[[package]]
 name = "setuptools"
 version = "68.1.2"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
@@ -1691,4 +1717,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "a787c59dd13a9e743e96c3b12e447e7d3399302d419cf5eba932fd84a15cc9a4"
+content-hash = "1dc2cf0e1bf3a6d225eac1e14d7ec341b5b69b4756fdbf4ae93807c6a257d66b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ optional = true
 
 [tool.poetry.group.dev.dependencies]
 mypy = ">=0.931"
+ruff = ">=0.4.4"
 pexpect = ">=4.8.0"
 poethepoet = ">=0.12.3"
 pre-commit = ">=2.17.0"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -65,8 +65,7 @@ COPIER_ANSWERS_FILE: Mapping[StrOrPath, str | bytes | Path] = {
 
 
 class Spawn(Protocol):
-    def __call__(self, cmd: tuple[str, ...], *, timeout: int | None) -> PopenSpawn:
-        ...
+    def __call__(self, cmd: tuple[str, ...], *, timeout: int | None) -> PopenSpawn: ...
 
 
 class Keyboard(str, Enum):

--- a/tests/test_legacy_migration.py
+++ b/tests/test_legacy_migration.py
@@ -15,6 +15,7 @@ from .helpers import BRACKET_ENVOPS_JSON, PROJECT_TEMPLATE, build_file_tree
 
 SRC = Path(f"{PROJECT_TEMPLATE}_legacy_migrations").absolute()
 
+
 # This fails on windows CI because, when the test tries to execute
 # `migrations.py`, it doesn't understand that it should be interpreted
 # by python.exe. Or maybe it fails because CI is using Git bash instead
@@ -240,7 +241,11 @@ def test_prereleases(tmp_path_factory: pytest.TempPathFactory) -> None:
     # Update it with prereleases
     with pytest.deprecated_call():
         run_update(
-            dst_path=dst, defaults=True, overwrite=True, use_prereleases=True, unsafe=True
+            dst_path=dst,
+            defaults=True,
+            overwrite=True,
+            use_prereleases=True,
+            unsafe=True,
         )
     answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
     assert answers["_commit"] == "v2.0.0.alpha1"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -61,8 +61,7 @@ def test_question_with_invalid_type(tmp_path_factory: pytest.TempPathFactory) ->
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
     build_file_tree(
         {
-            src
-            / "copier.yaml": """
+            src / "copier.yaml": """
                 bad:
                     type: invalid
                     default: 1
@@ -79,8 +78,7 @@ def test_answer_with_invalid_type(tmp_path_factory: pytest.TempPathFactory) -> N
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
     build_file_tree(
         {
-            src
-            / "copier.yaml": """
+            src / "copier.yaml": """
                 bad:
                     type: int
                     default: null

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -810,8 +810,7 @@ CHOICES = [pytest.param(*specs, id=id) for id, specs in _CHOICES.items()]
 
 
 class QuestionTreeFixture(Protocol):
-    def __call__(self, **kwargs) -> tuple[Path, Path]:
-        ...
+    def __call__(self, **kwargs) -> tuple[Path, Path]: ...
 
 
 @pytest.fixture
@@ -838,8 +837,7 @@ def question_tree(tmp_path_factory: pytest.TempPathFactory) -> QuestionTreeFixtu
 
 
 class CopierFixture(Protocol):
-    def __call__(self, *args, **kwargs) -> PopenSpawn:
-        ...
+    def __call__(self, *args, **kwargs) -> PopenSpawn: ...
 
 
 @pytest.fixture

--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -19,8 +19,7 @@ def test_copy_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: true
             """,
             repo / "target.txt": "Symlink target",
@@ -54,8 +53,7 @@ def test_copy_symlink_templated_name(tmp_path_factory: pytest.TempPathFactory) -
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: true
             symlink_name: symlink
             """,
@@ -92,8 +90,7 @@ def test_copy_symlink_templated_target(
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: true
             target_name: target
             """,
@@ -134,8 +131,7 @@ def test_copy_symlink_missing_target(tmp_path_factory: pytest.TempPathFactory) -
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: true
             """,
             repo / "symlink.txt": Path("target.txt"),
@@ -171,8 +167,7 @@ def test_option_preserve_symlinks_false(
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: false
             """,
             repo / "target.txt": "Symlink target",
@@ -207,8 +202,7 @@ def test_option_preserve_symlinks_default(
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             """,
             repo / "target.txt": "Symlink target",
             repo / "symlink.txt": Path("target.txt"),
@@ -238,21 +232,17 @@ def test_update_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
 
     build_file_tree(
         {
-            src
-            / ".copier-answers.yml.jinja": """\
+            src / ".copier-answers.yml.jinja": """\
                 # Changes here will be overwritten by Copier
                 {{ _copier_answers|to_nice_yaml }}
             """,
-            src
-            / "copier.yml": """\
+            src / "copier.yml": """\
                 _preserve_symlinks: true
             """,
-            src
-            / "aaaa.txt": """
+            src / "aaaa.txt": """
                 Lorem ipsum
             """,
-            src
-            / "bbbb.txt": """
+            src / "bbbb.txt": """
                 dolor sit amet
             """,
             src / "symlink.txt": Path("./aaaa.txt"),
@@ -298,21 +288,17 @@ def test_update_file_to_symlink(tmp_path_factory: pytest.TempPathFactory) -> Non
 
     build_file_tree(
         {
-            src
-            / ".copier-answers.yml.jinja": """\
+            src / ".copier-answers.yml.jinja": """\
                 # Changes here will be overwritten by Copier
                 {{ _copier_answers|to_nice_yaml }}
             """,
-            src
-            / "copier.yml": """\
+            src / "copier.yml": """\
                 _preserve_symlinks: true
             """,
-            src
-            / "aaaa.txt": """
+            src / "aaaa.txt": """
                 Lorem ipsum
             """,
-            src
-            / "bbbb.txt": """
+            src / "bbbb.txt": """
                 dolor sit amet
             """,
             src / "cccc.txt": Path("./aaaa.txt"),
@@ -361,8 +347,7 @@ def test_exclude_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: true
             """,
             repo / "target.txt": "Symlink target",
@@ -394,8 +379,7 @@ def test_pretend_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: true
             """,
             repo / "target.txt": "Symlink target",
@@ -427,8 +411,7 @@ def test_copy_symlink_none_path(tmp_path_factory: pytest.TempPathFactory) -> Non
     repo.mkdir()
     build_file_tree(
         {
-            repo
-            / "copier.yaml": """\
+            repo / "copier.yaml": """\
             _preserve_symlinks: true
             render: false
             """,

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -17,8 +17,7 @@ from copier.types import AnyByStrDict
 from .helpers import build_file_tree
 
 
-class JinjaExtension(Extension):
-    ...
+class JinjaExtension(Extension): ...
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR contains a few related commits regarding Ruff and pre-commit. Before, Ruff was a Nix dependency and configured as a pre-commit hook via [git-hooks.nix](https://github.com/cachix/git-hooks.nix/). This setup has been a bit problematic:

1.Ruff was either not available to non-Nix users or they were using a different version than the one locked by Nix (e.g. via the VS Code extension).

1. Dependabot cannot update Nix dependencies, so we tend to use an outdated Ruff version.
1. The Nix-locked Ruff version is not obvious, as Nix bundles its packages under a distribution release.

To address these problems and improve our (contributors') developer experience, I've made Ruff a regular Python development dependency managed via Poetry and configured a [custom hook](https://github.com/cachix/git-hooks.nix/?tab=readme-ov-file#custom-hooks) in `flake.nix` which uses the local `ruff` executable installed via Poetry. In a separate commit, I've added a similar custom hook for running Ruff's formatter. The custom hook definitions are based on [Ruff's official pre-commit hook definitions](https://github.com/astral-sh/ruff-pre-commit/blob/v0.4.4/.pre-commit-hooks.yaml) and [Ruff's own use thereof](https://github.com/astral-sh/ruff/blob/v0.4.4/.pre-commit-config.yaml#L58-L65). In another separate commit, I've run Ruff's linter and formatter on our code base.

I think this setup is better calibrated to ease contributions also by non-Nix users while retaining the advantages of Nix.