### PR TITLE
Reduce the number of test warnings

### DIFF
--- a/tests/test_legacy_migration.py
+++ b/tests/test_legacy_migration.py
@@ -66,9 +66,14 @@ def test_migrations_and_tasks(tmp_path: Path, skip_tasks: bool) -> None:
         git("add", ".")
         git("commit", "-m1")
     # Update it to v2
-    run_update(
-        dst_path=dst, defaults=True, overwrite=True, unsafe=True, skip_tasks=skip_tasks
-    )
+    with pytest.deprecated_call():
+        run_update(
+            dst_path=dst,
+            defaults=True,
+            overwrite=True,
+            unsafe=True,
+            skip_tasks=skip_tasks,
+        )
     # Check update was OK
     if skip_tasks:
         assert not (dst / "created-with-tasks.txt").exists()

--- a/tests/test_minimum_version.py
+++ b/tests/test_minimum_version.py
@@ -52,14 +52,16 @@ def test_version_greater_than_required(
 ) -> None:
     monkeypatch.setattr("copier.__version__", "99.99.99")
     # assert no error
-    copier.run_copy(template_path, tmp_path)
+    with pytest.warns(OldTemplateWarning):
+        copier.run_copy(template_path, tmp_path)
 
 
 def test_minimum_version_update(
     template_path: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr("copier.__version__", "11.0.0")
-    copier.run_copy(template_path, tmp_path)
+    with pytest.warns(OldTemplateWarning):
+        copier.run_copy(template_path, tmp_path)
 
     with local.cwd(tmp_path):
         git("init")
@@ -76,7 +78,8 @@ def test_minimum_version_update(
 
     monkeypatch.setattr("copier.__version__", "99.99.99")
     # assert no error
-    copier.run_copy(template_path, tmp_path)
+    with pytest.warns(OldTemplateWarning):
+        copier.run_copy(template_path, tmp_path)
 
 
 def test_version_0_0_0_ignored(

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -242,7 +242,9 @@ def test_templated_prompt_builtins(tmp_path_factory: pytest.TempPathFactory) -> 
             src / "make_secret.tmpl": "[[ question2 ]]",
         }
     )
-    Worker(str(src), dst, defaults=True, overwrite=True).run_copy()
+    with pytest.warns(FutureWarning) as warnings:
+        Worker(str(src), dst, defaults=True, overwrite=True).run_copy()
+    assert len([w for w in warnings if w.category is FutureWarning]) == 2
     that_now = datetime.fromisoformat((dst / "now").read_text())
     assert that_now <= datetime.utcnow()
     assert len((dst / "make_secret").read_text()) == 128

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -77,20 +77,23 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
                 author_name: Guybrush
                 _migrations:
                     -   version: v0.0.1
-                        before:
-                            - touch before-v0.0.1
-                        after:
-                            - touch after-v0.0.1
+                        when: "{{ _stage == 'before' }}"
+                        command: touch before-v0.0.1
+                    -   version: v0.0.1
+                        when: "{{ _stage == 'after' }}"
+                        command: touch after-v0.0.1
                     -   version: v0.0.2
-                        before:
-                            - touch before-v0.0.2
-                        after:
-                            - touch after-v0.0.2
+                        when: "{{ _stage == 'before' }}"
+                        command: touch before-v0.0.2
+                    -   version: v0.0.2
+                        when: "{{ _stage == 'after' }}"
+                        command: touch after-v0.0.2
                     -   version: v1.0.0
-                        before:
-                            - touch before-v1.0.0
-                        after:
-                            - touch after-v1.0.0
+                        when: "{{ _stage == 'before' }}"
+                        command: touch before-v1.0.0
+                    -   version: v1.0.0
+                        when: "{{ _stage == 'after' }}"
+                        command: touch after-v1.0.0
                 """
             ),
         }
@@ -110,20 +113,23 @@ def test_updatediff(tmp_path_factory: pytest.TempPathFactory) -> None:
                 author_name: Elaine
                 _migrations:
                     -   version: v0.0.1
-                        before:
-                            - touch before-v0.0.1
-                        after:
-                            - touch after-v0.0.1
+                        when: "{{ _stage == 'before' }}"
+                        command: touch before-v0.0.1
+                    -   version: v0.0.1
+                        when: "{{ _stage == 'after' }}"
+                        command: touch after-v0.0.1
                     -   version: v0.0.2
-                        before:
-                            - touch before-v0.0.2
-                        after:
-                            - touch after-v0.0.2
+                        when: "{{ _stage == 'before' }}"
+                        command: touch before-v0.0.2
+                    -   version: v0.0.2
+                        when: "{{ _stage == 'after' }}"
+                        command: touch after-v0.0.2
                     -   version: v1.0.0
-                        before:
-                            - touch before-v1.0.0
-                        after:
-                            - touch after-v1.0.0
+                        when: "{{ _stage == 'before' }}"
+                        command: touch before-v1.0.0
+                    -   version: v1.0.0
+                        when: "{{ _stage == 'after' }}"
+                        command: touch after-v1.0.0
                 """
             ),
             (repo / "README.txt.jinja"): (
@@ -1484,8 +1490,8 @@ def test_update_with_new_file_in_template_and_project_via_migration(
                     """\
                     _migrations:
                     -   version: v2
-                        before:
-                        -    "{{ _copier_python }} {{ _copier_conf.src_path / 'migrate.py' }}"
+                        when: "{{ _stage == 'before' }}"
+                        command: "{{ _copier_python }} {{ _copier_conf.src_path / 'migrate.py' }}"
                     """
                 ),
                 "migrate.py": (


### PR DESCRIPTION
This PR reduces the number of raised warning during tests:
- from 82 to 2 warnings on Python <= 3.11
- from 84 to 4 warnings on Python >= 3.12

To reduce those warnings, this PR:
- adds missing `pytest.warns()` context manager for expected warnings
- adds missing `pytest.deprecated_call()` on expected deprecation warnings
- migrate all tests containing migrations to the new migration format

Remaining warnings:
- 2 in `test_unsafe.py` on a remaining legacy migration test case (case only exists with legacy format)
- 2 `datetime.utcnow()` on Python 3.12+, tied to the deprecated built-in `now()`, adding a compatibility layer was not worth it given it will be removed

Benefits:
- tests expected warnings
- tests are up to date with the current API
- `pytest` output is uncluttered

This PR does not contain any functional change