### PR TITLE
fix: validate answers to secret questions

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -387,7 +387,7 @@ class Question:
             result["multiline"] = self.get_multiline()
             if placeholder := self.get_placeholder():
                 result["placeholder"] = placeholder
-        if questionary_type in {"input", "checkbox"}:
+        if questionary_type in {"input", "checkbox", "password"}:
             result["validate"] = _validate
         result.update({"type": questionary_type})
         return result

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -499,6 +499,15 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
             "abc",
             does_not_raise(),
         ),
+        (
+            {
+                "type": "str",
+                "secret": True,
+                "validator": "[% if q|length < 3 %]too short[% endif %]",
+            },
+            "",
+            pytest.raises(ValueError),
+        ),
         ({"type": "bool"}, "true", does_not_raise()),
         ({"type": "bool"}, "false", does_not_raise()),
         (
@@ -849,6 +858,15 @@ def test_required_choice_question_without_data(
         ("str", "1.0", does_not_raise()),
         ("str", 1.0, does_not_raise()),
         ("str", None, pytest.raises(TypeError)),
+        (
+            {
+                "type": "str",
+                "secret": True,
+                "validator": "[% if q|length < 3 %]too short[% endif %]",
+            },
+            "",
+            pytest.raises(ValueError),
+        ),
         ("int", 1, does_not_raise()),
         ("int", 1.0, does_not_raise()),
         ("int", "1", does_not_raise()),


### PR DESCRIPTION
I've fixed the answer validation to apply also to secret questions. This problem came up in an internal discussion with a colleague who stumbled over secret questions not being validated.

In general, I see no reason why answers to secret questions should not be validated. Secret questions are a special case regarding project updates though. We require a secret question to have a default value because we need _some_ value to exist for replaying a fresh project based on the old template using the recorded answers, which don't include secrets. For this to continue working, it's crucial that the default value of a secret question passes the validator – but this rule should actually apply to all questions because otherwise `copier copy --defaults ...` would be useless. Just saying.