### PR TITLE
build(renovate): fix configuring semantic commit type `build`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":semanticCommitType(build)"],
+  "extends": ["config:recommended", ":semanticCommitTypeAll(build)"],
   "nix": {
     "enabled": true
   },


### PR DESCRIPTION
Just a minor Renovate config fix to make it use the semantic commit type `build` instead of `chore`/`fix` which included in `config:recommended` via `:semanticPrefixFixDepsChoreOthers`. It turns out that #1832 was incorrect because `:semanticCommitType(build)` is a preset for a setting, but `:semanticPrefixFixDepsChoreOthers` is a preset for _package rules_, so overriding those package rules requires a _package rule_ (preset) – at least that's how I understand it. `:semanticCommitTypeAll(build)` is exactly this. See also https://github.com/renovatebot/renovate/discussions/8440.