### PR TITLE
fix(updating): ignore last answer of `when: false` questions

### DIFF
--- a/copier/main.py
+++ b/copier/main.py
@@ -563,6 +563,10 @@ class Worker:
             if not question.get_when():
                 # Omit its answer from the answers file.
                 self.answers.hide(var_name)
+                # Delete last answers to re-compute the answer from the default
+                # value (if it exists).
+                if var_name in self.answers.last:
+                    del self.answers.last[var_name]
                 # Skip immediately to the next question when it has no default
                 # value.
                 if question.default is MISSING:


### PR DESCRIPTION
I've fixed a bug that caused an update or recopy involving the switch of a question's `when` value from `when: true` to `when: false` to reuse the recorded answer, specifically for computed values the default value wasn't used to re-compute the answer. 

To fix it, we now delete the last answer of a `when: false` question.

Fixes #2057.