### PR TITLE
fix(updating): don't validate computed values

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -1003,7 +1003,11 @@ class Worker:
             with replace(
                 self,
                 dst_path=new_copy / subproject_subdir,
-                data=self.answers.combined,  # type: ignore[arg-type]
+                data={
+                    k: v
+                    for k, v in self.answers.combined.items()
+                    if k not in self.answers.hidden
+                },
                 defaults=True,
                 quiet=True,
                 src_path=self.subproject.template.url,  # type: ignore[union-attr]


### PR DESCRIPTION
I've fixed the update algorithm to always re-compute computed values in low-level `copy` calls, which fixes #1779 as side effect.