### PR TITLE
feat(settings): add user settings support with `defaults` values and trusts

### DIFF
--- a/copier/errors.py
+++ b/copier/errors.py
@@ -139,3 +139,7 @@ class DirtyLocalWarning(UserWarning, CopierWarning):
 
 class ShallowCloneWarning(UserWarning, CopierWarning):
     """The template repository is a shallow clone."""
+
+
+class MissingSettingsWarning(UserWarning, CopierWarning):
+    """Settings path has been defined but file is missing."""

--- a/copier/main.py
+++ b/copier/main.py
@@ -241,7 +241,7 @@ class Worker:
 
     def _check_unsafe(self, mode: Literal["copy", "update"]) -> None:
         """Check whether a template uses unsafe features."""
-        if self.unsafe:
+        if self.unsafe or self.settings.is_trusted(self.template.url):
             return
         features: set[str] = set()
         if self.template.jinja_extensions:

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -1,0 +1,40 @@
+"""User settings models and helper functions."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+from typing import Any
+
+import yaml
+from platformdirs import user_config_path
+from pydantic import BaseModel, Field
+
+from .errors import MissingSettingsWarning
+
+ENV_VAR = "COPIER_SETTINGS_PATH"
+
+
+class Settings(BaseModel):
+    """User settings model."""
+
+    defaults: dict[str, Any] = Field(default_factory=dict)
+
+    @classmethod
+    def from_file(cls, settings_path: Path | None = None) -> Settings:
+        """Load settings from a file."""
+        env_path = os.getenv(ENV_VAR)
+        if settings_path is None:
+            if env_path:
+                settings_path = Path(env_path)
+            else:
+                settings_path = user_config_path("copier") / "settings.yml"
+        if settings_path.is_file():
+            data = yaml.safe_load(settings_path.read_text())
+            return cls.model_validate(data)
+        elif env_path:
+            warnings.warn(
+                f"Settings file not found at {env_path}", MissingSettingsWarning
+            )
+        return cls()

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -23,6 +23,8 @@ from pydantic_core.core_schema import ValidationInfo
 from pygments.lexers.data import JsonLexer, YamlLexer
 from questionary.prompts.common import Choice
 
+from copier.settings import Settings
+
 from .errors import InvalidTypeError, UserMessageError
 from .tools import cast_to_bool, cast_to_str, force_str_end
 from .types import MISSING, AnyByStrDict, MissingType, OptStrOrPath, StrOrPath
@@ -178,6 +180,7 @@ class Question:
     var_name: str
     answers: AnswersMap
     jinja_env: SandboxedEnvironment
+    settings: Settings = field(default_factory=Settings)
     choices: Sequence[Any] | dict[Any, Any] | str = field(default_factory=list)
     multiselect: bool = False
     default: Any = MISSING
@@ -246,7 +249,9 @@ class Question:
                 except KeyError:
                     if self.default is MISSING:
                         return MISSING
-                    result = self.render_value(self.default)
+                    result = self.render_value(
+                        self.settings.defaults.get(self.var_name, self.default)
+                    )
         result = self.cast_answer(result)
         return result
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1588,6 +1588,10 @@ switch `--UNSAFE` or `--trust`.
 
     Not supported in `copier.yml`.
 
+!!! tip
+
+    See the [`trust` setting][trusted-locations] to mark some repositories as always trusted.
+
 ### `use_prereleases`
 
 -   Format: `bool`

--- a/docs/reference/settings.md
+++ b/docs/reference/settings.md
@@ -1,0 +1,1 @@
+::: copier.settings

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,39 @@
+# Settings
+
+Copier settings are stored in `<CONFIG_ROOT>/settings.yml` where `<CONFIG_ROOT>` is the
+standard configuration directory for your platform:
+
+-   `$XDG_CONFIG_HOME/copier` (`~/.config/copier ` in most cases) on Linux as defined by
+    [XDG Base Directory Specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+-   `~/Library/Application Support/copier` on macOS as defined by
+    [Apple File System Basics](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
+-   `%USERPROFILE%\AppData\Local\copier` on Windows as defined in
+    [Known folders](https://docs.microsoft.com/en-us/windows/win32/shell/known-folders)
+
+This location can be overridden by setting the `COPIER_SETTINGS_PATH` environment
+variable.
+
+## User defaults
+
+Users may define some reusable default variables in the `defaults` section of the
+configuration file.
+
+```yaml title="<CONFIG_ROOT>/settings.yml"
+defaults:
+    user_name: "John Doe"
+    user_email: john.doe@acme.com
+```
+
+This user data will replace the default value of fields of the same name.
+
+### Well-known variables
+
+To ensure templates efficiently reuse user-defined variables, we invite template authors
+to use the following well-known variables:
+
+| Variable name | Type  | Description            |
+| ------------- | ----- | ---------------------- |
+| `user_name`   | `str` | User's full name       |
+| `user_email`  | `str` | User's email address   |
+| `github_user` | `str` | User's GitHub username |
+| `gitlab_user` | `str` | User's GitLab username |

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -37,3 +37,20 @@ to use the following well-known variables:
 | `user_email`  | `str` | User's email address   |
 | `github_user` | `str` | User's GitHub username |
 | `gitlab_user` | `str` | User's GitLab username |
+
+## Trusted locations
+
+Users may define trusted locations in the `trust` setting. It should be a list of Copier
+template repositories, or repositories prefix.
+
+```yaml
+trust:
+    - https://github.com/your_account/your_template.git
+    - https://github.com/your_account/
+    - ~/templates/
+```
+
+!!! warning "Security considerations"
+
+    Locations ending with `/` will be matched as prefixes, trusting all templates starting with that path.
+    Locations not ending with `/` will be matched exactly.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,11 +11,13 @@ nav:
   - Configuring a template: "configuring.md"
   - Generating a project: "generating.md"
   - Updating a project: "updating.md"
+  - Settings: "settings.md"
   - Reference:
       - cli.py: "reference/cli.md"
       - errors.py: "reference/errors.md"
       - jinja_ext.py: "reference/jinja_ext.md"
       - main.py: "reference/main.md"
+      - settings.py: "reference/settings.md"
       - subproject.py: "reference/subproject.md"
       - template.py: "reference/template.md"
       - tools.py: "reference/tools.md"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1755,4 +1755,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9"
-content-hash = "888edb00b45adbcefa12e5e242365976d18e2f7356d522b873e973debbb59517"
+content-hash = "3c9bb33fa0a43bd04125dbd879cef233ac4e3582431b3e06817f77bc9da84920"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ pygments = ">=2.7.1"
 pyyaml = ">=5.3.1"
 questionary = ">=1.8.1"
 eval-type-backport = { version = ">=0.1.3,<0.3.0", python = "<3.10" }
+platformdirs = ">=4.3.6"
 
 [tool.poetry.group.dev]
 optional = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import platform
 import sys
+from pathlib import Path
 from typing import Any, Iterator
+from unittest.mock import patch
 
 import pytest
 from coverage.tracer import CTracer
@@ -75,3 +77,18 @@ def gitconfig(gitconfig: GitConfig) -> Iterator[GitConfig]:
     """
     with local.env(GIT_CONFIG_GLOBAL=str(gitconfig)):
         yield gitconfig
