### PR TITLE
build(vscode-extensions): update recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,9 +1,9 @@
 {
   "recommendations": [
-    "charliermarsh.ruff",
-    "esbenp.prettier-vscode",
-    "ms-python.python",
+    "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
     "editorconfig.editorconfig",
-    "bpruitt-goddard.mermaid-markdown-syntax-highlighting"
+    "elagil.pre-commit-helper",
+    "jnoortheen.nix-ide",
+    "ms-python.python"
   ]
 }


### PR DESCRIPTION
Using builtin prettier and ruff extensions is of no help because we use devenv.

Instead, pre-commit and nix-ide extensions integrate perfectly out of the box.

Thus, updating recommendations.