### PR TITLE
build: fix container-based linting in devtasks script

### DIFF
--- a/devtasks.py
+++ b/devtasks.py
@@ -1,6 +1,7 @@
 """Development helper tasks."""
 
 import logging
+import shlex
 from pathlib import Path
 
 from plumbum import TEE, CommandNotFound, ProcessExecutionError, local
@@ -24,7 +25,7 @@ def lint() -> None:
         "--accept-flake-config",
         "develop",
         "--impure",
-        HERE,
+        f"{HERE}",
         "--command",
         "pre-commit",
         "run",
@@ -45,8 +46,9 @@ def lint() -> None:
                     f"--volume={HERE}:{HERE}:rw,z",
                     f"--workdir={HERE}",
                     "docker.io/nixos/nix",
-                    "nix",
-                    args,
+                    "bash",
+                    "-c",
+                    f'git config --global --add safe.directory {HERE} && {shlex.join(["nix", *args])}',
                 ]
                 & TEE
             )

--- a/devtasks.py
+++ b/devtasks.py
@@ -48,7 +48,7 @@ def lint() -> None:
                     "docker.io/nixos/nix",
                     "bash",
                     "-c",
-                    f'git config --global --add safe.directory {HERE} && {shlex.join(["nix", *args])}',
+                    f"git config --global --add safe.directory {HERE} && {shlex.join(['nix', *args])}",
                 ]
                 & TEE
             )


### PR DESCRIPTION
I've fixed running linters in a `docker.io/nixos/nix` container. There were two problems:

- The `nix develop` command must be run in a shell, so I wrapped it in `bash -c 'nix develop ...'`.
- When running a non-rootless container, the current user in the container differs from the owner of the project files and directories. Git raises an error in this case unless `safe.directory = ...` is configured. Hence, I'm configuring Git globally to apply this setting only in the container context.