### PR TITLE
ci(flake): use commit message as PR title

### DIFF
--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -16,5 +16,6 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@main
         with:
           commit-msg: "build(flake): update lock"
+          pr-title: "build(flake): update lock"
           pr-labels: |
             dependencies


### PR DESCRIPTION
Just a minor enhancement to avoid non-conventional commits in the `master` branch when squash-merging `flake.lock` update PRs (see https://github.com/copier-org/copier/pull/1699#issuecomment-2233840071 :see_no_evil:).