### PR TITLE
feat: add support for dynamic choices

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -177,7 +177,7 @@ class Question:
     var_name: str
     answers: AnswersMap
     jinja_env: SandboxedEnvironment
-    choices: Sequence[Any] | dict[Any, Any] = field(default_factory=list)
+    choices: Sequence[Any] | dict[Any, Any] | str = field(default_factory=list)
     multiselect: bool = False
     default: Any = MISSING
     help: str = ""
@@ -291,8 +291,10 @@ class Question:
         result = []
         choices = self.choices
         default = self.get_default()
-        if isinstance(self.choices, dict):
-            choices = list(self.choices.items())
+        if isinstance(choices, str):
+            choices = parse_yaml_string(self.render_value(self.choices))
+        if isinstance(choices, dict):
+            choices = list(choices.items())
         for choice in choices:
             # If a choice is a value pair
             if isinstance(choice, (tuple, list)):

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -116,6 +116,41 @@ Supported keys:
         the message is shown. Choice validation is useful when the validity of a choice
         depends on the answer to a previous question.
 
+    !!! tip "Dynamic choices"
+
+        Choices can be created dynamically by using a templated string which renders
+        as valid list-style, dict-style, or tuple-style choices in YAML format. For
+        example:
+
+        ```yaml title="copier.yml"
+        language:
+            type: str
+            help: Which programming language do you use?
+            choices:
+                - python
+                - node
+
+        dependency_manager:
+            type: str
+            help: Which dependency manager do you use?
+            choices: |
+                {%- if language == "python" %}
+                - poetry
+                - pipenv
+                {%- else %}
+                - npm
+                - yarn
+                {%- endif %}
+        ```
+
+        Dynamic choices can be used as an alternative approach to conditional choices
+        via validators where dynamic choices hide disabled choices whereas choices
+        disabled via validators are visible with along with the validator's error
+        message but cannot be selected.
+
+        When combining dynamic choices with validators, make sure to escape the
+        validator template using `{% raw %}...{% endraw %}`.
+
     !!! warning
 
         You are able to use different types for each choice value, but it is not


### PR DESCRIPTION
I've added support for dynamic choices by allowing a templated string value for the `choices` key that renders as valid YAML. All choice styles are supported. See also https://github.com/orgs/copier-org/discussions/1193#discussioncomment-10040365.

Resolves #1746 #1193.