### PR TITLE
feat(settings): custom shortcuts

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -102,7 +102,7 @@ class Worker:
         src_path:
             String that can be resolved to a template path, be it local or remote.
 
-            See [copier.vcs.get_repo][].
+            See [copier.vcs.get_repo][] and [`shortcuts` setting][shortcuts]
 
             If it is `None`, then it means that you are
             [updating a project][updating-a-project], and the original
@@ -913,7 +913,10 @@ class Worker:
                 raise TypeError("Template not found")
             url = str(self.subproject.template.url)
         result = Template(
-            url=url, ref=self.vcs_ref, use_prereleases=self.use_prereleases
+            url=url,
+            ref=self.vcs_ref,
+            use_prereleases=self.use_prereleases,
+            settings=self.settings,
         )
         self._cleanup_hooks.append(result._cleanup)
         return result

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import warnings
 from os.path import expanduser
 from pathlib import Path
@@ -10,11 +11,42 @@ from typing import Any
 
 import yaml
 from platformdirs import user_config_path
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from .errors import MissingSettingsWarning
 
 ENV_VAR = "COPIER_SETTINGS_PATH"
+
+RE_REF = re.compile(r"^(?P<url>.+?)@(?P<ref>[^:]+)$")
+
+
+class Shortcut(BaseModel):
+    """Shortcut model."""
+
+    url: str = Field(description="Prefix url to replace the prefix with.")
+    suffix: bool = Field(default=True, description="Whether to add a `.git` suffix.")
+
+    @model_validator(mode="before")
+    @classmethod
+    def handle_string(cls, value: Any) -> Any:
+        """Allow short syntax using string only."""
+        if isinstance(value, str):
+            return {"url": value}
+        return value
+
+    @field_validator("url", mode="after")
+    @classmethod
+    def inject_trailing_slash(cls, value: str) -> str:
+        """Always add a trailing slash."""
+        if not value.endswith("/"):
+            value += "/"
+        return value
+
+
+DEFAULT_SHORTCUTS = {
+    "gh": Shortcut(url="https://github.com/"),
+    "gl": Shortcut(url="https://gitlab.com/"),
+}
 
 
 class Settings(BaseModel):
@@ -22,6 +54,9 @@ class Settings(BaseModel):
 
     defaults: dict[str, Any] = Field(
         default_factory=dict, description="Default values for questions"
+    )
+    shortcuts: dict[str, Shortcut] = Field(
+        DEFAULT_SHORTCUTS, description="URL shortcuts"
     )
     trust: set[str] = Field(
         default_factory=set, description="List of trusted repositories or prefixes"
@@ -45,17 +80,40 @@ class Settings(BaseModel):
             )
         return cls()
 
+    @field_validator("shortcuts", mode="after")
+    @classmethod
+    def inject_defaults(cls, value: dict[str, Shortcut]) -> dict[str, Shortcut]:
+        """Ensure default are always present unless overridden."""
+        return {**DEFAULT_SHORTCUTS, **value}
+
     def is_trusted(self, repository: str) -> bool:
         """Check if a repository is trusted."""
         return any(
-            repository.startswith(self.normalize(trusted))
+            self.normalize(repository).startswith(self.normalize(trusted))
             if trusted.endswith("/")
-            else repository == self.normalize(trusted)
+            else self.normalize(repository) == self.normalize(trusted)
             for trusted in self.trust
         )
 
     def normalize(self, url: str) -> str:
         """Normalize an URL using user settings."""
+        url, ref = url.removeprefix("git+"), None
+        if m := RE_REF.match(url):
+            url = m.group("url")
+            ref = m.group("ref")
+        for prefix, shortcut in self.shortcuts.items():
+            prefix = f"{prefix}:"
+            if url.startswith(prefix):
+                # Inject shortcut
+                url = url.replace(prefix, shortcut.url)
+                # Remove double slash if any
+                url = url.replace(f"{shortcut.url}/", shortcut.url)
+            if url.startswith(shortcut.url):
+                if not url.endswith((".git", "/")):
+                    url += ".git" if shortcut.suffix else "/"
+                break
         if url.startswith("~"):  # Only expand on str to avoid messing with URLs
             url = expanduser(url)  # noqa: PTH111
