### PR TITLE
fix(exclude): support negative exclude matching child of excluded parent

### DIFF
--- a/copier/tools.py
+++ b/copier/tools.py
@@ -13,7 +13,7 @@ from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Literal, TextIO, cast
+from typing import Any, Callable, Iterator, Literal, TextIO, cast
 
 import colorama
 from packaging.version import Version
@@ -256,3 +256,11 @@ def set_git_alternates(*repos: Path, path: Path = Path(".")) -> None:
     alternates_file = get_git_objects_dir(path) / "info" / "alternates"
     alternates_file.parent.mkdir(parents=True, exist_ok=True)
     alternates_file.write_bytes(b"\n".join(map(bytes, map(get_git_objects_dir, repos))))
+
+
+def scantree(path: str) -> Iterator[os.DirEntry[str]]:
+    """A recursive extension of `os.scandir`."""
+    for entry in os.scandir(path):
+        yield entry
+        if entry.is_dir(follow_symlinks=False):
+            yield from scantree(entry.path)


### PR DESCRIPTION
I've fixed the filtering of files and directories with exclude patterns. Before, a negative exclude pattern was ignored when some parent path matched the exclude patterns. The reason lies in the custom top-down filesystem walk implemented in `Worker._render_folder()` which didn't traverse the contents of a directory if an exclude pattern matched while a _negative_ exclude pattern also matched a child of this directory.

The solution is based on a different approach to walking the filesystem and excluding paths. Now, an iterator of all paths (files and directories) in the tree rooted at the template's copy root is produced via a recursive extension of `os.scandir()` and then filtered with the exclude patterns, so a subtree isn't pruned during the top-down tree walk. Instead, every path in the tree is considered and filtered individually based on the exclude patterns. Thus, `Worker._render_folder()` no longer implements a tree walk but simply creates a directory at the specified path. Also, `Worker._render_{folder,symlink,file}()` no longer render path templates, as paths need to be rendered prior to filtering with exclude patterns.

I decided to use `os.scandir()` over `os.walk()` or `Path.glob("**/*")` for better performance. It's also worth noting that, unlike before, the new implementation will walk subtrees of, e.g., `.git/`, even when they are excluded by the (default) exclude patterns, which may seem suboptimal. But I don't see a way to avoid it when supporting negative includes because pruning a subtree like before leads to incorrect results. That said, when using the [`subdirectory` setting](https://copier.readthedocs.io/en/stable/configuring/#subdirectory), the subtree of `.git/` is ignored because the root of the tree walk is the configured template subdirectory which doesn't contain the `.git/` directory.

Fixes #1794.