### PR TITLE
fix(updating): exclude deleted paths on update

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -949,7 +949,6 @@ class Worker:
                 # project to avoid recreating them during the update.
                 # Files listed in `skip_if_exists` should only be skipped if they exist.
                 # They should even be recreated if deleted intentionally.
-                # This was discussed in issue #1718.
                 files_removed = git(
                     "diff-tree",
                     "-r",

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -213,10 +213,18 @@ def normalize_git_path(path: str) -> str:
 
 
 def escape_git_path(path: str) -> str:
+    """Escape paths that will be used as literal gitwildmatch patterns.
+
+    If the path was returned by a Git command, it should be unescaped completely.
+    ``normalize_git_path`` can be used for this purpose.
+
+    Args:
+        path: The Git path to escape.
+
+    Returns:
+        str: The escaped Git path.
     """
-    Escape paths that will be used as literal gitwildmatch patterns.
-    The paths should be unescaped completely, as done by ``normalize_git_path``."""
-    # GitwWildMatchPattern.escape does not escape backslashes
+    # GitWildMatchPattern.escape does not escape backslashes
     # or trailing whitespace.
     path = path.replace("\\", "\\\\")
     path = GitWildMatchPattern.escape(path)

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -17,6 +17,7 @@ from typing import Any, Callable, Literal, TextIO, cast
 
 import colorama
 from packaging.version import Version
+from pathspec.patterns.gitwildmatch import GitWildMatchPattern
 from pydantic import StrictBool
 
 colorama.just_fix_windows_console()
@@ -184,17 +185,14 @@ def readlink(link: Path) -> Path:
         return Path(os.readlink(link))
 
 
-_re_octal = re.compile(r"\\([0-9]{3})\\([0-9]{3})")
-
-
-def _re_octal_replace(match: re.Match[str]) -> str:
-    return bytes([int(match.group(1), 8), int(match.group(2), 8)]).decode("utf8")
+_re_whitespace = re.compile(r"^\s+|\s+$")
 
 
 def normalize_git_path(path: str) -> str:
     r"""Convert weird characters returned by Git to normal UTF-8 path strings.
 
     A filename like âñ will be reported by Git as "\\303\\242\\303\\261" (octal notation).
+    Similarly, a filename like "<tab>foo\b<lf>ar" will be reported as "\tfoo\\b\nar".
     This can be disabled with `git config core.quotepath off`.
 
     Args:
@@ -208,5 +206,21 @@ def normalize_git_path(path: str) -> str:
         path = path[1:-1]
     # Repair double-quotes
     path = path.replace('\\"', '"')
+    # Unescape escape characters
+    path = path.encode("latin-1", "backslashreplace").decode("unicode-escape")
     # Convert octal to utf8
-    return _re_octal.sub(_re_octal_replace, path)
+    return path.encode("latin-1", "backslashreplace").decode("utf-8")
+
+
+def escape_git_path(path: str) -> str:
+    """
+    Escape paths that will be used as literal gitwildmatch patterns.
+    The paths should be unescaped completely, as done by ``normalize_git_path``."""
+    # GitwWildMatchPattern.escape does not escape backslashes
+    # or trailing whitespace.
+    path = path.replace("\\", "\\\\")
+    path = GitWildMatchPattern.escape(path)
+    return _re_whitespace.sub(
+        lambda match: "".join(f"\\{whitespace}" for whitespace in match.group()),
+        path,
+    )

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1313,8 +1313,8 @@ configuring `secret: true` in the [advanced prompt format][advanced-prompt-forma
 -   Default value: `[]`
 
 [Patterns][patterns-syntax] for files/folders that must be skipped only if they already
-exist, but always be present. If they do not exist in a project
-during an `update` operation, they will be recreated.
+exist, but always be present. If they do not exist in a project during an `update`
+operation, they will be recreated.
 
 !!! example
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1312,8 +1312,9 @@ configuring `secret: true` in the [advanced prompt format][advanced-prompt-forma
 -   CLI flags: `-s`, `--skip`
 -   Default value: `[]`
 
-[Patterns][patterns-syntax] for files/folders that must be skipped if they already
-exist.
+[Patterns][patterns-syntax] for files/folders that must be skipped only if they already
+exist, but always be present. If they do not exist in a project
+during an `update` operation, they will be recreated.
 
 !!! example
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -186,6 +186,16 @@ As you can see here, `copier` does several things:
 -   Finally, it re-applies the previously obtained diff and then runs the
     post-migrations.
 
+### Handling of deleted paths
+
+Template-based files/directories that were deleted in the generated project
+are automatically excluded from updates. If you want to recover such a file
+later on, you can run `copier recopy` and recommit it to your repository.
+Subsequent updates for the path will then be respected again.
+
+An exception to this behavior applies to paths that are matched by `skip_if_exists`.
+Their presence is always ensured, even during an `update` operation.
+
 ### Recover from a broken update
 
 Usually Copier will replay the last project generation without problems. However,

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -188,10 +188,10 @@ As you can see here, `copier` does several things:
 
 ### Handling of deleted paths
 
-Template-based files/directories that were deleted in the generated project
-are automatically excluded from updates. If you want to recover such a file
-later on, you can run `copier recopy` and recommit it to your repository.
-Subsequent updates for the path will then be respected again.
+Template-based files/directories that were deleted in the generated project are
+automatically excluded from updates. If you want to recover such a file later on, you
+can run `copier recopy` and recommit it to your repository. Subsequent updates for the
+path will then be respected again.
 
 An exception to this behavior applies to paths that are matched by `skip_if_exists`.
 Their presence is always ensured, even during an `update` operation.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -40,6 +40,14 @@ def test_temporary_directory_with_git_repo_deletion() -> None:
         ('quo\\"tes', 'quo"tes'),
         ('"surrounded"', "surrounded"),
         ("m4\\303\\2424\\303\\2614a", "m4â4ñ4a"),
+        ("tab\\t", "tab\t"),
+        ("lf\\n", "lf\n"),
+        ("crlf\\r\\n", "crlf\r\n"),
+        ("back\\\\slash", "back\\slash"),
+        (
+            "\\a\\b\\f\\n\\t\\vcontrol\\a\\b\\f\\n\\t\\vcharacters\\a\\b\\f\\n\\t\\v",
+            "\a\b\f\n\t\vcontrol\a\b\f\n\t\vcharacters\a\b\f\n\t\v",
+        ),
     ],
 )
 def test_normalizing_git_paths(path: str, normalized: str) -> None:

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -605,7 +605,6 @@ def test_skip_update_deleted(
     """
     Ensure that paths in ``skip_if_exists`` are always recreated
     if they are absent before updating.
-    This was discussed in issue #1718.
     """
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
@@ -705,7 +704,6 @@ def test_update_deleted_path(
     """
     Ensure that deleted paths are not regenerated during updates,
     even if the template has changes in that path.
-    Issue #1721
     """
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     with local.cwd(src):


### PR DESCRIPTION
~~Previously, paths that matched a pattern in `skip_if_exists` and that were deleted in the generated project were recreated during each update.~~

~~These deletions are contained in the diff between old vanilla generated project and the (pre-update) current one. They are not executed though since the paths are excluded from the diff application.~~

Previously, if a file that was deleted intentionally in a generated project was changed in the template, an update would have regenerated it (but not if it did not have any changes).

This patch ensures that update behavior is consistent for paths that are not listed in `skip_if_exists` - don't regenerate deleted paths during `update` - by acquiring a list of deleted paths and excluding them in the copy operations that are relevant for acquiring the update diff. `skip_if_exists` paths are not excluded, their presence is always ensured, even by `copier update` (https://github.com/copier-org/copier/issues/1718#issuecomment-2273622414).

Fixes: https://github.com/copier-org/copier/issues/1721

Thanks a lot for maintaining this very neat tool btw!