### PR TITLE
build(deps): update `JRMurr/direnv-nix-action` action to v4.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
             ${{ hashFiles('pyproject.toml', '*.lock', '*.nix') }}
 
       # Check direnv works as expected
-      - uses: JRMurr/direnv-nix-action@v3
+      - uses: JRMurr/direnv-nix-action@v4.2.0
         with:
           install-nix: "false"
           cache-store: "false"


### PR DESCRIPTION
I've updated the `JRMurr/direnv-nix-action` action to v4.2.0 which should resolve the problem of our failing Nix CI jobs:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v3.0.11`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
```

I requested a `v4` tag alias for `v4.2.0`, but the author hasn't responded yet, so I decided to use the full version for us to move forward.