### PR TITLE
docs(git): tell how to pass HTTPS credentials

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -195,15 +195,19 @@ Copier skips its autodetection and just goes for the `HEAD` you already chose.
 
 ## How to pass credentials to Git?
 
-If you do something like this, and the template supports updates, you'll notice that the credentials will end up stored in [the answers file][file][the-copier-answersyml-file]:
+If you do something like this, and the template supports updates, you'll notice that the
+credentials will end up stored in [the answers file][file][the-copier-answersyml-file]:
 
 ```shell
 copier copy https://myuser:example.com/repo.git .
 ```
 
-To avoid that, the simplest fix is to clone using SSH with cryptographic key authentication. If you cannot do that, then check out these links for strategies on passing HTTPS credentials to Git:
-- https://github.com/copier-org/copier/issues/466#issuecomment-2338160284
-- https://stackoverflow.com/q/35942754
-- https://git-scm.com/docs/gitcredentials
-- https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage#_credential_caching
-- https://github.com/topics/git-credential-helper
+To avoid that, the simplest fix is to clone using SSH with cryptographic key
+authentication. If you cannot do that, then check out these links for strategies on
+passing HTTPS credentials to Git:
+
+-   https://github.com/copier-org/copier/issues/466#issuecomment-2338160284
+-   https://stackoverflow.com/q/35942754
+-   https://git-scm.com/docs/gitcredentials
+-   https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage#_credential_caching
+-   https://github.com/topics/git-credential-helper

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -192,3 +192,18 @@ $ copier copy -r HEAD ./src ./dst
 
 ... then you'll notice `new-file.txt` does exist. You passed a specific ref to copy, so
 Copier skips its autodetection and just goes for the `HEAD` you already chose.
+
+## How to pass credentials to Git?
+
+If you do something like this, and the template supports updates, you'll notice that the credentials will end up stored in [the answers file][file][the-copier-answersyml-file]:
+
+```shell
+copier copy https://myuser:example.com/repo.git .
+```
+
+To avoid that, the simplest fix is to clone using SSH with cryptographic key authentication. If you cannot do that, then check out these links for strategies on passing HTTPS credentials to Git:
+- https://github.com/copier-org/copier/issues/466#issuecomment-2338160284
+- https://stackoverflow.com/q/35942754
+- https://git-scm.com/docs/gitcredentials
+- https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage#_credential_caching
+- https://github.com/topics/git-credential-helper


### PR DESCRIPTION
Fixes https://github.com/copier-org/copier/issues/466