### PR TITLE
fix: settings dir with deduplicated copier subdir

### DIFF
--- a/copier/settings.py
+++ b/copier/settings.py
@@ -35,7 +35,20 @@ class Settings(BaseModel):
             if env_path:
                 settings_path = Path(env_path)
             else:
-                settings_path = user_config_path(appname="copier", appauthor=False) / "settings.yml"
+                settings_path = (
+                    user_config_path("copier", appauthor=False) / "settings.yml"
+                )
+                # NOTE: Remove after a sufficiently long deprecation period.
+                if OS == "windows":
+                    old_settings_path = user_config_path("copier") / "settings.yml"
+                    if old_settings_path.is_file():
+                        warnings.warn(
+                            f"Settings path {old_settings_path} is deprecated. "
+                            f"Please migrate to {settings_path}.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
+                        settings_path = old_settings_path
         if settings_path.is_file():
             data = yaml.safe_load(settings_path.read_bytes())
             return cls.model_validate(data)

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -28,6 +28,10 @@ class Settings(BaseModel):
         default_factory=set, description="List of trusted repositories or prefixes"
     )
 
+    def _default_settings_path() -> Path:
+        return user_config_path("copier", appauthor=False) / "settings.yml"
+
+
     @classmethod
     def from_file(cls, settings_path: Path | None = None) -> Settings:
         """Load settings from a file."""
@@ -36,8 +40,7 @@ class Settings(BaseModel):
             if env_path:
                 settings_path = Path(env_path)
             else:
-                settings_path = (
-                    user_config_path("copier", appauthor=False) / "settings.yml"
+                settings_path = _default_settings_path()
                 )
                 # NOTE: Remove after a sufficiently long deprecation period.
                 if OS == "windows":

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -31,7 +31,6 @@ class Settings(BaseModel):
     def _default_settings_path() -> Path:
         return user_config_path("copier", appauthor=False) / "settings.yml"
 
-
     @classmethod
     def from_file(cls, settings_path: Path | None = None) -> Settings:
         """Load settings from a file."""
@@ -41,7 +40,7 @@ class Settings(BaseModel):
                 settings_path = Path(env_path)
             else:
                 settings_path = cls._default_settings_path()
-                
+
                 # NOTE: Remove after a sufficiently long deprecation period.
                 if OS == "windows":
                     old_settings_path = user_config_path("copier") / "settings.yml"

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -35,7 +35,7 @@ class Settings(BaseModel):
             if env_path:
                 settings_path = Path(env_path)
             else:
-                settings_path = user_config_path("copier") / "settings.yml"
+                settings_path = user_config_path(appname="copier", appauthor=False) / "settings.yml"
         if settings_path.is_file():
             data = yaml.safe_load(settings_path.read_bytes())
             return cls.model_validate(data)

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -13,7 +13,6 @@ from platformdirs import user_config_path
 from pydantic import BaseModel, Field
 
 from .errors import MissingSettingsWarning
-from .tools import OS
 
 ENV_VAR = "COPIER_SETTINGS_PATH"
 

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -28,6 +28,7 @@ class Settings(BaseModel):
         default_factory=set, description="List of trusted repositories or prefixes"
     )
 
+    @staticmethod
     def _default_settings_path() -> Path:
         return user_config_path("copier", appauthor=False) / "settings.yml"
 
@@ -40,8 +41,8 @@ class Settings(BaseModel):
             if env_path:
                 settings_path = Path(env_path)
             else:
-                settings_path = _default_settings_path()
-                )
+                settings_path = cls._default_settings_path()
+                
                 # NOTE: Remove after a sufficiently long deprecation period.
                 if OS == "windows":
                     old_settings_path = user_config_path("copier") / "settings.yml"

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -13,6 +13,7 @@ from platformdirs import user_config_path
 from pydantic import BaseModel, Field
 
 from .errors import MissingSettingsWarning
