### PR TITLE
test: use helper function to load answers file data

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,7 @@ import yaml
 from plumbum import local
 
 from copier.cli import CopierApp
+from copier.user_data import load_answersfile_data
 
 from .helpers import COPIER_CMD, build_file_tree, git
 
@@ -70,7 +71,7 @@ def test_good_cli_run(template_path: str, tmp_path: Path) -> None:
     assert a_txt.exists()
     assert a_txt.is_file()
     assert a_txt.read_text() == "EXAMPLE_CONTENT"
-    answers = yaml.safe_load((tmp_path / "altered-answers.yml").read_text())
+    answers = load_answersfile_data(tmp_path, "altered-answers.yml")
     assert answers["_src_path"] == template_path
 
 
@@ -126,7 +127,7 @@ def test_cli_data_parsed_by_question_type(
         exit=False,
     )
     assert run_result[1] == 0
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    answers = load_answersfile_data(dst)
     assert answers["_src_path"] == str(src)
     assert answers["question"] == expected
 
@@ -165,7 +166,7 @@ def test_data_file_parsed_by_question_type(
         exit=False,
     )
     assert run_result[1] == 0
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    answers = load_answersfile_data(dst)
     assert answers["_src_path"] == str(src)
     assert answers["question"] == "answer"
 
@@ -216,7 +217,7 @@ def test_data_cli_takes_precedence_over_data_file(
         exit=False,
     )
     assert run_result[1] == 0
