### PR TITLE
docs: Restructure context vars, add undocumented ones

### DIFF
--- a/docs/creating.md
+++ b/docs/creating.md
@@ -75,27 +75,58 @@ their usage.
 
 In addition to
 [all the features Jinja supports](https://jinja.palletsprojects.com/en/3.1.x/templates/),
-Copier includes:
+Copier provides all functions and filters from
+[jinja2-ansible-filters](https://gitlab.com/dreamer-labs/libraries/jinja2-ansible-filters/).
+This includes the `to_nice_yaml` filter, which is used extensively in our context.
 
--   All functions and filters from
-    [jinja2-ansible-filters](https://gitlab.com/dreamer-labs/libraries/jinja2-ansible-filters/).
+## Variables (global)
 
-    -   This includes the `to_nice_yaml` filter, which is used extensively in our
-        context.
+The following variables are always available in Jinja templates:
 
--   `_copier_answers` includes the current answers dict, but slightly modified to make
-    it suitable to [autoupdate your project safely][the-copier-answersyml-file]:
-    -   It doesn't contain secret answers.
-    -   It doesn't contain any data that is not easy to render to JSON or YAML.
-    -   It contains special keys like `_commit` and `_src_path`, indicating how the last
-        template update was done.
--   `_copier_conf` includes a representation of the current Copier
-    <!-- prettier-ignore -->
-    [Worker][copier.main.Worker] object, also slightly modified:
-    -   It only contains JSON-serializable data.
-    -   You can serialize it with `{{ _copier_conf|to_json }}`.
-    -   ⚠️ It contains secret answers inside its `.data` key.
-    -   Modifying it doesn't alter the current rendering configuration.
-    -   It contains the current commit hash from the template in
-        `{{ _copier_conf.vcs_ref_hash }}`.
-    -   Contains Operating System-specific directory separator under `sep` key.
+### `_copier_answers`
+
+`_copier_answers` includes the current answers dict, but slightly modified to make it
+suitable to [autoupdate your project safely][the-copier-answersyml-file]:
+
+-   It doesn't contain secret answers.
+-   It doesn't contain any data that is not easy to render to JSON or YAML.
+-   It contains special keys like `_commit` and `_src_path`, indicating how the last
+    template update was done.
+
+### `_copier_conf`
+
+`_copier_conf` includes a representation of the current Copier
+[Worker][copier.main.Worker] object, also slightly modified:
+
+-   It only contains JSON-serializable data.
+-   You can serialize it with `{{ _copier_conf|to_json }}`.
+-   ⚠️ It contains secret answers inside its `.data` key.
+-   Modifying it doesn't alter the current rendering configuration.
+
+Furthermore, the following keys are added:
+
+#### `_copier_conf.os`
+
+The detected Operating System, either `linux`, `macos`, `windows` or `None`.
+
+#### `_copier_conf.sep`
+
+The Operating System-specific directory separator.
+
+#### `_copier_conf.vcs_ref_hash`
+
+The current commit hash from the template.
+
+### `_copier_python`
+
+The absolute path of the Python interpreter running Copier.
+
+### `_folder_name`
+
+The name of the project root directory.
+
+## Variables (context-specific)
+
+Some rendering contexts provide variables unique to them:
+
+-   [`migrations`](configuring.md#migrations)

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -105,15 +105,15 @@ suitable to [autoupdate your project safely][the-copier-answersyml-file]:
 
 Furthermore, the following keys are added:
 
-#### `_copier_conf.os`
+#### `os` { #\_copier_conf.os }
 
-The detected Operating System, either `linux`, `macos`, `windows` or `None`.
+The detected operating system, either `"linux"`, `"macos"`, `"windows"` or `None`.
 
-#### `_copier_conf.sep`
+#### `sep` { #\_copier_conf.sep }
 
-The Operating System-specific directory separator.
+The operating system-specific directory separator.
 
-#### `_copier_conf.vcs_ref_hash`
+#### `vcs_ref_hash` { #\_copier_conf.vcs_ref_hash }
 
 The current commit hash from the template.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,6 +57,7 @@ extra_css:
 
 markdown_extensions:
   - admonition
+  - attr_list
   - pymdownx.highlight:
       use_pygments: true
   - pymdownx.superfences:


### PR DESCRIPTION
* Restructures documentation about available context variables.
* Adds (semi-)undocumented ones (`_copier_python`, `_folder_name`, `_copier_conf.os`).

Following [a request](https://github.com/copier-org/copier/pull/1733#discussion_r1836593276) by @sisp, this is extracted from https://github.com/copier-org/copier/pull/1733, which motivated the new structure for clarity.

Ref: https://github.com/copier-org/copier/issues/1842