### PR TITLE
fix: re-render answers file path when producing render context

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -520,7 +520,7 @@ class Worker:
 
         self.answers = result
 
-    @cached_property
+    @property
     def answers_relpath(self) -> Path:
         """Obtain the proper relative path for the answers file.
 

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -78,3 +78,43 @@ def test_answersfile_templating(
     assert (tmp_path / first_answers_file).exists()
     answers = load_answersfile_data(tmp_path, first_answers_file)
     assert answers["module_name"] == "mymodule"
+
+
+def test_answersfile_templating_with_message_before_copy(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Test templated `_answers_file` setting with `_message_before_copy`.
+
+    Checks that the tempated answers file name is rendered correctly while
+    having printing a message before the "copy" operation, which uses the render
+    context before including any answers from the questionnaire.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yml"): (
+                """\
+                _answers_file: ".copier-answers-{{ module_name }}.yml"
+                _message_before_copy: "Hello world"
+
+                module_name:
+                    type: str
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+            (src / "result.txt.jinja"): "{{ module_name }}",
+        }
+    )
+    copier.run_copy(
+        str(src), dst, data={"module_name": "mymodule"}, overwrite=True, unsafe=True
+    )
+    assert (dst / ".copier-answers-mymodule.yml").exists()
+    answers = load_answersfile_data(dst, ".copier-answers-mymodule.yml")
+    assert answers["module_name"] == "mymodule"
+    assert (dst / "result.txt").exists()
+    assert (dst / "result.txt").read_text() == "mymodule"


### PR DESCRIPTION
I've fixed a bug related to rendering a template answers file name/path in combination with `_message_before_copy`.

The reason for this bug is as follows: When `_message_before_copy` is set, Copier [renders this message](https://github.com/copier-org/copier/blob/05aa1756d505b6223eef8eead6c875f353597846/copier/main.py#L832) before [starting the questionnaire](https://github.com/copier-org/copier/blob/05aa1756d505b6223eef8eead6c875f353597846/copier/main.py#L833), and thus at this point the [render context](https://github.com/copier-org/copier/blob/05aa1756d505b6223eef8eead6c875f353597846/copier/main.py#L334-L357) does not include any answers of questions, so rendering the templated `_answers_file` value leads to an incorrect result – but there's likely no practical reason to render the answers file in the pre-copy message. But rendering the pre-copy message requires the [render context which contains the rendered answers file](https://github.com/copier-org/copier/blob/05aa1756d505b6223eef8eead6c875f353597846/copier/main.py#L342) and prior to this PR the [rendered answers file value was cached](https://github.com/copier-org/copier/blob/05aa1756d505b6223eef8eead6c875f353597846/copier/main.py#L523-L524), hence the incorrect value was cached when the first render context was produced for rendering the pre-copy message.

This PR solves the problem by simply re-rendering the answers file path every time a render context is produced.

By the way, this bug would have been caught with less confusion if [Copier had supported configuring Jinja with `StrictUndefined`](https://github.com/copier-org/copier/issues/1522). :nerd_face:

Fixes #1825.