### PR TITLE
refactor: drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       # HACK https://github.com/actions/cache/issues/315

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,7 @@ mkdocs:
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.12"
   jobs:
     post_install:
       - pip install poetry

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A library and CLI app for rendering project templates.
 
 ## Installation
 
-1. Install Python 3.8 or newer.
+1. Install Python 3.9 or newer.
 1. Install Git 2.27 or newer.
 1. To use as a CLI app: `pipx install copier`
 1. To use as a library: `pip install copier` or `conda install -c conda-forge copier`

--- a/copier/main.py
+++ b/copier/main.py
@@ -53,7 +53,6 @@ from .tools import (
     escape_git_path,
     normalize_git_path,
     printf,
-    readlink,
     set_git_alternates,
 )
 from .types import (
@@ -423,7 +422,7 @@ class Worker:
         try:
             previous_content: bytes | Path
             if previous_is_symlink:
-                previous_content = readlink(dst_abspath)
+                previous_content = dst_abspath.readlink()
             else:
                 previous_content = dst_abspath.read_bytes()
         except FileNotFoundError:
@@ -655,7 +654,7 @@ class Worker:
             return
         dst_abspath = Path(self.subproject.local_abspath, dst_relpath)
 
-        src_target = readlink(src_abspath)
+        src_target = src_abspath.readlink()
         if src_abspath.name.endswith(self.template.templates_suffix):
             dst_target = Path(self._render_string(str(src_target)))
         else:

--- a/copier/tools.py
+++ b/copier/tools.py
@@ -174,17 +174,6 @@ def handle_remove_readonly(
         raise
 
 
-def readlink(link: Path) -> Path:
-    """A custom version of os.readlink/pathlib.Path.readlink.
-
-    pathlib.Path.readlink is what we ideally would want to use, but it is only available on python>=3.9.
-    """
-    if sys.version_info >= (3, 9):
-        return link.readlink()
-    else:
-        return Path(os.readlink(link))
-
-
 _re_whitespace = re.compile(r"^\s+|\s+$")
 
 

--- a/copier/types.py
+++ b/copier/types.py
@@ -1,8 +1,8 @@
 """Complex types, annotations, validators."""
 
-import sys
 from pathlib import Path
 from typing import (
+    Annotated,
     Any,
     Dict,
     Literal,
@@ -15,11 +15,6 @@ from typing import (
 )
 
 from pydantic import AfterValidator
-
-if sys.version_info >= (3, 9):
-    from typing import Annotated
-else:
-    from typing_extensions import Annotated
 
 # simple types
 StrOrPath = Union[str, Path]

--- a/poetry.lock
+++ b/poetry.lock
@@ -11,9 +11,6 @@ files = [
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
 ]
 
-[package.dependencies]
-typing-extensions = {version = ">=4.0.0", markers = "python_version < \"3.9\""}
-
 [[package]]
 name = "babel"
 version = "2.12.1"
@@ -24,9 +21,6 @@ files = [
     {file = "Babel-2.12.1-py3-none-any.whl", hash = "sha256:b4246fb7677d3b98f501a39d43396d3cafdc8eadb045f4a31be01863f655c610"},
     {file = "Babel-2.12.1.tar.gz", hash = "sha256:cc2d99999cd01d44420ae725a21c9e3711b3aadc7976d6147f622d8581963455"},
 ]
-
-[package.dependencies]
-pytz = {version = ">=2015.7", markers = "python_version < \"3.9\""}
 
 [[package]]
 name = "certifi"
@@ -430,24 +424,6 @@ zipp = ">=0.5"
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
 testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
-
-[[package]]
-name = "importlib-resources"
-version = "6.1.0"
-description = "Read resources from Python packages"
-optional = false
-python-versions = ">=3.8"
-files = [
-    {file = "importlib_resources-6.1.0-py3-none-any.whl", hash = "sha256:aa50258bbfa56d4e33fbd8aa3ef48ded10d1735f11532b8df95388cc6bdb7e83"},
-    {file = "importlib_resources-6.1.0.tar.gz", hash = "sha256:9d48dcccc213325e810fd723e7fbb45ccb39f6cf5c31f00cf2b965f5f10f3cb9"},
-]
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (<7.2.5)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy (>=0.9.1)", "pytest-ruff", "zipp (>=3.17)"]
 
 [[package]]
 name = "iniconfig"
@@ -906,7 +882,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-resources = {version = "*", markers = "python_version < \"3.9\""}
 pywin32 = {version = "*", markers = "platform_system == \"Windows\" and platform_python_implementation != \"PyPy\""}
 
 [package.extras]
@@ -1204,7 +1179,6 @@ files = [
 ]
 
 [package.dependencies]
-importlib-resources = {version = ">=1.3", markers = "python_version < \"3.9\""}
 pytest = ">=7.1.2"
 
 [[package]]
@@ -1240,17 +1214,6 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
-
-[[package]]
-name = "pytz"
-version = "2023.3"
-description = "World timezone definitions, modern and historical"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
-    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
-]
 
 [[package]]
 name = "pywin32"
@@ -1722,5 +1685,5 @@ test = ["big-O", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-it
 
 [metadata]
 lock-version = "2.0"
-python-versions = ">=3.8"
-content-hash = "e9f5b300ab32886155c864b53e3d0e1dcf7cfdd7ed12567cf781cdf5e2edaaa8"
+python-versions = ">=3.9"
+content-hash = "2faadc22481219780bbf25b968d5391829a1e2833281e7b0f6947e97d7697008"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
   "Intended Audience :: Developers",
   "License :: OSI Approved :: MIT License",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -28,7 +27,7 @@ copier = "copier.__main__:copier_app_run"
 "Bug Tracker" = "https://github.com/copier-org/copier/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.8"
+python = ">=3.9"
 colorama = ">=0.4.6"
 dunamai = ">=1.7.0"
 funcy = ">=1.17"
@@ -41,7 +40,6 @@ pydantic = ">=2.4.2"
 pygments = ">=2.7.1"
 pyyaml = ">=5.3.1"
 questionary = ">=1.8.1"
-typing-extensions = { version = ">=3.7.4,<5.0.0", python = "<3.9" }
 eval-type-backport = { version = ">=0.1.3,<0.3.0", python = "<3.10" }
 
 [tool.poetry.group.dev]
@@ -61,6 +59,7 @@ types-colorama = ">=0.4"
 types-psutil = "*"
 types-pygments = ">=2.17"
 types-pyyaml = ">=6.0.4"
+typing-extensions = { version = ">=3.10.0.0,<5.0.0", python = "<3.10" }
 
 [tool.poetry.group.docs]
 optional = true

--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -6,7 +6,6 @@ from plumbum import local
 
 from copier import run_copy, run_update
 from copier.errors import DirtyLocalWarning
-from copier.tools import readlink
 
 from .helpers import build_file_tree, git
 
@@ -43,7 +42,7 @@ def test_copy_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert os.path.exists(dst / "target.txt")
     assert os.path.exists(dst / "symlink.txt")
     assert os.path.islink(dst / "symlink.txt")
-    assert readlink(dst / "symlink.txt") == Path("target.txt")
+    assert (dst / "symlink.txt").readlink() == Path("target.txt")
 
 
 def test_copy_symlink_templated_name(tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -79,7 +78,7 @@ def test_copy_symlink_templated_name(tmp_path_factory: pytest.TempPathFactory) -
     assert os.path.exists(dst / "target.txt")
     assert os.path.exists(dst / "symlink.txt")
     assert os.path.islink(dst / "symlink.txt")
-    assert readlink(dst / "symlink.txt") == Path("target.txt")
+    assert (dst / "symlink.txt").readlink() == Path("target.txt")
 
 
 def test_copy_symlink_templated_target(
@@ -119,11 +118,11 @@ def test_copy_symlink_templated_target(
 
     assert os.path.exists(dst / "symlink1.txt")
     assert os.path.islink(dst / "symlink1.txt")
-    assert readlink(dst / "symlink1.txt") == Path("target.txt")
+    assert (dst / "symlink1.txt").readlink() == Path("target.txt")
 
     assert not os.path.exists(dst / "symlink2.txt")
     assert os.path.islink(dst / "symlink2.txt")
-    assert readlink(dst / "symlink2.txt") == Path("{{ target_name }}.txt")
+    assert (dst / "symlink2.txt").readlink() == Path("{{ target_name }}.txt")
 
 
 def test_copy_symlink_missing_target(tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -155,7 +154,7 @@ def test_copy_symlink_missing_target(tmp_path_factory: pytest.TempPathFactory) -
     )
 
     assert os.path.islink(dst / "symlink.txt")
-    assert readlink(dst / "symlink.txt") == Path("target.txt")
+    assert (dst / "symlink.txt").readlink() == Path("target.txt")
     assert not os.path.exists(
         dst / "symlink.txt"
     )  # exists follows symlinks, It returns False as the target doesn't exist
@@ -289,7 +288,7 @@ def test_update_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
     p2 = dst / "symlink.txt"
     assert p1.read_text() == p2.read_text()
 
-    assert readlink(dst / "symlink.txt") == Path("bbbb.txt")
+    assert (dst / "symlink.txt").readlink() == Path("bbbb.txt")
 
 
 def test_update_file_to_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
@@ -348,7 +347,7 @@ def test_update_file_to_symlink(tmp_path_factory: pytest.TempPathFactory) -> Non
 
     # make sure changes propagate after update
     assert (dst / "bbbb.txt").is_symlink()
-    assert readlink(dst / "bbbb.txt") == Path("aaaa.txt")
+    assert (dst / "bbbb.txt").readlink() == Path("aaaa.txt")
     assert not (dst / "cccc.txt").is_symlink()
     assert (dst / "cccc.txt").read_text() == "Lorem ipsum"
 
@@ -464,4 +463,4 @@ def test_recursive_symlink(tmp_path_factory: pytest.TempPathFactory) -> None:
     )
     run_copy(str(src), dst, defaults=True, overwrite=True)
     assert (dst / "one" / "two" / "three" / "root").is_symlink()
-    assert readlink(dst / "one" / "two" / "three" / "root") == Path("../../../")
+    assert (dst / "one" / "two" / "three" / "root").readlink() == Path("../../../")


### PR DESCRIPTION
I've dropped support for Python 3.8, as it reached its [EOL on October 7, 2024](https://devguide.python.org/versions/#unsupported-versions). 

The cleanup to reduce technical debt involves two ~breaking~notable changes because we're now using features only available on Python 3.9+:

- Use `pathlib.Path.readlink` and remove our custom compatibility function
- Use `typing.Annotated` instead of `typing_extensions.Annotated`, and remove the runtime dependency on `typing-extensions`

@copier-org/maintainers ~Should we make another release prior to merging this PR? And should we consider the changes in this PR non-breaking because Python 3.8 has reached EOL and shouldn't be used anymore?~ On second thought, I think none of the changes should be considered breaking because (a) an EOL Python version shouldn't be used anymore and (b) any proper dependency resolver will not include a Copier release with `requires-python = ">=3.9"` for Python 3.8. I'll remove the breaking change marker and footer from the commit message.