### PR TITLE
ci(release): publish to test.pypi.org on pushing to `master` branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,7 @@ name: release
 
 on:
   push:
+    branches: [master]
     tags: ["*"]
 
 env:
@@ -37,7 +38,7 @@ jobs:
     name: Publish package distributions to test.pypi.org
     runs-on: ubuntu-latest
     needs: [build]
-    if: startsWith(github.ref, 'refs/tags/')
+    if: ${{ github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/') }}
     environment:
       name: pypi-test
       url: https://test.pypi.org/p/copier


### PR DESCRIPTION
I've changed the release setup to upload to test.pypi.org also on the default branch (`master`) to test the publishing process more regularly (with some inspiration from [`github.com/iterative-ai/dvc:.github/workflows/build.yaml`](https://github.com/iterative/dvc/blob/99d9ca714de61518bd672ff647ed1ad7fb56f1d1/.github/workflows/build.yaml#L50-L73)).