### PR TITLE
build(renovate): add preset `customManagers:githubActionsVersions`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":semanticCommitTypeAll(build)"],
+  "extends": [
+    "config:recommended",
+    "customManagers:githubActionsVersions",
+    ":semanticCommitTypeAll(build)"
+  ],
   "nix": {
     "enabled": true
   },


### PR DESCRIPTION
I've added the preset [`customManagers:githubActionsVersions`](https://docs.renovatebot.com/presets-customManagers/#custommanagersgithubactionsversions) to the Renovate config to support Renovate comments in GitHub Actions like:

```yaml
# renovate: datasource=pypi depName=uv
UV_VERSION: "0.6.13"
```

Follow-up of #2079.