### PR TITLE
fix: expose only answers in question rendering context

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -27,7 +27,14 @@ from copier.settings import Settings
 
 from .errors import InvalidTypeError, MissingFileWarning, UserMessageError
 from .tools import cast_to_bool, cast_to_str, force_str_end
-from .types import MISSING, AnyByStrDict, AnyByStrMutableMapping, MissingType, StrOrPath
+from .types import (
+    MISSING,
+    AnyByStrDict,
+    AnyByStrMutableMapping,
+    LazyDict,
+    MissingType,
+    StrOrPath,
+)
 
 
 # TODO Remove these two functions as well as DEFAULT_DATA in a future release
@@ -57,7 +64,7 @@ DEFAULT_DATA: AnyByStrDict = {
 }
 
 
-@dataclass
+@dataclass(config=ConfigDict(arbitrary_types_allowed=True))
 class AnswersMap:
     """Object that gathers answers from different sources.
 
@@ -99,7 +106,7 @@ class AnswersMap:
     metadata: AnyByStrMutableMapping = field(default_factory=dict)
     last: AnyByStrMutableMapping = field(default_factory=dict)
     user_defaults: AnyByStrMutableMapping = field(default_factory=dict)
-    system: AnyByStrMutableMapping = field(default_factory=dict)
+    external: LazyDict = field(default_factory=LazyDict)
 
     @property
     def combined(self) -> Mapping[str, Any]:
@@ -111,7 +118,7 @@ class AnswersMap:
                 self.metadata,
                 self.last,
                 self.user_defaults,
-                self.system,
+                {"_external_data": self.external},
                 DEFAULT_DATA,
             )
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -346,7 +346,7 @@ def is_subdict(small: dict[Any, Any], big: dict[Any, Any]) -> bool:
 def test_worker_good_data(tmp_path: Path) -> None:
     # This test is probably useless, as it tests the what and not the how
     conf = copier.Worker("./tests/demo_data", tmp_path)
-    assert conf._system_render_context()["_folder_name"] == tmp_path.name
+    assert conf._render_context()["_folder_name"] == tmp_path.name
     assert conf.all_exclusions == ("exclude1", "exclude2")
     assert conf.template.skip_if_exists == ["skip_if_exists1", "skip_if_exists2"]
     assert conf.template.tasks == [


### PR DESCRIPTION
I've reverted a change in #1880 that broke context manipulation via `copier-templates-extensions`. As part of #1880, we [extended the `copier.user_data.AnswersMap` to include additional Jinja context](https://github.com/copier-org/copier/pull/1880/files#diff-51a5fc56dc37de31d15f74ed1458469179fe72a8b697cbbc83b2a8e8e508f90bL455-R505) like `_copier_*` variables, which was called _system render context_. With this change, the Jinja context for rendering questions did not only include (previous) answers [but also system render context variables](https://github.com/copier-org/copier/pull/1880/files#diff-51a5fc56dc37de31d15f74ed1458469179fe72a8b697cbbc83b2a8e8e508f90bR510). Among those system render context variables is the [`answers_file` variable](https://github.com/copier-org/copier/pull/1880/files#diff-51a5fc56dc37de31d15f74ed1458469179fe72a8b697cbbc83b2a8e8e508f90bR385) whose value is the _rendered_ answers file path. When a Jinja context hook via the `copier-templates-extension` extension is registered, it intercepts each Jinja template render call. The first render call occurred when [passing the system render context to the `copier.user_data.AnswersMap` constructor](https://github.com/copier-org/copier/pull/1880/files#diff-51a5fc56dc37de31d15f74ed1458469179fe72a8b697cbbc83b2a8e8e508f90bR505) where the `answers_file` template was rendered. At this point, no answers – not even non-interactively provided data – had been added to the context yet. Thus, accessing such data in the context hook was failing.

Here is the stack trace that helped me debug this problem:

```
.venv/lib/python3.13/site-packages/copier/main.py:1334: in run_copy
    with Worker(src_path=src_path, dst_path=Path(dst_path), **kwargs) as worker:
.venv/lib/python3.13/site-packages/copier/main.py:254: in __exit__
    raise value
.venv/lib/python3.13/site-packages/copier/main.py:1335: in run_copy
    worker.run_copy()
.venv/lib/python3.13/site-packages/copier/main.py:950: in run_copy
    self._ask()
.venv/lib/python3.13/site-packages/copier/main.py:505: in _ask
    system=self._system_render_context(),
.venv/lib/python3.13/site-packages/copier/main.py:385: in _system_render_context
    "answers_file": self.answers_relpath,
.venv/lib/python3.13/site-packages/copier/main.py:582: in answers_relpath
    return Path(template.render(**self.answers.combined))
.venv/lib/python3.13/site-packages/jinja2/environment.py:1290: in render
    ctx = self.new_context(dict(*args, **kwargs))
.venv/lib/python3.13/site-packages/jinja2/environment.py:1388: in new_context
    return new_context(
.venv/lib/python3.13/site-packages/jinja2/runtime.py:117: in new_context
    return environment.context_class(
src/copier_templates_extensions/extensions/context.py:48: in __init__
    if "_copier_conf" in parent and (context := extension_self.hook(parent)) is not None:
```

I've solved the problem by removing the system render context from the `copier.user_data.AnswersMap` again and adding only external data instead. This way, all non-interactively provided data are part of the `copier.user_data.AnswersMap` before deriving the render context for the first render call.

Fixes #1977.