### PR TITLE
feat: Allow tasks to run in two stages, "before" or "after" copy

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -1016,6 +1016,9 @@ class Worker:
                     f"\nCopying from template version {self.template.version}",
                     file=sys.stderr,
                 )
+            if not self.skip_tasks:
+                with Phase.use(Phase.TASKS):
+                    self._execute_tasks(self.template.tasks("before"))
             with Phase.use(Phase.RENDER):
                 self._render_template()
             if not self.quiet:
@@ -1023,7 +1026,7 @@ class Worker:
                 print("")  # padding space
             if not self.skip_tasks:
                 with Phase.use(Phase.TASKS):
-                    self._execute_tasks(self.template.tasks)
+                    self._execute_tasks(self.template.tasks("after"))
         except Exception:
             if not was_existing and self.cleanup_on_error:
                 rmtree(self.subproject.local_abspath)

--- a/copier/template.py
+++ b/copier/template.py
@@ -509,13 +509,12 @@ class Template:
         """
         return self.config_data.get("subdirectory", "")
 
-    @cached_property
-    def tasks(self) -> Sequence[Task]:
+    def tasks(self, stage: Literal["before", "after"]) -> Sequence[Task]:
         """Get tasks defined in the template.
 
         See [tasks][].
         """
-        extra_vars = {"stage": "task"}
+        extra_vars = {"stage": stage}
         tasks = []
         for task in self.config_data.get("tasks", []):
             if isinstance(task, dict):
@@ -523,12 +522,18 @@ class Template:
                     Task(
                         cmd=task["command"],
                         extra_vars=extra_vars,
-                        condition=task.get("when", "true"),
+                        condition=task.get("when", "{{ _stage == 'after' }}"),
                         working_directory=Path(task.get("working_directory", ".")),
                     )
                 )
             else:
-                tasks.append(Task(cmd=task, extra_vars=extra_vars))
+                tasks.append(
+                    Task(
+                        cmd=task,
+                        extra_vars=extra_vars,
+                        condition="{{ _stage == 'after' }}",
+                    )
+                )
         return tasks
 
     @cached_property


### PR DESCRIPTION
## What

This PR looks to resolve https://github.com/copier-org/copier/issues/240 by allowing tasks to run in two stages, "before" or "after" copy, similar to how #1510 implemented pre-copy and post-copy migration tasks

## How

- Make `Template.tasks` function accept an additional argument `stage`
  - Pass this `stage` via `extra_vars` so that the rendering context knows which `_stage` we're in
  - Default tasks' condition to `{{ _stage == 'after' }}` so that the default behavior is post-copy tasks
- In `main.py`: Change `run_copy` to execute tasks twice, before and after `_render_template`