### PR TITLE
feat: raise `InteractiveSessionError` when prompting in non-interactive environment

### DIFF
--- a/copier/errors.py
+++ b/copier/errors.py
@@ -147,3 +147,10 @@ class MissingSettingsWarning(UserWarning, CopierWarning):
 
 class MissingFileWarning(UserWarning, CopierWarning):
     """I still couldn't find what I'm looking for."""
+
+
+class InteractiveSessionError(UserMessageError):
+    """An interactive session is required to run this program."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(f"Interactive session required: {message}")


### PR DESCRIPTION
I've improved the error handling when prompting in a non-interactive environment, which was failing with `EOFError`. Now, the new `InteractiveSessionError` exception is raised.

Resolves #1988.