### PR TITLE
Silence `copier.tools` deprecation warning

### DIFF
--- a/copier/settings.py
+++ b/copier/settings.py
@@ -13,7 +13,7 @@ from platformdirs import user_config_path
 from pydantic import BaseModel, Field
 
 from .errors import MissingSettingsWarning
-from .tools import OS
+from ._tools import OS
 
 ENV_VAR = "COPIER_SETTINGS_PATH"
 

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -12,8 +12,8 @@ import yaml
 from platformdirs import user_config_path
 from pydantic import BaseModel, Field
 
-from .errors import MissingSettingsWarning
 from ._tools import OS
+from .errors import MissingSettingsWarning
 
 ENV_VAR = "COPIER_SETTINGS_PATH"
 


### PR DESCRIPTION
This is to avoid this warning with copier 9.7:

`.venv/lib/python3.13/site-packages/copier/settings.py:16: DeprecationWarning: Importing `OS` from `copier.tools` is deprecated. This module member is intended for internal use only and will become inaccessible in the future. If you have any questions or concerns, please raise an issue at <https://github.com/copier-org/copier/issues>`