### PR TITLE
feat(context): expose a `_phase` context variable (fix #1883)

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import json
 import warnings
 from collections import ChainMap
+from collections.abc import Mapping, Sequence
 from dataclasses import field
 from datetime import datetime
 from functools import cached_property
 from hashlib import sha512
 from os import urandom
 from pathlib import Path
-from typing import Any, Callable, Literal, Mapping, Sequence
+from typing import Any, Callable, Literal
 
 import yaml
 from jinja2 import UndefinedError
@@ -33,6 +34,7 @@ from .types import (
     AnyByStrMutableMapping,
     LazyDict,
     MissingType,
+    Phase,
     StrOrPath,
 )
 
@@ -464,7 +466,13 @@ class Question:
                 else value
             )
         try:
-            return template.render({**self.answers.combined, **(extra_answers or {})})
+            return template.render(
+                {
+                    **self.answers.combined,
+                    **(extra_answers or {}),
+                    "_copier_phase": Phase.current(),
+                }
+            )
         except UndefinedError as error:
             raise UserMessageError(str(error)) from error
 

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -136,6 +136,16 @@ variable:
 
 The name of the project root directory.
 
+### `_copier_phase`
+
+The current phase, one of `"prompt"`,`"tasks"`, `"migrate"` or `"render"`.
+
+!!! note
+
+    There is also an additional `"undefined"` phase used when not in any phase.
+    You may encounter this phase when rendering outside of those phases,
+    when rendering lazily (and the phase notion can be irrelevant) or when testing.
+
 ## Variables (context-specific)
 
 Some rendering contexts provide variables unique to them:

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -118,3 +118,21 @@ def test_answersfile_templating_with_message_before_copy(
     assert answers["module_name"] == "mymodule"
     assert (dst / "result.txt").exists()
     assert (dst / "result.txt").read_text() == "mymodule"
+
+
+def test_answersfile_templating_phase(tmp_path_factory: pytest.TempPathFactory) -> None:
+    """
+    Ensure `_copier_phase` is available while render `answers_relpath`.
+    Not because it is directly useful, but because some extensions might need it.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": """\
+                _answers_file: ".copier-answers-{{ _copier_phase }}.yml"
+                """,
+            src / "{{ _copier_conf.answers_file }}.jinja": "",
+        }
+    )
+    copier.run_copy(str(src), dst, overwrite=True, unsafe=True)
+    assert (dst / ".copier-answers-render.yml").exists()

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1041,3 +1041,11 @@ def test_templated_choices(tmp_path_factory: pytest.TempPathFactory, spec: str) 
     )
     copier.run_copy(str(src), dst, data={"q": "two"})
     assert yaml.safe_load((dst / "q.txt").read_text()) == "two"
+
+
+def test_copier_phase_variable(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree({src / "{{ _copier_phase }}.jinja": "{{ _copier_phase }}"})
+    copier.run_copy(str(src), dst)
+    assert (dst / "render").exists()
+    assert (dst / "render").read_text() == "render"

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -164,3 +164,19 @@ def test_os_specific_tasks(
     monkeypatch.setattr("copier.main.OS", os)
     copier.run_copy(str(src), dst, unsafe=True)
     assert (dst / filename).exists()
+
+
+def test_copier_phase_variable(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yml"): (
+                """
+                _tasks:
+                    - touch {{ _copier_phase }}
+                """
+            )
+        }
+    )
+    copier.run_copy(str(src), dst, unsafe=True)
+    assert (dst / "tasks").exists()

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -563,3 +563,22 @@ def test_multiselect_choices_with_templated_default_value(
         "python_version": "3.11",
         "github_runner_python_version": ["3.11"],
     }
+
+
+def test_copier_phase_variable(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yml"): """\
+                phase:
+                    type: str
+                    default: "{{ _copier_phase }}"
+            """
+        }
+    )
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    expect_prompt(tui, "phase", "str")
+    tui.expect_exact("prompt")


### PR DESCRIPTION
This PR exposes a `_phase` variable which can be one of `prompt`, `tasks`, `mmigrate` and `render`.
The known phases are grouped into the `copier.types.Phase` enum.

This implements #1883 and allows fixing copier-org/copier-templates-extensions#7