### PR TITLE
fix: parse new answer when `--skip-answered` is used

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -480,9 +480,6 @@ class Worker:
                 else:
                     if question.validate_answer(answer):
                         del result.last[var_name]
-            # Skip a question when the user already answered it.
-            if self.skip_answered and var_name in result.last:
-                continue
             # Skip a question when the skip condition is met.
             if not question.get_when():
                 # Omit its answer from the answers file.
@@ -501,6 +498,9 @@ class Worker:
                 # At this point, the answer value is valid. Do not ask the
                 # question again, but set answer as the user's answer instead.
                 result.user[var_name] = answer
+                continue
+            # Skip a question when the user already answered it.
+            if self.skip_answered and var_name in result.last:
                 continue
 
             # Display TUI and ask user interactively only without --defaults


### PR DESCRIPTION
I've fixed a bug where a recopy/update with `-A, --skip-answered` did not parse a new answer passed via `-d, --data`. The solution was simple: Skipping a question because of `-A, --skip-answered` needs to happen _after_ parsing a new answer via `-d, --data` takes place, so that using the new answer takes precedence over skipping it.

Fixes #1728.