### PR TITLE
docs:mention `uv tool` as an alterative to `pipx`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,10 @@ Ready to contribute? Here's how to set up the project for local development.
     ```shell
     pipx run pyclean . --debris --verbose
     ```
+    or
+    ```shell
+    uv tool run pyclean . --debris --verbose
+    ```
 
 1.  Commit your changes and push your branch to GitHub:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,9 @@ Ready to contribute? Here's how to set up the project for local development.
     ```shell
     pipx run pyclean . --debris --verbose
     ```
+
     or
+
     ```shell
     uvx pyclean . --debris --verbose
     ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ Ready to contribute? Here's how to set up the project for local development.
     ```
     or
     ```shell
-    uv tool run pyclean . --debris --verbose
+    uvx pyclean . --debris --verbose
     ```
 
 1.  Commit your changes and push your branch to GitHub:

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 A library and CLI app for rendering project templates.
 
-- Works with **local** paths and **Git URLs**.
-- Your project can include any file and Copier can dynamically replace values in any
+-   Works with **local** paths and **Git URLs**.
+-   Your project can include any file and Copier can dynamically replace values in any
     kind of text file.
-- It generates a beautiful output and takes care of not overwriting existing files
+-   It generates a beautiful output and takes care of not overwriting existing files
     unless instructed to do so.
 
 ![Sample output](https://github.com/copier-org/copier/raw/master/img/copier-output.png)
@@ -71,13 +71,13 @@ print("Hello from {{module_name}}!")
 
 To generate a project from the template:
 
-- On the command-line:
+-   On the command-line:
 
     ```shell
     copier copy path/to/project/template path/to/destination
     ```
 
-- Or in Python code, programmatically:
+-   Or in Python code, programmatically:
 
     ```python
     from copier import run_copy
@@ -107,13 +107,13 @@ Copier is composed of these main concepts:
 
 Copier targets these main human audiences:
 
-1. **Template creators**. Programmers that repeat code too much and prefer a tool to do
+1.  **Template creators**. Programmers that repeat code too much and prefer a tool to do
     it for them.
 
     **_Tip:_** Copier doesn't replace the DRY principle... but sometimes you simply
     can't be DRY and you need a DRYing machine...
 
-1. **Template consumers**. Programmers that want to start a new project quickly, or
+1.  **Template consumers**. Programmers that want to start a new project quickly, or
     that want to evolve it comfortably.
 
 Non-humans should be happy also by using Copier's CLI or API, as long as their

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
 
 A library and CLI app for rendering project templates.
 
--   Works with **local** paths and **Git URLs**.
--   Your project can include any file and Copier can dynamically replace values in any
+- Works with **local** paths and **Git URLs**.
+- Your project can include any file and Copier can dynamically replace values in any
     kind of text file.
--   It generates a beautiful output and takes care of not overwriting existing files
+- It generates a beautiful output and takes care of not overwriting existing files
     unless instructed to do so.
 
 ![Sample output](https://github.com/copier-org/copier/raw/master/img/copier-output.png)
@@ -25,7 +25,7 @@ A library and CLI app for rendering project templates.
 
 1. Install Python 3.9 or newer.
 1. Install Git 2.27 or newer.
-1. To use as a CLI app: [`pipx install copier`](https://github.com/pypa/pipx) or [`uv install copier`](https://docs.astral.sh/uv/#tool-management)
+1. To use as a CLI app: [`pipx install copier`](https://github.com/pypa/pipx) or [`uv tool install copier`](https://docs.astral.sh/uv/#tool-management)
 1. To use as a library: `pip install copier` or `conda install -c conda-forge copier`
 
 ### Nix flake
@@ -71,13 +71,13 @@ print("Hello from {{module_name}}!")
 
 To generate a project from the template:
 
--   On the command-line:
+- On the command-line:
 
     ```shell
     copier copy path/to/project/template path/to/destination
     ```
 
--   Or in Python code, programmatically:
+- Or in Python code, programmatically:
 
     ```python
     from copier import run_copy
@@ -107,13 +107,13 @@ Copier is composed of these main concepts:
 
 Copier targets these main human audiences:
 
-1.  **Template creators**. Programmers that repeat code too much and prefer a tool to do
+1. **Template creators**. Programmers that repeat code too much and prefer a tool to do
     it for them.
 
     **_Tip:_** Copier doesn't replace the DRY principle... but sometimes you simply
     can't be DRY and you need a DRYing machine...
 
-1.  **Template consumers**. Programmers that want to start a new project quickly, or
+1. **Template consumers**. Programmers that want to start a new project quickly, or
     that want to evolve it comfortably.
 
 Non-humans should be happy also by using Copier's CLI or API, as long as their

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ A library and CLI app for rendering project templates.
 
 1. Install Python 3.9 or newer.
 1. Install Git 2.27 or newer.
-1. To use as a CLI app: [`pipx install copier`](https://github.com/pypa/pipx) or [`uv tool install copier`](https://docs.astral.sh/uv/#tool-management)
+1. To use as a CLI app: [`pipx install copier`](https://github.com/pypa/pipx) or
+   [`uv tool install copier`](https://docs.astral.sh/uv/#tool-management)
 1. To use as a library: `pip install copier` or `conda install -c conda-forge copier`
 
 ### Nix flake

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A library and CLI app for rendering project templates.
 
 1. Install Python 3.9 or newer.
 1. Install Git 2.27 or newer.
-1. To use as a CLI app: `pipx install copier`
+1. To use as a CLI app: [`pipx install copier`](https://github.com/pypa/pipx) or [`uv install copier`](https://docs.astral.sh/uv/#tool-management)
 1. To use as a library: `pip install copier` or `conda install -c conda-forge copier`
 
 ### Nix flake

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1013,6 +1013,8 @@ on them, so they are always installed when Copier is installed.
 
     # if Copier was installed with pipx
     pipx inject copier jinja2-time
+    # if Copier was installed with uv tool
+    uv tool install --with jinja2-time copier
     ```
 
 !!! example

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1013,7 +1013,7 @@ on them, so they are always installed when Copier is installed.
 
     # if Copier was installed with pipx
     pipx inject copier jinja2-time
-    # if Copier was installed with uv tool
+    # if Copier was installed with uv
     uv tool install --with jinja2-time copier
     ```
 


### PR DESCRIPTION
A small change in the docs to support the use of `uv tool` instead of `pipx`, as it is sensibly faster and not many know about it.