+
+
+@pytest.fixture
+def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    config_path = tmp_path / "config"
+    monkeypatch.delenv("COPIER_SETTINGS_PATH", raising=False)
+    with patch("copier.settings.user_config_path", return_value=config_path):
+        yield config_path
+
+
+@pytest.fixture
+def settings_path(config_path: Path) -> Path:
+    config_path.mkdir()
+    settings_path = config_path / "settings.yml"
+    return settings_path

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,6 +12,7 @@ def test_default_settings() -> None:
     settings = Settings()
 
     assert settings.defaults == {}
+    assert settings.trust == set()
 
 
 def test_settings_from_default_location(settings_path: Path) -> None:
@@ -69,3 +70,32 @@ def test_settings_defined_but_missing(
 
     with pytest.warns(MissingSettingsWarning):
         Settings.from_file()
+
+
+@pytest.mark.parametrize(
+    ("repository", "trust", "is_trusted"),
+    [
+        ("https://github.com/user/repo.git", set(), False),
+        (
+            "https://github.com/user/repo.git",
+            {"https://github.com/user/repo.git"},
+            True,
+        ),
+        ("https://github.com/user/repo", {"https://github.com/user/repo.git"}, False),
+        ("https://github.com/user/repo.git", {"https://github.com/user/"}, True),
+        ("https://github.com/user/repo.git", {"https://github.com/user/repo"}, False),
+        ("https://github.com/user/repo.git", {"https://github.com/user"}, False),
+        ("https://github.com/user/repo.git", {"https://github.com/"}, True),
+        ("https://github.com/user/repo.git", {"https://github.com"}, False),
+        (f"{Path.home()}/template", set(), False),
+        (f"{Path.home()}/template", {f"{Path.home()}/template"}, True),
+        (f"{Path.home()}/template", {"~/template"}, True),
+        (f"{Path.home()}/path/to/template", {"~/path/to/template"}, True),
+        (f"{Path.home()}/path/to/template", {"~/path/to/"}, True),
+        (f"{Path.home()}/path/to/template", {"~/path/to"}, False),
+    ],
+)
+def test_is_trusted(repository: str, trust: set[str], is_trusted: bool) -> None:
+    settings = Settings(trust=trust)
+
+    assert settings.is_trusted(repository) == is_trusted

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from copier.errors import MissingSettingsWarning
+from copier.settings import Settings
+
+
+def test_default_settings() -> None:
+    settings = Settings()
+
+    assert settings.defaults == {}
+
+
+def test_settings_from_default_location(settings_path: Path) -> None:
+    settings_path.write_text("defaults:\n  foo: bar")
+
+    settings = Settings.from_file()
+
+    assert settings.defaults == {"foo": "bar"}
+
+
+@pytest.mark.usefixtures("config_path")
+def test_settings_from_default_location_dont_exists() -> None:
+    settings = Settings.from_file()
+
+    assert settings.defaults == {}
+
+
+def test_settings_from_env_location(
+    settings_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings_path.write_text("defaults:\n  foo: bar")
+
+    settings_from_env_path = tmp_path / "settings.yml"
+    settings_from_env_path.write_text("defaults:\n  foo: baz")
+
+    monkeypatch.setenv("COPIER_SETTINGS_PATH", str(settings_from_env_path))
+
+    settings = Settings.from_file()
+
+    assert settings.defaults == {"foo": "baz"}
+
+
+def test_settings_from_param(
+    settings_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    settings_path.write_text("defaults:\n  foo: bar")
+
+    settings_from_env_path = tmp_path / "settings.yml"
+    settings_from_env_path.write_text("defaults:\n  foo: baz")
+
+    monkeypatch.setenv("COPIER_SETTINGS_PATH", str(settings_from_env_path))
+
+    file_path = tmp_path / "file.yml"
+    file_path.write_text("defaults:\n  from: file")
+
+    settings = Settings.from_file(file_path)
+
+    assert settings.defaults == {"from": "file"}
+
+
+def test_settings_defined_but_missing(
+    settings_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COPIER_SETTINGS_PATH", str(settings_path))
+
+    with pytest.warns(MissingSettingsWarning):
+        Settings.from_file()


### PR DESCRIPTION
Hello 👋🏼 

This PR adds support for user settings with initial support for:
- user defaults (#235)
- trusted repositories

Settings are stored in `<CONFIG_ROOT>/settings.yml` where `<CONFIG_ROOT>` is the
standard configuration directory for your platform:

- `$XDG_CONFIG_HOME/copier` (`~/.config/copier ` in most cases) on Linux as defined by
    [XDG Base Directory Specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
- `~/Library/Application Support/copier` on macOS as defined by
    [Apple File System Basics](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
- `%USERPROFILE%\AppData\Local\copier` on Windows as defined in
    [Known folders](https://docs.microsoft.com/en-us/windows/win32/shell/known-folders)

This location can be overridden by setting the `COPIER_SETTINGS` environment variable.

The settings look like:
```yaml
defaults:
    user_name: "John Doe"
    user_email: john.doe@acme.com
trust:
    - https://github.com/account/template.git
    - https://github.com/org/
    - ~/templates/
```