### PR TITLE
build(deps): pin versions of dev-dependencies in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,24 +45,24 @@ copier = "copier.__main__:CopierApp.run"
 
 [dependency-groups]
 dev = [
-  "mypy>=0.931",
-  "pexpect>=4.8.0",
-  "poethepoet>=0.12.3",
-  "pre-commit>=2.17.0",
-  "pytest>=7.2.0",
-  "pytest-cov>=3.0.0",
-  "pytest-gitconfig>=0.6.0",
-  "pytest-xdist>=2.5.0",
-  "types-backports>=0.1.3",
-  "types-colorama>=0.4",
-  "types-pygments>=2.17",
-  "types-pyyaml>=6.0.4",
-  "typing-extensions>=3.10.0.0,<5.0.0; python_version < '<3.10'",
+  "mypy==1.15.0",
+  "pexpect==4.9.0",
+  "poethepoet==0.33.1",
+  "pre-commit==4.2.0",
+  "pytest==8.3.5",
+  "pytest-cov==6.1.1",
+  "pytest-gitconfig==0.7.0",
+  "pytest-xdist==3.6.1",
+  "types-backports==0.1.3",
+  "types-colorama==0.4.15.20240311",
+  "types-pygments==2.19.0.20250305",
+  "types-pyyaml==6.0.12.20250402",
+  "typing-extensions==4.13.1; python_version < '<3.10'",
 ]
 docs = [
-  "markdown-exec>=1.3.0",
-  "mkdocs-material>=8.2,<10.0.0",
-  "mkdocstrings[python]>=0.19.0",
+  "markdown-exec==1.10.3",
+  "mkdocs-material==9.6.11",
+  "mkdocstrings[python]==0.29.1",
 ]
 
 [tool.poe.tasks.coverage]

--- a/renovate.json
+++ b/renovate.json
@@ -12,6 +12,7 @@
     "enabled": true,
     "schedule": "every 4 week on Monday"
   },
+  "rangeStrategy": "replace",
   "labels": ["dependencies"],
   "packageRules": [
     {

--- a/uv.lock
+++ b/uv.lock
@@ -164,6 +164,7 @@ dependencies = [
     { name = "pygments" },
     { name = "pyyaml" },
     { name = "questionary" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 
 [package.dev-dependencies]
@@ -204,28 +205,29 @@ requires-dist = [
     { name = "pygments", specifier = ">=2.7.1" },
     { name = "pyyaml", specifier = ">=5.3.1" },
     { name = "questionary", specifier = ">=1.8.1" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'", specifier = ">=4.0.0,<5.0.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "mypy", specifier = ">=0.931" },
-    { name = "pexpect", specifier = ">=4.8.0" },
-    { name = "poethepoet", specifier = ">=0.12.3" },
-    { name = "pre-commit", specifier = ">=2.17.0" },
-    { name = "pytest", specifier = ">=7.2.0" },
-    { name = "pytest-cov", specifier = ">=3.0.0" },
-    { name = "pytest-gitconfig", specifier = ">=0.6.0" },
-    { name = "pytest-xdist", specifier = ">=2.5.0" },
-    { name = "types-backports", specifier = ">=0.1.3" },
-    { name = "types-colorama", specifier = ">=0.4" },
-    { name = "types-pygments", specifier = ">=2.17" },
-    { name = "types-pyyaml", specifier = ">=6.0.4" },
-    { name = "typing-extensions", specifier = ">=3.10.0.0,<5.0.0" },
+    { name = "mypy", specifier = "==1.15.0" },
+    { name = "pexpect", specifier = "==4.9.0" },
+    { name = "poethepoet", specifier = "==0.33.1" },
+    { name = "pre-commit", specifier = "==4.2.0" },
+    { name = "pytest", specifier = "==8.3.5" },
+    { name = "pytest-cov", specifier = "==6.1.1" },
+    { name = "pytest-gitconfig", specifier = "==0.7.0" },
+    { name = "pytest-xdist", specifier = "==3.6.1" },
+    { name = "types-backports", specifier = "==0.1.3" },
+    { name = "types-colorama", specifier = "==0.4.15.20240311" },
+    { name = "types-pygments", specifier = "==2.19.0.20250305" },
+    { name = "types-pyyaml", specifier = "==6.0.12.20250402" },
+    { name = "typing-extensions", specifier = "==4.13.1" },
 ]
 docs = [
-    { name = "markdown-exec", specifier = ">=1.3.0" },
-    { name = "mkdocs-material", specifier = ">=8.2,<10.0.0" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.19.0" },
+    { name = "markdown-exec", specifier = "==1.10.3" },
+    { name = "mkdocs-material", specifier = "==9.6.11" },
+    { name = "mkdocstrings", extras = ["python"], specifier = "==0.29.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
I've pinned the versions of dev-dependencies in `pyproject.toml` because:

- We control the exact version and can ensure compatible configuration. With lower-bounded versions, the dependency resolver may downgrade a dependency without us noticing unless we study the lock file changes diligently.
- We don't need to maintain an accurate version lower bound. Strictly speaking, if we declare a lower version bound – even for a development dependency –, we'd need to ensure that all versions that satisfy this constraint work. This is difficult and extremely cumbersome to achieve with, e.g., linters and formatters because different versions may result in different linting and formatting results. If we pin such development dependencies, we're not suggesting that a range of versions yields identical results, and the maintenance effort is minimized.