+        if ref:
+            url = f"{url}@{ref}"
         return url

--- a/copier/template.py
+++ b/copier/template.py
@@ -21,6 +21,8 @@ from packaging.version import Version, parse
 from plumbum.machines import local
 from pydantic.dataclasses import dataclass
 
+from copier.settings import Settings
+
 from .errors import (
     InvalidConfigFileError,
     MultipleConfigFilesError,
@@ -216,6 +218,7 @@ class Template:
     url: str
     ref: str | None = None
     use_prereleases: bool = False
+    settings: Settings = field(default_factory=Settings)
 
     def _cleanup(self) -> None:
         if temp_clone := self._temp_clone():
@@ -578,7 +581,7 @@ class Template:
         format, which wouldn't be understood by the underlying VCS system. This
         property returns the expanded version, which should work properly.
         """
-        return get_repo(self.url) or self.url
+        return self.settings.normalize(self.url)
 
     @cached_property
     def version(self) -> Version | None:
@@ -611,6 +614,6 @@ class Template:
     @cached_property
     def vcs(self) -> VCSTypes | None:
         """Get VCS system used by the template, if any."""
-        if get_repo(self.url):
+        if get_repo(self.url_expanded):
             return "git"
         return None

--- a/copier/vcs.py
+++ b/copier/vcs.py
@@ -43,12 +43,6 @@ def get_git_version() -> Version:
 
 GIT_PREFIX = ("git@", "git://", "git+", "https://github.com/", "https://gitlab.com/")
 GIT_POSTFIX = ".git"
-REPLACEMENTS = (
-    (re.compile(r"^gh:/?(.*\.git)$"), r"https://github.com/\1"),
-    (re.compile(r"^gh:/?(.*)$"), r"https://github.com/\1.git"),
-    (re.compile(r"^gl:/?(.*\.git)$"), r"https://gitlab.com/\1"),
-    (re.compile(r"^gl:/?(.*)$"), r"https://gitlab.com/\1.git"),
-)
 
 
 def is_git_repo_root(path: StrOrPath) -> bool:
@@ -97,8 +91,6 @@ def get_repo(url: str) -> str | None:
         url:
             Valid examples:
 
-            - gh:copier-org/copier
-            - gl:copier-org/copier
             - git@github.com:copier-org/copier.git
             - git+https://mywebsiteisagitrepo.example.com/
             - /local/path/to/git/repo
@@ -106,9 +98,6 @@ def get_repo(url: str) -> str | None:
             - ~/path/to/git/repo
             - ~/path/to/git/repo.bundle
     """
-    for pattern, replacement in REPLACEMENTS:
-        url = re.sub(pattern, replacement, url)
-
     if url.endswith(GIT_POSTFIX) or url.startswith(GIT_PREFIX):
         if url.startswith("git+"):
             return url[4:]

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -54,3 +54,72 @@ trust:
 
     Locations ending with `/` will be matched as prefixes, trusting all templates starting with that path.
     Locations not ending with `/` will be matched exactly.
+
+## Shortcuts
+
+It is possible to define shortcuts in the `shortcuts` setting. It should be a dictionary
+where keys are the shortcut names and values are [copier.settings.Shortcut][] objects.
+
+```yaml
+shortcuts:
+    company:
+        url: "https://git.company.org"
+        suffix: true
+    local:
+        url: ~/project/templates
+        suffix: false
+```
+
+If suffix is `True` (default), the `.git` suffix will be appended to the URL if missing.
+
+A string can be used as short syntax instead of a full Shortcut object.
+
+This snippet is equivalent to the previous one:
+
+```yaml
+shortcuts:
+    company: "https://git.company.org"
+    local:
+        url: ~/project/templates
+        suffix: false
+```
+
+You can now write:
+
+```shell
+copier copy company:team/repo
+copier copy local:template
+```
+
+There are 2 default shortcuts always available unless you explicitely override them:
+
+```yaml
+shortcuts:
+    gh: "https://github.com/"
+    gl: "https://gitlab.com/"
+```
+
+!!! tip "Working with private repositories"
+
+    If you work with private GitHub or Gitlab repositories,
+    you might want to override those to force authenticated ssh access:
+
+    ```yaml
+    shortcuts:
+        gh: 'git@github.com:'
+        gl: 'git@gitlab.com:'
+    ```
+
+    Note the trailing `:` in the URL, it is required to make Git use the SSH protocol.
+    (`gh:user/repo` will be expanded into `git@github.com:user/repo.git`)
+
+!!! tip "Trusted locations and shortcuts"
+
+    Trusted locations can be defined using shortcuts.
+
+    ```yaml
+    trust:
+        - gh:user/repo
+        - gh:company/
+        - 'local:'
+    ```

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pytest
 
 from copier.errors import MissingSettingsWarning
-from copier.settings import Settings
+from copier.settings import DEFAULT_SHORTCUTS, Settings, Shortcut
 
 
 def test_default_settings() -> None:
@@ -13,6 +13,7 @@ def test_default_settings() -> None:
 
     assert settings.defaults == {}
     assert settings.trust == set()
+    assert settings.shortcuts == DEFAULT_SHORTCUTS
 
 
 def test_settings_from_default_location(settings_path: Path) -> None:
@@ -81,21 +82,132 @@ def test_settings_defined_but_missing(
             {"https://github.com/user/repo.git"},
             True,
         ),
-        ("https://github.com/user/repo", {"https://github.com/user/repo.git"}, False),
+        ("https://github.com/user/repo", {"https://github.com/user/repo.git"}, True),
         ("https://github.com/user/repo.git", {"https://github.com/user/"}, True),
-        ("https://github.com/user/repo.git", {"https://github.com/user/repo"}, False),
+        ("https://github.com/user/repo.git", {"https://github.com/user/repo"}, True),
         ("https://github.com/user/repo.git", {"https://github.com/user"}, False),
         ("https://github.com/user/repo.git", {"https://github.com/"}, True),
         ("https://github.com/user/repo.git", {"https://github.com"}, False),
         (f"{Path.home()}/template", set(), False),
         (f"{Path.home()}/template", {f"{Path.home()}/template"}, True),
         (f"{Path.home()}/template", {"~/template"}, True),
+        ("~/template", {f"{Path.home()}/template"}, True),
         (f"{Path.home()}/path/to/template", {"~/path/to/template"}, True),
         (f"{Path.home()}/path/to/template", {"~/path/to/"}, True),
         (f"{Path.home()}/path/to/template", {"~/path/to"}, False),
+        ("https://github.com/user/repo.git", {"gh:user/"}, True),
+        ("https://github.com/user/repo.git", {"gh:user/repo"}, True),
+        ("https://github.com/user/repo.git", {"gh:user/rep"}, False),
     ],
 )
 def test_is_trusted(repository: str, trust: set[str], is_trusted: bool) -> None:
     settings = Settings(trust=trust)
 
     assert settings.is_trusted(repository) == is_trusted
