### PR TITLE
chore: Update dependency requests (yanked, related to CVE-2024-35195)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1426,13 +1426,13 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.0"
+version = "2.32.3"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "requests-2.32.0-py3-none-any.whl", hash = "sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5"},
-    {file = "requests-2.32.0.tar.gz", hash = "sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8"},
+    {file = "requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"},
+    {file = "requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
When updating any of the packages managed as a dependency by Poetry, you currently get this warning:

```
Updating dependencies
Resolving dependencies... (0.4s)
Warning: The locked version 2.32.0 for requests is a yanked version. Reason for being yanked: Yanked due to conflicts with CVE-2024-35195 mitigation

No dependencies to install or update

Writing lock file
```

This change hence updates the `requests` package (2.32.0 ➜ 2.32.3) to fix the issue.