### PR TITLE
fix: Don't mark files without conflict markers as unmerged

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -1108,12 +1108,12 @@ class Worker:
                         # The 3-way merge might have resolved conflicts automatically,
                         # so we need to check if the file contains conflict markers
                         # before storing the file name for marking it as unmerged after the loop.
-                        # with open(fname) as conflicts_candidate:
-                        #     if any(
-                        #         line.rstrip() in ("<<<<<<< before updating", ">>>>>>> after updating")
-                        #         for line in conflicts_candidate
-                        #     ):
-                        #         conflicted.append(fname)
+                        with open(fname) as conflicts_candidate:
+                            if any(
+                                line.rstrip() in ("<<<<<<< before updating", ">>>>>>> after updating")
+                                for line in conflicts_candidate
+                            ):
+                                conflicted.append(fname)
                     # Forcefully mark files with conflict markers as unmerged,
                     # see SO post: https://stackoverflow.com/questions/77391627/
                     # and Git docs: https://git-scm.com/docs/git-update-index#_using_index_info.

--- a/copier/main.py
+++ b/copier/main.py
@@ -1110,7 +1110,7 @@ class Worker:
                         # before storing the file name for marking it as unmerged after the loop.
                         with open(fname) as conflicts_candidate:
                             if any(
-                                line.rstrip() in ("<<<<<<< before updating", ">>>>>>> after updating")
+                                line.rstrip() in {"<<<<<<< before updating", ">>>>>>> after updating"}
                                 for line in conflicts_candidate
                             ):
                                 conflicted.append(fname)

--- a/copier/main.py
+++ b/copier/main.py
@@ -1102,10 +1102,10 @@ class Worker:
                         # The 3-way merge might have resolved conflicts automatically,
                         # so we need to check if the file contains conflict markers
                         # before storing the file name for marking it as unmerged after the loop.
-                        with open(fname) as f:
+                        with open(fname) as conflicts_candidate:
                             if any(
-                                line in ("<<<<<<< before updating", ">>>>>>> after updating")
-                                for line in f
+                                line.rstrip() in ("<<<<<<< before updating", ">>>>>>> after updating")
+                                for line in conflicts_candidate
                             ):
                                 conflicted.append(fname)
                     # Forcefully mark files with conflict markers as unmerged,

--- a/copier/main.py
+++ b/copier/main.py
@@ -1099,8 +1099,15 @@ class Worker:
                         )
                         # Remove rejection witness
                         Path(f"{fname}.rej").unlink()
-                        # Store file name for marking it as unmerged after the loop
-                        conflicted.append(fname)
+                        # The 3-way merge might have resolved conflicts automatically,
+                        # so we need to check if the file contains conflict markers
+                        # before storing the file name for marking it as unmerged after the loop.
+                        with open(fname) as f:
+                            if any(
+                                line in ("<<<<<<< before updating", ">>>>>>> after updating")
+                                for line in f
+                            ):
+                                conflicted.append(fname)
                     # Forcefully mark files with conflict markers as unmerged,
                     # see SO post: https://stackoverflow.com/questions/77391627/
                     # and Git docs: https://git-scm.com/docs/git-update-index#_using_index_info.

--- a/copier/main.py
+++ b/copier/main.py
@@ -1108,12 +1108,12 @@ class Worker:
                         # The 3-way merge might have resolved conflicts automatically,
                         # so we need to check if the file contains conflict markers
                         # before storing the file name for marking it as unmerged after the loop.
-                        with open(fname) as conflicts_candidate:
-                            if any(
-                                line.rstrip() in ("<<<<<<< before updating", ">>>>>>> after updating")
-                                for line in conflicts_candidate
-                            ):
-                                conflicted.append(fname)
+                        # with open(fname) as conflicts_candidate:
+                        #     if any(
+                        #         line.rstrip() in ("<<<<<<< before updating", ">>>>>>> after updating")
+                        #         for line in conflicts_candidate
+                        #     ):
+                        #         conflicted.append(fname)
                     # Forcefully mark files with conflict markers as unmerged,
                     # see SO post: https://stackoverflow.com/questions/77391627/
                     # and Git docs: https://git-scm.com/docs/git-update-index#_using_index_info.

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1239,7 +1239,7 @@ def test_conflicted_files_are_marked_unmerged(
     run_update(dst_path=dst, defaults=True, overwrite=True, conflict="inline")
     assert "_commit: v2" in (dst / ".copier-answers.yml").read_text()
 
-    # Assert that the file still exists, has inline markers,
+    # Assert that the file still exists, has inline conflict markers,
     # and is reported as "unmerged" by Git.
     assert (dst / filename).exists()
 
@@ -1258,6 +1258,72 @@ def test_conflicted_files_are_marked_unmerged(
     with local.cwd(dst):
         lines = git("status", "--porcelain=v1").strip().splitlines()
         assert any(
+            line.startswith("UU") and normalize_git_path(line[3:]) == filename
+            for line in lines
+        )
+
+
+def test_3way_merged_files_without_conflicts_are_not_marked_unmerged(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    filename = "readme.md"
+
+    # Template in v1 has a file with a single line;
+    # in v2 it changes that line.
+    # Meanwhile, downstream project made the same change.
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    # First, create the template with an initial file
+    build_file_tree(
+        {
+            (src / filename): "upstream version 1",
+            (src / "{{_copier_conf.answers_file}}.jinja"): (
+                "{{_copier_answers|to_nice_yaml}}"
+            ),
+        }
+    )
+    with local.cwd(src):
+        git_init("hello template")
+        git("tag", "v1")
+
+    # Generate the project a first time, assert the file exists
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+    assert (dst / filename).exists()
+    assert "_commit: v1" in (dst / ".copier-answers.yml").read_text()
+
+    # Start versioning the generated project
+    with local.cwd(dst):
+        git_init("hello project")
+
+        # After first commit, change the file, commit again
+        Path(filename).write_text("upstream version 2")
+        git("commit", "-am", "updated file")
+
+    # Now change the template
+    with local.cwd(src):
+        # Update the file
+        Path(filename).write_text("upstream version 2")
+
+        # Commit the changes
+        git("add", ".", "-A")
+        git("commit", "-m", "change line in file")
+        git("tag", "v2")
+
+    # Finally, update the generated project
+    run_update(dst_path=dst, defaults=True, overwrite=True, conflict="inline")
+    assert "_commit: v2" in (dst / ".copier-answers.yml").read_text()
+
+    # Assert that the file still exists, does not have inline conflict markers,
+    # and is not reported as "unmerged" by Git.
+    assert (dst / filename).exists()
+
+    expected_contents = "upstream version 2"
+    assert (dst / filename).read_text() == expected_contents
+    assert not (dst / f"{filename}.rej").exists()
+
+    with local.cwd(dst):
+        lines = git("status", "--porcelain=v1").strip().splitlines()
+        assert not any(
             line.startswith("UU") and normalize_git_path(line[3:]) == filename
             for line in lines
         )


### PR DESCRIPTION
Closes #1763.

**Please squash when merging, do not rebase.**