### PR TITLE
chore: Use pyclean to reduce custom developer tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,6 +121,12 @@ Ready to contribute? Here's how to set up the project for local development.
     poe lint
     ```
 
+1.  Optionally, use pyclean to remove Python bytecode and build artifacts, e.g.
+
+    ```shell
+    pipx run pyclean . --debris --verbose
+    ```
+
 1.  Commit your changes and push your branch to GitHub:
 
     ```shell

--- a/devtasks.py
+++ b/devtasks.py
@@ -1,38 +1,11 @@
 """Development helper tasks."""
 import logging
-import shutil
 from pathlib import Path
 
 from plumbum import TEE, CommandNotFound, ProcessExecutionError, local
 
 _logger = logging.getLogger(__name__)
 HERE = Path(__file__).parent
-
-
-def clean() -> None:
-    """Clean build, test or other process artifacts from the project workspace."""
-    build_artefacts = (
-        "build/",
-        "dist/",
-        "*.egg-info",
-        "pip-wheel-metadata",
-    )
-    python_artefacts = (
-        ".pytest_cache",
-        "htmlcov",
-        ".coverage",
-        "**/__pycache__",
-        "**/*.pyc",
-        "**/*.pyo",
-    )
-    project_dir = Path(".").resolve()
-    for pattern in build_artefacts + python_artefacts:
-        for matching_path in project_dir.glob(pattern):
-            print(f"Deleting {matching_path}")
-            if matching_path.is_dir():
-                shutil.rmtree(matching_path)
-            else:
-                matching_path.unlink()
 
 
 def dev_setup() -> None:

--- a/poetry.lock
+++ b/poetry.lock
@@ -975,17 +975,6 @@ files = [
 ]
 
 [[package]]
-name = "pyclean"
-version = "3.0.0"
-description = "Pure Python cross-platform pyclean. Clean up your Python bytecode."
-optional = false
-python-versions = ">=3.5"
-files = [
-    {file = "pyclean-3.0.0-py3-none-any.whl", hash = "sha256:a1d8114991cf09994bc511cd0b050f3e398ae2bc8bfc0bbd1bdbec8ba048e6dd"},
-    {file = "pyclean-3.0.0.tar.gz", hash = "sha256:a48be7afd512b1923a7b9decc1219bbbe2d73199c939b46c936448f904a180ce"},
-]
-
-[[package]]
 name = "pydantic"
 version = "2.7.4"
 description = "Data validation using Python type hints"
@@ -1701,4 +1690,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "30064fe7e1705b6e3586518165b841e33327cdf72c52e2b7242e01a895443ec3"
+content-hash = "e9f5b300ab32886155c864b53e3d0e1dcf7cfdd7ed12567cf781cdf5e2edaaa8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -975,6 +975,17 @@ files = [
 ]
 
 [[package]]
+name = "pyclean"
+version = "3.0.0"
+description = "Pure Python cross-platform pyclean. Clean up your Python bytecode."
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "pyclean-3.0.0-py3-none-any.whl", hash = "sha256:a1d8114991cf09994bc511cd0b050f3e398ae2bc8bfc0bbd1bdbec8ba048e6dd"},
+    {file = "pyclean-3.0.0.tar.gz", hash = "sha256:a48be7afd512b1923a7b9decc1219bbbe2d73199c939b46c936448f904a180ce"},
+]
+
+[[package]]
 name = "pydantic"
 version = "2.7.4"
 description = "Data validation using Python type hints"
@@ -1264,7 +1275,6 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
-    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -1691,4 +1701,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8"
-content-hash = "e9f5b300ab32886155c864b53e3d0e1dcf7cfdd7ed12567cf781cdf5e2edaaa8"
+content-hash = "30064fe7e1705b6e3586518165b841e33327cdf72c52e2b7242e01a895443ec3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ mypy = ">=0.931"
 pexpect = ">=4.8.0"
 poethepoet = ">=0.12.3"
 pre-commit = ">=2.17.0"