+from .tools import OS
 
 ENV_VAR = "COPIER_SETTINGS_PATH"
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,6 +10,10 @@ standard configuration directory for your platform:
 -   `%USERPROFILE%\AppData\Local\copier` on Windows as defined in
     [Known folders](https://docs.microsoft.com/en-us/windows/win32/shell/known-folders)
 
+!!! note
+
+    Windows only: `%USERPROFILE%\AppData\Local\copier\copier` was the standard configuration directory until v9.6.0. This standard configuration directory is deprecated and will removed in a future version.
+
 This location can be overridden by setting the `COPIER_SETTINGS_PATH` environment
 variable.
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -12,7 +12,7 @@ standard configuration directory for your platform:
 
 !!! note
 
-    Windows only: `%USERPROFILE%\AppData\Local\copier\copier` was the standard configuration directory until v9.6.0. This standard configuration directory is deprecated and will removed in a future version.
+    Windows only: `%USERPROFILE%\AppData\Local\copier\copier` was the standard configuration directory until v9.6.0. This standard configuration directory is deprecated and will be removed in a future version.
 
 This location can be overridden by setting the `COPIER_SETTINGS_PATH` environment
 variable.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import sys
+import os
 from pathlib import Path
+import platform
 
 import pytest
 import yaml
@@ -25,10 +27,10 @@ def test_settings_from_default_location(settings_path: Path) -> None:
 
     assert settings.defaults == {"foo": "bar"}
 
-@pytest.mark.skipif(platform.system() != "Windows")
+@pytest.mark.skipif(platform.system() != "Windows", reason="Windows-only test")
 def test_default_windows_settings_path() -> None:
     settings = Settings()
-    assert settings._default_settings_path() = Path(os.getenv("USER_PROFILE"), "copier", "settings.yml")
+    assert settings._default_settings_path() == Path(os.getenv("USERPROFILE", default=""), "AppData", "Local", "copier", "settings.yml")
 
 
 @pytest.mark.usefixtures("config_path")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -8,6 +8,7 @@ import yaml
 
 from copier.errors import MissingSettingsWarning
 from copier.settings import Settings
+from copier.tools import OS
 
 
 def test_default_settings() -> None:
@@ -23,6 +24,11 @@ def test_settings_from_default_location(settings_path: Path) -> None:
     settings = Settings.from_file()
 
     assert settings.defaults == {"foo": "bar"}
+
+@pytest.mark.skipif(OS != 'windows')
+def test_default_windows_settings_path() -> None:
+    settings = Settings()
+    assert settings._default_settings_path() = Path(os.getenv("USER_PROFILE"), "copier", "settings.yml")
 
 
 @pytest.mark.usefixtures("config_path")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,7 +25,7 @@ def test_settings_from_default_location(settings_path: Path) -> None:
 
     assert settings.defaults == {"foo": "bar"}
 
-@pytest.mark.skipif(OS != 'windows')
+@pytest.mark.skipif(platform.system() != "Windows")
 def test_default_windows_settings_path() -> None:
     settings = Settings()
     assert settings._default_settings_path() = Path(os.getenv("USER_PROFILE"), "copier", "settings.yml")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,16 +1,15 @@
 from __future__ import annotations
 
-import sys
 import os
-from pathlib import Path
 import platform
+import sys
+from pathlib import Path
 
 import pytest
 import yaml
 
 from copier.errors import MissingSettingsWarning
 from copier.settings import Settings
-from copier.tools import OS
 
 
 def test_default_settings() -> None:
@@ -27,10 +26,17 @@ def test_settings_from_default_location(settings_path: Path) -> None:
 
     assert settings.defaults == {"foo": "bar"}
 
+
 @pytest.mark.skipif(platform.system() != "Windows", reason="Windows-only test")
 def test_default_windows_settings_path() -> None:
     settings = Settings()
-    assert settings._default_settings_path() == Path(os.getenv("USERPROFILE", default=""), "AppData", "Local", "copier", "settings.yml")
+    assert settings._default_settings_path() == Path(
+        os.getenv("USERPROFILE", default=""),
+        "AppData",
+        "Local",
+        "copier",
+        "settings.yml",
+    )
 
 
 @pytest.mark.usefixtures("config_path")


### PR DESCRIPTION
platformdirs implicitely sets appauthor to appname if not explicitely set to false, resulting in an dir with <CONFIG_ROOT>/copier/copier

Closes https://github.com/copier-org/copier/issues/2070