### PR TITLE
build(deps): add version specifier for `types-psutil` dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1741,4 +1741,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "2faadc22481219780bbf25b968d5391829a1e2833281e7b0f6947e97d7697008"
+content-hash = "ff0c17bbced2ef047a991d8a2905dcbba444ddae6b0a245be25e1b7d05db52d3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ pytest-gitconfig = ">=0.6.0"
 pytest-xdist = ">=2.5.0"
 types-backports = ">=0.1.3"
 types-colorama = ">=0.4"
-types-psutil = "*"
+types-psutil = ">=0"
 types-pygments = ">=2.17"
 types-pyyaml = ">=6.0.4"
 typing-extensions = { version = ">=3.10.0.0,<5.0.0", python = "<3.10" }


### PR DESCRIPTION
I've added an alternative version specifier for `types-psutil` which uses PEP440 and not Poetry syntax. The constraint is equivalent, but it also works around a Renovate bug that prevents Poetry lock file updates for dependencies constrained with `*`.

Renovate's implementation of Poetry's versioning scheme uses transformation to SemVer and NPM, as Poetry draws much inspiration from there, but PEP440 is a superset of SemVer, so Renovate's Poetry support has some limitations.