### PR TITLE
Document how to update when changing a multiselect base answer

### DIFF
--- a/docs/updating.md
+++ b/docs/updating.md
@@ -129,29 +129,14 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
-Note: if that question is a multiselect base choice, e.g.:
-
+Note: it is not yet possible to update a multiselect base choice that way, for example a value that
+looks like this in the file `.copier-answers.yml`:
 ```yaml
 python_tested_versions:
     - "3.10"
     - "3.11"
 ```
-
-then you first need to create a file outside of the directory, e.g.
-`~/tmp/copier_answer.yaml`, with the content you want, e.g.:
-
-```yaml
-python_tested_versions:
-    - "3.10"
-    - "3.11"
-    - "3.12"
-```
-
-and then run the command with the `--data-file` argument:
-
-```shell
-copier update --defaults  --data-file=~/tmp/copier_answer.yaml
-```
+As a workaround, you need to use the `--data_file` option instead. See [here](https://copier.readthedocs.io/en/stable/configuring/#data_file) for usage information.
 
 ## How the update works
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -129,7 +129,7 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
-You can achieve the same using a [data file][data file]:
+You can achieve the same using a [data file][data_file]:
 
 ˋˋˋshell
 echo "updated_question: my new answer" > /tmp/data-file.yml

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -129,6 +129,24 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
+Note: if that question is a multiselect base choice, e.g.:
+  ```yaml
+  python_tested_versions:
+  - '3.10'
+  - '3.11'
+  ```
+then you first need to create a file outside of the directory, e.g. `~/tmp/copier_answer.yaml`, with the content you want, e.g.:
+```yaml
+python_tested_versions:
+- '3.10'
+- '3.11'
+- '3.12'
+```
+and then run the command with the `--data-file` argument:
+```shell
+hatch run update-template --defaults  --data-file=`~/tmp/copier_answer.yaml
+```
+
 ## How the update works
 
 To understand how the updating process works, take a look at this diagram:

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -150,7 +150,7 @@ python_tested_versions:
 and then run the command with the `--data-file` argument:
 
 ```shell
-hatch run update-template --defaults  --data-file=`~/tmp/copier_answer.yaml
+copier update --defaults  --data-file=~/tmp/copier_answer.yaml
 ```
 
 ## How the update works

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -129,7 +129,7 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
-Note: it is not yet possible to update a multiselect base choice that way, for example a value that
+Note: it is not yet possible ([ref. issue](https://github.com/copier-org/copier/issues/1474)) to update a multiselect base choice that way, for example a value that
 looks like this in the file `.copier-answers.yml`:
 ```yaml
 python_tested_versions:

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -130,19 +130,25 @@ copier update --defaults --data updated_question="my new answer"
 ```
 
 Note: if that question is a multiselect base choice, e.g.:
-  ```yaml
-  python_tested_versions:
-  - '3.10'
-  - '3.11'
-  ```
-then you first need to create a file outside of the directory, e.g. `~/tmp/copier_answer.yaml`, with the content you want, e.g.:
+
 ```yaml
 python_tested_versions:
-- '3.10'
-- '3.11'
-- '3.12'
+    - "3.10"
+    - "3.11"
 ```
+
+then you first need to create a file outside of the directory, e.g.
+`~/tmp/copier_answer.yaml`, with the content you want, e.g.:
+
+```yaml
+python_tested_versions:
+    - "3.10"
+    - "3.11"
+    - "3.12"
+```
+
 and then run the command with the `--data-file` argument:
+
 ```shell
 hatch run update-template --defaults  --data-file=`~/tmp/copier_answer.yaml
 ```

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -129,7 +129,7 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
-Note: it is not yet possible ([ref. issue](https://github.com/copier-org/copier/issues/1474)) to update a multiselect base choice that way, for example a value that
+Note: it is not yet possible ([ref. issue](https://github.com/copier-org/copier/issues/1474)) to update a multiselect choice that way, for example a value that
 looks like this in the file `.copier-answers.yml`:
 ```yaml
 python_tested_versions:

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -129,13 +129,17 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
-Note: it is not yet possible ([ref. issue](https://github.com/copier-org/copier/issues/1474)) to update a multiselect choice that way, for example a value that
-looks like this in the file `.copier-answers.yml`:
+Note: it is not yet possible
+([ref. issue](https://github.com/copier-org/copier/issues/1474)) to update a multiselect
+choice that way, for example a value that looks like this in the file
+`.copier-answers.yml`:
+
 ```yaml
 python_tested_versions:
     - "3.10"
     - "3.11"
 ```
+
 As a workaround, for now you need to use [the `--data-file` option][data_file] instead.
 
 ## How the update works

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -131,8 +131,10 @@ copier update --defaults --data updated_question="my new answer"
 
 You can achieve the same using a [data file][data_file]:
 
-ˋˋˋshell echo "updated_question: my new answer" > /tmp/data-file.yml copier update
---defaults --data-file /tmp/data-file.yml ˋˋˋ
+```shell
+echo "updated_question: my new answer" > /tmp/data-file.yaml
+copier update --defaults --data-file /tmp/data-file.yaml
+```
 
 !!! note
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -136,7 +136,7 @@ python_tested_versions:
     - "3.10"
     - "3.11"
 ```
-As a workaround, you need to use the `--data_file` option instead. See [here](https://copier.readthedocs.io/en/stable/configuring/#data_file) for usage information.
+As a workaround, for now you need to use [the `--data-file` option][data_file] instead.
 
 ## How the update works
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -129,18 +129,18 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
-Note: it is not yet possible
-([ref. issue](https://github.com/copier-org/copier/issues/1474)) to update a multiselect
-choice that way, for example a value that looks like this in the file
-`.copier-answers.yml`:
+You can achieve the same using a [data file][data file]:
 
-```yaml
-python_tested_versions:
-    - "3.10"
-    - "3.11"
-```
+ˋˋˋshell
+echo "updated_question: my new answer" > /tmp/data-file.yml
+copier update --defaults --data-file /tmp/data-file.yml
+ˋˋˋ
 
-As a workaround, for now you need to use [the `--data-file` option][data_file] instead.
+!!! note
+
+    Due to [issue #1474](https://github.com/copier-org/copier/issues/1474),
+    it is not yet possible to update a multiselect choice using ˋ--dataˋ.
+    Use ˋ--data-fileˋ instead for now.
 
 ## How the update works
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -131,10 +131,8 @@ copier update --defaults --data updated_question="my new answer"
 
 You can achieve the same using a [data file][data_file]:
 
-ˋˋˋshell
-echo "updated_question: my new answer" > /tmp/data-file.yml
-copier update --defaults --data-file /tmp/data-file.yml
-ˋˋˋ
+ˋˋˋshell echo "updated_question: my new answer" > /tmp/data-file.yml copier update
+--defaults --data-file /tmp/data-file.yml ˋˋˋ
 
 !!! note
 


### PR DESCRIPTION
Document how to update when changing a multiselect base answer
The documentation to update, changing only one answer  when the question is a multi-select base choice, is missing.

This is from https://github.com/copier-org/copier/issues/1474#issuecomment-2328522026, but it also indicates to create the `.yaml` file in another directory (to avoid error `Destination repository is dirty; cannot continue. Please commit or stash your local changes and retry.`).