### PR TITLE
ci(release): migrate to PyPI trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches: [master]
-    tags: ["*"]
   workflow_dispatch:
     inputs:
       pytest_addopts:
@@ -115,37 +114,3 @@ jobs:
 
       # Run tests
       - run: devenv test
-
-  publish:
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
-    needs:
-      - build
-      - flake-check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Needs all tags to compute dynamic version
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          version: ${{ env.UV_VERSION }}
-          enable-cache: "true"
-          cache-suffix: "3.13"
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-      - name: Build dist
-        run: uv build
-      - name: Publish distribution 📦 to Test PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.test_pypi_token_copier }}
-          repository_url: https://test.pypi.org/legacy/
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_token_copier }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: release
 
 on:
   push:
-    branches: [master]
     tags: ["*"]
 
 env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: release
+
+on:
+  push:
+    branches: [master]
+    tags: ["*"]
+
+env:
+  # renovate: datasource=pypi depName=uv
+  UV_VERSION: "0.6.16"
+
+jobs:
+  build:
+    name: Build project for distribution
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          version: ${{ env.UV_VERSION }}
+
+      - name: Build project for distribution
+        run: uv build
+
+      - name: Upload artifact containing distribution files
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-test:
+    name: Publish package distributions to test.pypi.org
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi-test
+      url: https://test.pypi.org/p/copier
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download artifact containing distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Upload package distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/
+          repository-url: https://test.pypi.org/legacy/
+
+  publish:
+    name: Publish package distributions to pypi.org
+    runs-on: ubuntu-latest
+    needs: [publish-test]
+    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/copier
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Download artifact containing distribution files
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Upload package distributions
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist/


### PR DESCRIPTION
I've migrated our release workflow from using PyPI access tokens to [trusted publishing](https://docs.pypi.org/trusted-publishers/).

A few remarks about advice on https://docs.pypi.org/trusted-publishers/security-model/ that I've followed:

* I've created a dedicated workflow `release.yml` that is trusted by pypi.org. But it seems that dependence on jobs from another workflow (here, `build` and `flake-check` from `ci.yml`) via `needs` isn't supported. The only alternative I've found is dependence on the completion and success of a complete workflow via [`workflow_run`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run) and `job.<job_id>.if: ${{ github.event.workflow_run.conclusion == 'success' }}`, but I haven't found a Python project that implements this approach. I think it's sufficiently safe to assume that the tests are passing when making a release, but I'm open to hearing different opinions.
* I've limited the scope of the publishing jobs by using separate `build` and `publish`/`publish-test` jobs where only the latter have write permissions.
* I've created dedicated environments `pypi`/`pypi-test` scoped to tags with the name pattern `v*`.
* I've created tag protection rules.

As before, the distribution files are uploaded to test.pypi.org when a tag is pushed. In a follow-up PR, I plan to change this setup to upload to test.pypi.org also on the default branch (`master`) to test the publishing process more regularly (with some inspiration from [`github.com/iterative-ai/dvc:.github/workflows/build.yaml`](https://github.com/iterative/dvc/blob/99d9ca714de61518bd672ff647ed1ad7fb56f1d1/.github/workflows/build.yaml#L50-L73)).

**Todos after merging this PR:**

- [ ] Configure trusted publishing on pypi.org
- [ ] Configure trusted publishing on test.pypi.org