### PR TITLE
refactor: Separate part of run_copy logic into a new generate method

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -832,6 +832,10 @@ class Worker:
         self._check_unsafe("copy")
         self._print_message(self.template.message_before_copy)
         self._ask()
+        self._generate()
+
+    def _generate(self) -> None:
+        """Generate the project files after answers have been collected."""
         was_existing = self.subproject.local_abspath.exists()
         try:
             if not self.quiet:


### PR DESCRIPTION
The `run_copy` method contained logic for both asking the questions and running the project generation. This made it impossible to do something between the two actions (after asking the questions and before running generation). Dividing the generation into it's own separate method allows for this.