### PR TITLE
Add the jinja2-slugify extension

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -547,6 +547,7 @@ class Worker:
         paths = [str(self.template.local_abspath)]
         loader = FileSystemLoader(paths)
         default_extensions = [
+            "jinja2_slug.SlugExtension",
             "jinja2_ansible_filters.AnsibleCoreFiltersExtension",
         ]
         extensions = default_extensions + list(self.template.jinja_extensions)

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -985,7 +985,6 @@ on them, so they are always installed when Copier is installed.
     ```yaml title="copier.yml"
     _jinja_extensions:
         - jinja_markdown.MarkdownExtension
-        - jinja2_slug.SlugExtension
         - jinja2_time.TimeExtension
     ```
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -475,6 +475,25 @@ PyYAML = "*"
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "jinja2-slug"
+version = "0.2.0"
+description = "Jinja2 Extension for creating slugs"
+optional = false
+python-versions = "^3.7"
+files = []
+develop = false
+
+[package.dependencies]
+jinja2 = ">=2.10"
+unicode-slugify = "^0.1.3"
+
+[package.source]
+type = "git"
+url = "https://github.com/xsteadfastx/jinja2-slug"
+reference = "97104e2"
+resolved_reference = "97104e269f08088e58e1dac0cb0bcf881a45cb2b"
+
+[[package]]
 name = "markdown"
 version = "3.4.4"
 description = "Python implementation of John Gruber's Markdown."
@@ -1601,6 +1620,32 @@ files = [
 ]
 
 [[package]]
+name = "unicode-slugify"
+version = "0.1.5"
+description = "A slug generator that turns strings into unicode slugs."
+optional = false
+python-versions = "*"
+files = [
+    {file = "unicode-slugify-0.1.5.tar.gz", hash = "sha256:25f424258317e4cb41093e2953374b3af1f23097297664731cdb3ae46f6bd6c3"},
+    {file = "unicode_slugify-0.1.5-py3-none-any.whl", hash = "sha256:33a11c0ac901f7220659dd0dd6f232cf39637dfd1b9f5f35ef5ead9fef696879"},
+]
+
+[package.dependencies]
+six = "*"
+unidecode = "*"
+
+[[package]]
+name = "unidecode"
+version = "1.3.8"
+description = "ASCII transliterations of Unicode text"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "Unidecode-1.3.8-py3-none-any.whl", hash = "sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39"},
+    {file = "Unidecode-1.3.8.tar.gz", hash = "sha256:cfdb349d46ed3873ece4586b96aa75258726e2fa8ec21d6f00a591d98806c2f4"},
+]
+
+[[package]]
 name = "urllib3"
 version = "1.26.19"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -1704,5 +1749,5 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8"
-content-hash = "e9f5b300ab32886155c864b53e3d0e1dcf7cfdd7ed12567cf781cdf5e2edaaa8"
+python-versions = ">=3.8,<4.0"
+content-hash = "c5dbf4178e55caa73f95ce42d431a7dbb840f2313672a0c64c3831b1a26cc08b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,12 +27,15 @@ copier = "copier.__main__:copier_app_run"
 "Bug Tracker" = "https://github.com/copier-org/copier/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.8,<4.0"
 colorama = ">=0.4.6"
 dunamai = ">=1.7.0"
 funcy = ">=1.17"
 jinja2 = ">=3.1.4"
 jinja2-ansible-filters = ">=1.3.1"
+# The most recent release of jinja2-slug on PyPi is out of date
+# and sets an upper bound of 2.x for jinja2
+jinja2-slug = { git = "https://github.com/xsteadfastx/jinja2-slug", rev = "97104e2" }
 packaging = ">=23.0"
 pathspec = ">=0.9.0"
 plumbum = ">=1.6.9"

--- a/tests/demo_extensions_default/super_file.md.jinja
+++ b/tests/demo_extensions_default/super_file.md.jinja
@@ -1,1 +1,3 @@
 {{ "/absolute/path"|basename }}
+
+{{ "my cool name" | slug }}

--- a/tests/test_jinja2_extensions.py
+++ b/tests/test_jinja2_extensions.py
@@ -40,7 +40,7 @@ def test_default_jinja2_extensions(tmp_path: Path) -> None:
     copier.run_copy(str(PROJECT_TEMPLATE) + "_extensions_default", tmp_path)
     super_file = tmp_path / "super_file.md"
     assert super_file.exists()
-    assert super_file.read_text() == "path\n"
+    assert super_file.read_text() == "path\n\nmy-cool-name\n"
 
 
 def test_additional_jinja2_extensions(tmp_path: Path) -> None:


### PR DESCRIPTION
While #370 addressed a subset of the requested extensions in #208, it did not in fact pull in cookiecutter, which means that the slugify extension that cookiecutter offers didn't make it.

Thus, this PR, which gets the tip version of [jinja2-slug](https://github.com/xsteadfastx/jinja2-slug) and adds it to the default extension set.