### PR TITLE
build(renovate): configure semantic commit type `build`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":semanticCommitType(build)"],
   "nix": {
     "enabled": true
   },
@@ -17,14 +17,6 @@
     {
       "matchManagers": ["github-actions"],
       "addLabels": ["github_actions"]
-    },
-    {
-      "matchPackageNames": ["*"],
-      "semanticCommitType": "build"
-    },
-    {
-      "matchDepTypes": ["dependencies"],
-      "semanticCommitType": "fix"
     }
   ]
 }


### PR DESCRIPTION
I've re-configured Renovate to use the semantic commit type `build` for all commits. The previous setting was behaving differently than I thought. I thought `fix` would only be used when also the manifest was updated, but it turns out that any runtime dependency updates would use `fix`. This is not desirable when maintaining a _library_ because lock file updates shouldn't be communicated to the users in the changelog. Thus, I've removed the previous configuration and added an override preset to use `build` for all updates.