-pyclean = ">=3.0.0"
 pytest = ">=7.2.0"
 pytest-cov = ">=3.0.0"
 pytest-gitconfig = ">=0.6.0"
@@ -76,10 +75,6 @@ optional = true
 
 [tool.poetry.group.build.dependencies]
 poetry-dynamic-versioning = { version = ">=1.1.0", markers = "python_version < '4'" }
-
-[tool.poe.tasks.clean]
-cmd = "pyclean . --debris --verbose"
-help = "remove Python bytecode and build artifacts"
 
 [tool.poe.tasks.coverage]
 cmd = "pytest --cov-report html --cov copier copier tests"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ mypy = ">=0.931"
 pexpect = ">=4.8.0"
 poethepoet = ">=0.12.3"
 pre-commit = ">=2.17.0"
+pyclean = ">=3.0.0"
 pytest = ">=7.2.0"
 pytest-cov = ">=3.0.0"
 pytest-gitconfig = ">=0.6.0"
@@ -77,8 +78,8 @@ optional = true
 poetry-dynamic-versioning = { version = ">=1.1.0", markers = "python_version < '4'" }
 
 [tool.poe.tasks.clean]
-script = "devtasks:clean"
-help = "remove build/python artifacts"
+cmd = "pyclean . --debris --verbose"
+help = "remove Python bytecode and build artifacts"
 
 [tool.poe.tasks.coverage]
 cmd = "pytest --cov-report html --cov copier copier tests"


### PR DESCRIPTION
Reduces the code in the `devtasks` module replacing cleanup activity code by integrating [pyclean](https://pypi.org/project/pyclean/) in the development toolchain. PyClean is a tool focused on cleaning up Python bytecode and build artifacts.

<details>
<summary>`poetry install --with dev` (click to show output)</summary>

```console
$ poetry install --with dev
Installing dependencies from lock file

Package operations: 33 installs, 0 updates, 0 removals

  - Installing distlib (0.3.7)
  - Installing exceptiongroup (1.1.0)
  - Installing filelock (3.13.0)
  - Installing iniconfig (2.0.0)
  - Installing platformdirs (3.11.0)
  - Installing pluggy (1.5.0)
  - Installing setuptools (68.1.2)
  - Installing tomli (2.0.1)
  - Installing cfgv (3.3.1)
  - Installing coverage (7.0.5)
  - Installing execnet (2.1.1)
  - Installing identify (2.5.13)
  - Installing mypy-extensions (1.0.0)
  - Installing nodeenv (1.7.0)
  - Installing pastel (0.2.1)
  - Installing ptyprocess (0.7.0)
  - Installing pytest (8.2.2)
  - Installing types-docutils (0.20.0.20240317)
  - Installing types-setuptools (69.2.0.20240317)
  - Installing virtualenv (20.24.6)
  - Installing mypy (1.10.0)
  - Installing pexpect (4.9.0)
  - Installing poethepoet (0.26.1)
  - Installing pre-commit (3.5.0)
  - Installing pyclean (3.0.0)
  - Installing pytest-cov (5.0.0)
  - Installing pytest-gitconfig (0.6.0)
  - Installing pytest-xdist (3.6.1)
  - Installing types-backports (0.1.3)
  - Installing types-colorama (0.4.15.20240311)
  - Installing types-psutil (6.0.0.20240621)
  - Installing types-pygments (2.18.0.20240506)
  - Installing types-pyyaml (6.0.12.20240311)

Installing the current project: copier (0.0.0)
```

</details>

<details>
<summary>`poe clean` (click to show output)</summary>

```console
$ poe clean
Poe => pyclean . --debris --verbose
Debris topics to scan for: cache coverage package pytest ruff
Ignored directories: .git .hg .svn .tox .venv node_modules venv
Cleaning directory .
Skipping .git
Scanning for debris of Cache ...
Scanning for debris of Coverage ...
Scanning for debris of Package ...
Scanning for debris of Pytest ...
Scanning for debris of Ruff ...
Total 0 files, 0 directories removed.
```

</details>

Closes: #1669