### PR TITLE
fix: restore access to full rendering context in prompt phase

### DIFF
--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -579,3 +579,22 @@ def test_copier_phase_variable(
     tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
     expect_prompt(tui, "phase", "str")
     tui.expect_exact("prompt")
+
+
+def test_copier_conf_variable(
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            (src / "copier.yml"): """\
+                project_name:
+                    type: str
+                    default: "{{ _copier_conf.dst_path | basename }}"
+            """
+        }
+    )
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst / "test_project")), timeout=10)
+    expect_prompt(tui, "project_name", "str")
+    tui.expect_exact("test_project")


### PR DESCRIPTION
I've restored access to the full rendering context (including, e.g., `_copier_conf.*`) in the prompt phase. For example, the following question specification is now valid:

```yaml
project_name:
  type: str
  default: "{{ _copier_conf.dst_path | basename }}"
```

Support for this feature was unintentionally added by #1880 merely as a side effect and released as v9.5.0. As it turned out, #1880 introduced a regression (#1977) which we fixed in #1993 by partially reverting #1880, released as v9.6.0. As a result, only answers (and external data) were accessible in the rendering context of the prompt phase (i.e., pre-v9.5.0 behavior). But some Copier template authors have already started using variables from the full rendering context in the prompt phase with v9.5.0, so v9.6.0 contains a breaking change for them. As this feature had been requested and approved (#1050), I think this unfortunate situation is resolved best by officially exposing the full rendering context in the prompt phase.

To enable exposing the full rendering context in the prompt phase, I've changed the way the `_copier_conf` dict is constructed by essentially replacing `asdict(self)` with a lazy dict, such that any value is retrieved only upon first access. In particular, the `_copier_conf.answers_file` value is based on the `Worker.answers_relpath` property, which renders a template that requires access to the rendering context, thereby introducing a recursion. This recursion remains, but it causes no problem because of the lazy evaluation of dict values. Once we support `StrictUndefined` (#1522), catching bugs in templates that access context variables before they become available will become easier. But that's a separate topic.

Resolves #1050. Fixes #2021.