### PR TITLE
fix: get_git_objects_dir compatible with git 2.30.2

### DIFF
--- a/copier/tools.py
+++ b/copier/tools.py
@@ -230,16 +230,15 @@ def get_git_objects_dir(path: Path) -> Path:
     from .vcs import get_git
 
     git = get_git()
-    return Path(
+    return path.joinpath(
         git(
             "-C",
             path,
             "rev-parse",
-            "--path-format=absolute",
             "--git-path",
             "objects",
         ).strip()
-    )
+    ).absolute()
 
 
 def set_git_alternates(*repos: Path, path: Path = Path(".")) -> None:


### PR DESCRIPTION
fixes https://github.com/copier-org/copier/issues/1837 by using pathlib logic to get an absolute path

info @wt-io-it