### PR TITLE
fix: auto-detect encoding when reading external data file

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -522,7 +522,7 @@ def load_answersfile_data(
 ) -> AnyByStrDict:
     """Load answers data from a `$dst_path/$answers_file` file if it exists."""
     try:
-        with Path(dst_path, answers_file).open(encoding="utf-8") as fd:
+        with Path(dst_path, answers_file).open("rb") as fd:
             return yaml.safe_load(fd)
     except (FileNotFoundError, IsADirectoryError):
         warnings.warn(


### PR DESCRIPTION
I've fixed loading external data files to auto-detect the encoding instead of using the system's default encoding.

Without the fix, the added test fails with this error:

```
self = <yaml.loader.SafeLoader object at 0x7f20921b6e70>, size = 4096

    def update_raw(self, size=4096):
>       data = self.stream.read(size)
E       UnicodeDecodeError: 'cp932' codec can't decode byte 0x98 in position 7: illegal multibyte sequence
```

Follow-up of #1973. Inspired by #1998.