+
+
+@pytest.mark.parametrize(
+    "provided,expected",
+    [
+        ({}, DEFAULT_SHORTCUTS),
+        # Default shortcuts are always provided
+        (
+            {"some": {"url": "https://somewhere.com/", "suffix": False}},
+            {
+                "some": Shortcut(url="https://somewhere.com/", suffix=False),
+                **DEFAULT_SHORTCUTS,
+            },
+        ),
+        # Trailing slash is always appended
+        (
+            {"some": {"url": "https://somewhere.com"}},
+            {
+                "some": Shortcut(url="https://somewhere.com/"),
+                **DEFAULT_SHORTCUTS,
+            },
+        ),
+        # strings are properly handled
+        (
+            {"some": "https://somewhere.com/"},
+            {
+                "some": Shortcut(url="https://somewhere.com/"),
+                **DEFAULT_SHORTCUTS,
+            },
+        ),
+        # Default are overridable
+        (
+            {"gh": "https://somewhere.com/"},
+            {
+                "gh": Shortcut(url="https://somewhere.com/"),
+                "gl": Shortcut(url="https://gitlab.com/"),
+            },
+        ),
+    ],
+)
+def test_shortcuts_parsing(
+    provided: dict[str, str | Shortcut], expected: dict[str, Shortcut]
+) -> None:
+    settings = Settings(shortcuts=provided)
+
+    assert settings.shortcuts == expected
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/user/repo", "https://github.com/user/repo.git"),
+        ("gh:user/repo", "https://github.com/user/repo.git"),
+        ("gl:user/repo", "https://gitlab.com/user/repo.git"),
+        ("gh:/user/repo", "https://github.com/user/repo.git"),
+        ("gh:user/repo.git", "https://github.com/user/repo.git"),
+        ("gh:/user/repo.git", "https://github.com/user/repo.git"),
+        ("gh:user/", "https://github.com/user/"),
+        ("gh:/user/", "https://github.com/user/"),
+        ("gh:user", "https://github.com/user.git"),
+        ("local:", f"{Path.home()}/projects/"),
+        ("local:/", f"{Path.home()}/projects/"),
+        ("local:dir", f"{Path.home()}/projects/dir/"),
+        ("local:/dir", f"{Path.home()}/projects/dir/"),
+        ("local:dir/", f"{Path.home()}/projects/dir/"),
+        ("~/projects", f"{Path.home()}/projects"),
+        (
+            "git://git.myproject.org/MyProject.git@master",
+            "git://git.myproject.org/MyProject.git@master",
+        ),
+        (
+            "git://git.myproject.org/MyProject@master",
+            "git://git.myproject.org/MyProject.git@master",
+        ),
+        (
+            "git://git.myproject.org/MyProject.git@v1.0",
+            "git://git.myproject.org/MyProject.git@v1.0",
+        ),
+        (
+            "git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef956018",
+            "git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef956018",
+        ),
+        (
+            "project:MyProject@master",
+            "git://git.myproject.org/MyProject.git@master",
+        ),
+        ("project:MyProject.git@v1.0", "git://git.myproject.org/MyProject.git@v1.0"),
+        (
+            "project:MyProject@da39a3ee5e6b4b0d3255bfef956018",
+            "git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef956018",
+        ),
+        ("git+https://github.com/user/repo", "https://github.com/user/repo.git"),
+        (
+            "git@git.myproject.org:MyProject@master",
+            "git@git.myproject.org:MyProject@master",
+        ),
+    ],
+)
+def test_normalize(url: str, expected: str) -> None:
+    settings = Settings(
+        shortcuts={
+            "local": Shortcut(url="~/projects", suffix=False),
+            "project": Shortcut(url="git://git.myproject.org/"),
+        }
+    )
+
+    assert settings.normalize(url) == expected

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -15,55 +15,48 @@ from copier.vcs import checkout_latest_tag, clone, get_git_version, get_repo
 from .helpers import git
 
 
