### PR TITLE
chore: llms-txt as post-build step to generate llms.txt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,3 +11,5 @@ build:
     post_install:
       - pip install poetry
       - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --with docs
+    post_build:
+      - llms-txt --docs-dir $READTHEDOCS_OUTPUT/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+llms-txt-action~=1.0.0


### PR DESCRIPTION
This PR adds an open-source post-build readthedocs step to generate llms files to the docs as per the standard. fixes #1922 
