### PR TITLE
Improve instruction for multiselection variable

### DIFF
--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -406,7 +406,9 @@ class Question:
         if self.choices:
             if self.multiselect:
                 questionary_type = "checkbox"
-                result["instruction"] = "(Use arrow keys to move, <space> (un)select, <a> (un)select all, <i> invert selection, <enter> confirm)"
+                result["instruction"] = (
+                    "(Use arrow keys to move, <space> (un)select, <a> (un)select all, <i> invert selection, <enter> confirm)"
+                )
             else:
                 questionary_type = "select"
             result["choices"] = self._formatted_choices

--- a/copier/user_data.py
+++ b/copier/user_data.py
@@ -404,7 +404,11 @@ class Question:
             if default is MISSING:
                 result["default"] = False
         if self.choices:
-            questionary_type = "checkbox" if self.multiselect else "select"
+            if self.multiselect:
+                questionary_type = "checkbox"
+                result["instruction"] = "(Use arrow keys to move, <space> (un)select, <a> (un)select all, <i> invert selection, <enter> confirm)"
+            else:
+                questionary_type = "select"
             result["choices"] = self._formatted_choices
         if questionary_type == "input":
             if self.secret:


### PR DESCRIPTION
Closes #2033.

The instruction was co-authored with @pawamoy.

Currently, I have two issues with this code:

1. Instruction is too big.
2. Is it okay to leave the instruction like this? Like a literal.

*And yes, the instruction should be wrapped in parenthesis and shouldn't include a preceding space.*
