### PR TITLE
docs: Fix ineffective escaping, emphasize error messages

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -216,9 +216,9 @@ the introduced changes to your code base, specifically when you have unpleasant
 conflicts, it's not 100% obvious how to get back to the previously clean copy of your
 branch. The following strategies won't work:
 
--   `git checkout <branch>` – error: you need to resolve your current index first
--   `git checkout .` – error: path '\<filename>' is unmerged
--   `git merge --abort` – fatal: There is no merge to abort (MERGE_HEAD missing)
+-   `git checkout <branch>` – _error: you need to resolve your current index first_
+-   `git checkout .` – _error: path '&lt;filename&gt;' is unmerged_
+-   `git merge --abort` – _fatal: There is no merge to abort (MERGE_HEAD missing)_
 
 Here is what you can do using Git in the terminal to throw away all changes:
 


### PR DESCRIPTION
As discussed in https://github.com/copier-org/copier/pull/1668#discussion_r1648990816:

![Screenshot from 2024-06-21 15-42-42](https://github.com/copier-org/copier/assets/665072/d5f4d825-5c57-4dec-9fbe-4b3cd72569ef)

Fixes the broken markup by using HTML entities.

In addition, I used slanted font (emphasized) for the error messages to make it clearer how to interpret the text.