### PR TITLE
fix: decode answers file content explicitly as UTF-8

### DIFF
--- a/copier/subproject.py
+++ b/copier/subproject.py
@@ -56,7 +56,7 @@ class Subproject:
         """Get last answers, loaded raw as yaml."""
         try:
             return yaml.safe_load(
-                (self.local_abspath / self.answers_relpath).read_text()
+                (self.local_abspath / self.answers_relpath).read_text("utf-8")
             )
         except OSError:
             return {}


### PR DESCRIPTION
I've fixed a string encoding/decoding bug on Windows that broke updating a project with recorded non-ASCII character answers.

According to my investigation, `pathlib.Path.read_text()` calls [`io.text_encoding()`](https://github.com/python/cpython/blob/aa845af9bb39b3e2ed08bbb00a8e932a97be8fc0/Lib/pathlib/_local.py#L776), and when no encoding value is provided (i.e., `encoding=None`) then a [default encoding is determined](https://github.com/python/cpython/blob/fc8c99a8ce483db23fa624592457e350e99193f6/Lib/_pyio.py#L56-L59). When I reproduced the error on a quite clean Windows 11, `sys.flags.utf8_mode == 0`, so `io.text_encoding(encoding=none)` returns `"locale"` and `locale.getencoding()` returns `"cp1252"`. At the same time, the [`to_nice_yaml` filter passes the serialized YAML string through `to_text()`](https://gitlab.com/dreamer-labs/libraries/jinja2-ansible-filters/-/blob/58e352012f1b0bd6eb68cd02a4618f9af21d61bb/jinja2_ansible_filters/core_filters.py#L98) without passing an explicit value to the [`encoding` argument which defaults to `"utf-8"`](https://gitlab.com/dreamer-labs/libraries/jinja2-ansible-filters/-/blob/58e352012f1b0bd6eb68cd02a4618f9af21d61bb/jinja2_ansible_filters/module_utils.py#L196). Hence, when the answers file content is rendered as `{{ _copier_answers|to_nice_yaml }}`, it is _always_ encoded as UTF-8, but on Windows 11 its content was decoded as CP-1252.

The solution is to _always_ decode the answers file content as UTF-8.

I believe we'll need to fix this problem also for [loading from external data files](https://github.com/copier-org/copier/pull/1880) and for [loading user settings](https://github.com/copier-org/copier/pull/1940). I'll send follow-up PRs if/where needed once this one has been merged.

Fixes #1963.