### PR TITLE
Introducing Copier Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 [![PyPI](https://img.shields.io/pypi/v/copier?logo=pypi&logoColor=%23959DA5)](https://pypi.org/project/copier/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Documentation Status](https://img.shields.io/readthedocs/copier/latest?logo=readthedocs)](https://copier.readthedocs.io/en/latest)
+[![](https://img.shields.io/badge/Gurubase-Ask%20Copier%20Guru-006BFF)](https://gurubase.io/g/copier)
 
 A library and CLI app for rendering project templates.
 


### PR DESCRIPTION
Hello Copier team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Copier Guru](https://gurubase.io/g/copier) to Gurubase. Copier Guru uses the data from this repo and data from the [docs](https://copier.readthedocs.io/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Copier Guru" badge, which highlights that Copier now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Copier Guru in Gurubase, just let me know that's totally fine.