-    actual_answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    actual_answers = load_answersfile_data(dst)
     expected_answers = {
         "_src_path": str(src),
         "question": answer_override,
@@ -293,10 +294,8 @@ def test_read_utf_data_file(
         "text1": "\u3053\u3093\u306b\u3061\u306f",
         "text2": "\U0001f60e",
     }
-    with Path(dst / ".copier-answers.yml").open(encoding="utf-8") as f:
-        content = f.read()
-        actual_answers = yaml.safe_load(content)
-    assert actual_answers == expected_answers
+    answers = load_answersfile_data(dst)
+    assert answers == expected_answers
 
 
 @pytest.mark.parametrize(
@@ -338,9 +337,7 @@ def test_good_cli_run_dot_config(
     assert a_txt.exists()
     assert a_txt.is_file()
     assert a_txt.read_text() == "EXAMPLE_CONTENT"
-    answers = yaml.safe_load(
-        (tmp_path / config_folder / "altered-answers.yml").read_text()
-    )
+    answers = load_answersfile_data(tmp_path / config_folder, "altered-answers.yml")
     assert answers["_src_path"] == src
 
     with local.cwd(str(tmp_path)):
@@ -410,7 +407,7 @@ def test_skip_filenotexists(template_path: str, tmp_path: Path) -> None:
     assert a_txt.exists()
     assert a_txt.is_file()
     assert a_txt.read_text() == "EXAMPLE_CONTENT"
-    answers = yaml.safe_load((tmp_path / "altered-answers.yml").read_text())
+    answers = load_answersfile_data(tmp_path, "altered-answers.yml")
     assert answers["_src_path"] == str(template_path)
 
 
@@ -435,5 +432,5 @@ def test_skip_fileexists(template_path: str, tmp_path: Path) -> None:
     assert a_txt.exists()
     assert a_txt.is_file()
     assert a_txt.read_text() == "PREVIOUS_CONTENT"
-    answers = yaml.safe_load((tmp_path / "altered-answers.yml").read_text())
+    answers = load_answersfile_data(tmp_path, "altered-answers.yml")
     assert answers["_src_path"] == str(template_path)

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -12,6 +12,7 @@ from pexpect.popen_spawn import PopenSpawn
 from plumbum import local
 
 from copier import run_copy, run_update
+from copier.user_data import load_answersfile_data
 
 from .helpers import (
     BRACKET_ENVOPS,
@@ -570,11 +571,11 @@ def test_multi_template_answers(tmp_path_factory: pytest.TempPathFactory) -> Non
         git("add", "-A")
         git("commit", "-m2")
         # Check contents
-        answers1 = yaml.safe_load(Path(".copier-answers.yml").read_text())
+        answers1 = load_answersfile_data(".")
         assert answers1["_src_path"] == str(tpl1)
         assert answers1["q1"] == "a1"
         assert "q2" not in answers1
-        answers2 = yaml.safe_load(Path("two.yml").read_text())
+        answers2 = load_answersfile_data(".", "two.yml")
         assert answers2["_src_path"] == str(tpl2)
         assert answers2["q2"] == "a2"
         assert "q1" not in answers2
@@ -610,7 +611,7 @@ def test_omit_answer_for_skipped_question(
         }
     )
     run_copy(str(src), dst, defaults=True, data={"disabled": "hello"})
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    answers = load_answersfile_data(dst)
     assert answers == {"_src_path": str(src)}
     context = yaml.safe_load((dst / "context.yml").read_text())
     assert context == {"disabled": "hello", "disabled_with_default": "hello"}

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,11 +1,11 @@
 from pathlib import Path
 
 import pytest
-import yaml
 from plumbum import local
 
 from copier import run_copy, run_update
 from copier.errors import UnsafeTemplateError, UserMessageError
+from copier.user_data import load_answersfile_data
 
 from .helpers import (
     COPIER_ANSWERS_FILE,
@@ -160,7 +160,7 @@ def test_prerelease_version_migration(tmp_path_factory: pytest.TempPathFactory) 
         # No pre-releases. Should update to v1.9
         run_update(defaults=True, overwrite=True, unsafe=True)
 
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    answers = load_answersfile_data(dst)
     assert answers["_commit"] == "v1.9"
     assert (dst / "v1.9").exists()
     assert all(not (dst / version).exists() for version in versions)
@@ -170,7 +170,7 @@ def test_prerelease_version_migration(tmp_path_factory: pytest.TempPathFactory) 
         # With pre-releases. Should update to v2.a2
         run_update(defaults=True, overwrite=True, unsafe=True, use_prereleases=True)
 
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    answers = load_answersfile_data(dst)
     assert answers["_commit"] == "v2.a2"
     assert (dst / "v1.9").exists()
     assert all((dst / version).exists() for version in versions)

--- a/tests/test_recopy.py
+++ b/tests/test_recopy.py
@@ -2,11 +2,11 @@ from pathlib import Path
 from textwrap import dedent
 
 import pytest
-import yaml
 from plumbum import local
 
 from copier import run_copy, run_recopy
 from copier.cli import CopierApp
+from copier.user_data import load_answersfile_data
 from copier.vcs import get_git
 
 from .helpers import build_file_tree, git_save
@@ -92,12 +92,11 @@ def test_recopy_with_skip_answered_and_new_answer(
     # First copy
     run_copy(str(src), dst, defaults=True, overwrite=True)
     git_save(dst)
-    answers_file = dst / ".copier-answers.yml"
-    answers = yaml.safe_load(answers_file.read_text())
+    answers = load_answersfile_data(dst)
     assert answers["boolean"] is False
     # Recopy with different answer and `skip_answered=True`
     run_recopy(dst, data={"boolean": "true"}, skip_answered=True, overwrite=True)
-    answers = yaml.safe_load(answers_file.read_text())
+    answers = load_answersfile_data(dst)
     assert answers["boolean"] is True
 
 
@@ -125,10 +124,9 @@ def test_recopy_dont_validate_computed_value(
     # First copy
     run_copy(str(src), dst, defaults=True, overwrite=True)
     git_save(dst)
-    answers_file = dst / ".copier-answers.yml"
-    answers = yaml.safe_load(answers_file.read_text())
+    answers = load_answersfile_data(dst)
     assert "computed" not in answers
     # Recopy
     run_recopy(dst, overwrite=True)
-    answers = yaml.safe_load(answers_file.read_text())
+    answers = load_answersfile_data(dst)
     assert "computed" not in answers

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -13,6 +13,7 @@ from plumbum import local
 from copier import Worker
 from copier.errors import InvalidTypeError
 from copier.types import AnyByStrDict
+from copier.user_data import load_answersfile_data
 
 from .helpers import (
     BRACKET_ENVOPS,
@@ -181,7 +182,7 @@ def test_templated_prompt(
             tui.expect_exact(output)
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    answers = load_answersfile_data(dst)
     assert answers[question_name] == expected_value
 
 
@@ -476,10 +477,7 @@ def test_templated_prompt_update_previous_answer_disabled(
     tui.sendline(Keyboard.Down)  # select "Cloud Formation"
     tui.expect_exact(pexpect.EOF)
 
-    answers_file = dst / ".copier-answers.yml"
-
-    assert answers_file.exists()
-    assert yaml.safe_load(answers_file.read_text()) == {
+    assert load_answersfile_data(dst) == {
         "_src_path": str(src),
         "_commit": "v1",
         "cloud": "AWS",
@@ -496,8 +494,7 @@ def test_templated_prompt_update_previous_answer_disabled(
     tui.sendline()  # select "Terraform" (first supported)
     tui.expect_exact(pexpect.EOF)
 
-    assert answers_file.exists()
-    assert yaml.safe_load(answers_file.read_text()) == {
+    assert load_answersfile_data(dst) == {
         "_src_path": str(src),
         "_commit": "v1",
         "cloud": "Azure",
@@ -558,9 +555,7 @@ def test_multiselect_choices_with_templated_default_value(
     tui.sendline()  # select "[3.11]" (default value)
     tui.expect_exact(pexpect.EOF)
 
-    answers_file = dst / ".copier-answers.yml"
-    assert answers_file.exists()
-    assert yaml.safe_load(answers_file.read_text()) == {
+    assert load_answersfile_data(dst) == {
         "_src_path": str(src),
         "python_version": "3.11",
         "github_runner_python_version": ["3.11"],

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -12,6 +12,7 @@ from copier.cli import CopierApp
 from copier.errors import UnsafeTemplateError
 from copier.main import run_copy, run_update
 from copier.types import AnyByStrDict
+from copier.user_data import load_answersfile_data
 
 from .helpers import build_file_tree, git
 
@@ -329,7 +330,7 @@ def test_update(
         git("tag", "v1")
 
     run_copy(str(src), dst, unsafe=True)
-    assert "_commit: v1" in (dst / ".copier-answers.yml").read_text()
+    assert load_answersfile_data(dst).get("_commit") == "v1"
 
     with local.cwd(dst):
         git("init")
@@ -382,7 +383,7 @@ def test_update_cli(
         exit=False,
     )
     assert retcode == 0
-    assert "_commit: v1" in (dst / ".copier-answers.yml").read_text()
+    assert load_answersfile_data(dst).get("_commit") == "v1"
     capsys.readouterr()
 
     with local.cwd(dst):

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -4,12 +4,12 @@ from pathlib import Path
 from typing import Callable, Iterator, Sequence
 
 import pytest
-import yaml
 from packaging.version import Version
 from plumbum import local
 
 from copier import Worker, run_copy, run_update
 from copier.errors import ShallowCloneWarning
+from copier.user_data import load_answersfile_data
 from copier.vcs import checkout_latest_tag, clone, get_git_version, get_repo
 
 from .helpers import git
@@ -206,5 +206,5 @@ def test_select_latest_version_tag(
 
     assert (dst / filename).is_file()
     assert (dst / filename).read_text() == "v1.0.1"
-    answers = yaml.safe_load((dst / ".copier-answers.yml").read_text())
+    answers = load_answersfile_data(dst)
     assert answers["_commit"] == "v1.0.1"


### PR DESCRIPTION
I've improved the test suite to consistently use our helper function `copier.user_data.load_answersfile_data()` for loading answers. There are only a few exceptions where the answers file was written and read as JSON; changing those to YAML would slightly alter the semantics of the test.