### PR TITLE
refactor: use common answers file loader

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -293,7 +293,9 @@ class Worker:
         return _LazyDict(
             **{
                 name: lambda path=path: load_answersfile_data(
-                    self.dst_path, self._render_string(path)
+                    self.dst_path,
+                    self._render_string(path),
+                    warn_on_missing=True,
                 )
                 for name, path in self.template.external_data.items()
             }

--- a/copier/subproject.py
+++ b/copier/subproject.py
@@ -10,12 +10,12 @@ from functools import cached_property
 from pathlib import Path
 from typing import Callable
 
-import yaml
 from plumbum.machines import local
 from pydantic.dataclasses import dataclass
 
 from .template import Template
 from .types import AbsolutePath, AnyByStrDict, VCSTypes
+from .user_data import load_answersfile_data
 from .vcs import get_git, is_in_git_repo
 
 
@@ -55,9 +55,7 @@ class Subproject:
     def _raw_answers(self) -> AnyByStrDict:
         """Get last answers, loaded raw as yaml."""
         try:
-            return yaml.safe_load(
-                (self.local_abspath / self.answers_relpath).read_text("utf-8")
-            )
+            return load_answersfile_data(self.local_abspath, self.answers_relpath)
         except OSError:
             return {}
 

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -504,15 +504,19 @@ def parse_yaml_string(string: str) -> Any:
 def load_answersfile_data(
     dst_path: StrOrPath,
     answers_file: StrOrPath = ".copier-answers.yml",
+    *,
+    warn_on_missing: bool = False,
 ) -> AnyByStrDict:
     """Load answers data from a `$dst_path/$answers_file` file if it exists."""
     try:
         with Path(dst_path, answers_file).open(encoding="utf-8") as fd:
             return yaml.safe_load(fd)
     except (FileNotFoundError, IsADirectoryError):
-        warnings.warn(
-            f"File not found; returning empty dict: {answers_file}", MissingFileWarning
-        )
+        if warn_on_missing:
+            warnings.warn(
+                f"File not found; returning empty dict: {answers_file}",
+                MissingFileWarning,
+            )
         return {}
 
 


### PR DESCRIPTION
I've refactored answers file loading to use the common loader function `copier.user_data.load_answersfile_data()`. This shall ensure consistent loading behavior for the answers file and external data files.

Follow-up of #1970 and 1973.