### PR TITLE
Explicitly specify file encoding for windows

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -1232,10 +1232,13 @@ class Worker:
                         # The 3-way merge might have resolved conflicts automatically,
                         # so we need to check if the file contains conflict markers
                         # before storing the file name for marking it as unmerged after the loop.
-                        with Path(fname).open() as conflicts_candidate:
+                        with Path(fname).open("rb") as conflicts_candidate:
                             if any(
                                 line.rstrip()
-                                in {"<<<<<<< before updating", ">>>>>>> after updating"}
+                                in {
+                                    b"<<<<<<< before updating",
+                                    b">>>>>>> after updating",
+                                }
                                 for line in conflicts_candidate
                             ):
                                 conflicted.append(fname)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -102,7 +102,9 @@ def assert_file(tmp_path: Path, *path: str) -> None:
 
 
 def build_file_tree(
-    spec: Mapping[StrOrPath, str | bytes | Path], dedent: bool = True
+    spec: Mapping[StrOrPath, str | bytes | Path],
+    dedent: bool = True,
+    encoding: str = "utf-8",
 ) -> None:
     """Builds a file tree based on the received spec.
 
@@ -124,7 +126,8 @@ def build_file_tree(
                 assert isinstance(contents, str)
                 contents = textwrap.dedent(contents)
             mode = "wb" if binary else "w"
-            with path.open(mode) as fd:
+            enc = None if binary else encoding
+            with Path(path).open(mode, encoding=enc) as fd:
                 fd.write(contents)
 
 

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -54,11 +54,6 @@ def test_config_include(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert (dst / "copier.yml").exists()
 
 
-@pytest.mark.xfail(
-    condition=platform.system() in {"Darwin", "Windows"},
-    reason="OS without proper UTF-8 filesystem.",
-    strict=True,
-)
 def test_path_filter(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     file_excluded: Mapping[StrOrPath, bool] = {

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,4 +1,3 @@
-import platform
 from pathlib import Path
 from typing import Mapping
 

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -1,3 +1,4 @@
+import platform
 from pathlib import Path
 from typing import Mapping
 
@@ -53,6 +54,11 @@ def test_config_include(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert (dst / "copier.yml").exists()
 
 
+@pytest.mark.xfail(
+    condition=platform.system() == "Darwin",
+    reason="OS without proper UTF-8 filesystem.",
+    strict=True,
+)
 def test_path_filter(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     file_excluded: Mapping[StrOrPath, bool] = {


### PR DESCRIPTION
It seems that this place was overlooked. The file encoding is specified on all other non-binary `open(...)` calls except for this one.

Closes #2006