-def test_get_repo() -> None:
-    get = get_repo
-
-    assert get("git@git.myproject.org:MyProject") == "git@git.myproject.org:MyProject"
-    assert (
-        get("git://git.myproject.org/MyProject") == "git://git.myproject.org/MyProject"
-    )
-    assert (
-        get("https://github.com/jpscaletti/copier.git")
-        == "https://github.com/jpscaletti/copier.git"
-    )
-
-    assert (
-        get("https://github.com/jpscaletti/copier")
-        == "https://github.com/jpscaletti/copier.git"
-    )
-    assert (
-        get("https://gitlab.com/gitlab-org/gitlab")
-        == "https://gitlab.com/gitlab-org/gitlab.git"
-    )
-
-    assert (
-        get("gh:/jpscaletti/copier.git") == "https://github.com/jpscaletti/copier.git"
-    )
-    assert get("gh:jpscaletti/copier.git") == "https://github.com/jpscaletti/copier.git"
-    assert get("gl:jpscaletti/copier.git") == "https://gitlab.com/jpscaletti/copier.git"
-    assert get("gh:jpscaletti/copier") == "https://github.com/jpscaletti/copier.git"
-    assert get("gl:jpscaletti/copier") == "https://gitlab.com/jpscaletti/copier.git"
-
-    assert (
-        get("git+https://git.myproject.org/MyProject")
-        == "https://git.myproject.org/MyProject"
-    )
-    assert (
-        get("git+ssh://git.myproject.org/MyProject")
-        == "ssh://git.myproject.org/MyProject"
-    )
-
-    assert get("git://git.myproject.org/MyProject.git@master")
-    assert get("git://git.myproject.org/MyProject.git@v1.0")
-    assert get("git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef956018")
-
-    assert get("http://google.com") is None
-    assert get("git.myproject.org/MyProject") is None
-    assert get("https://google.com") is None
-
-    assert (
-        get("tests/demo_updatediff_repo.bundle") == "tests/demo_updatediff_repo.bundle"
-    )
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("git@git.myproject.org:MyProject", "git@git.myproject.org:MyProject"),
+        ("git://git.myproject.org/MyProject", "git://git.myproject.org/MyProject"),
+        (
+            "https://github.com/jpscaletti/copier.git",
+            "https://github.com/jpscaletti/copier.git",
+        ),
+        (
+            "https://github.com/jpscaletti/copier",
+            "https://github.com/jpscaletti/copier.git",
+        ),
+        (
+            "https://gitlab.com/gitlab-org/gitlab",
+            "https://gitlab.com/gitlab-org/gitlab.git",
+        ),
+        (
+            "git+https://git.myproject.org/MyProject",
+            "https://git.myproject.org/MyProject",
+        ),
+        ("git+ssh://git.myproject.org/MyProject", "ssh://git.myproject.org/MyProject"),
+        (
+            "git://git.myproject.org/MyProject.git@master",
+            "git://git.myproject.org/MyProject.git@master",
+        ),
+        (
+            "git://git.myproject.org/MyProject.git@v1.0",
+            "git://git.myproject.org/MyProject.git@v1.0",
+        ),
+        (
+            "git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef956018",
+            "git://git.myproject.org/MyProject.git@da39a3ee5e6b4b0d3255bfef956018",
+        ),
+        ("http://google.com", None),
+        ("git.myproject.org/MyProject", None),
+        ("https://google.com", None),
+        ("tests/demo_updatediff_repo.bundle", "tests/demo_updatediff_repo.bundle"),
+    ],
+)
+def test_get_repo(url: str, expected: str) -> None:
+    assert get_repo(url) == expected
 
 
 @pytest.mark.impure


### PR DESCRIPTION
It makes the prefixes (currently `gh:` and `gl:`) customizable using user settings, allowing to:
- add your own (remote and local)
- override the existing ones (especially to force ssh access on private repositories)
- benefit from specific GitHub and GitLab behavior on alternative, private or corporate instances

It moves URL normalization into the settings to benefit from custom shortcuts.

Some decisions are required on the `vcs.get_repo()` behavior: 
it currently only assumes `https://gitlab` and `https://github` are http git repositories, unless prefixed with `git+`.
However, non git remotes are not supported, so I wonder if it would be simpler to consider all `https://` as git repositories (it would fail if this is not the case, whatever this method returns)