### PR TITLE
ci(release): build distributions without local version identifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
         with:
           version: ${{ env.UV_VERSION }}
 
+      # See https://peps.python.org/pep-0440/#local-version-identifiers
+      - name: Omit local version for publishing to test.pypi.org
+        run: >
+          echo SETUPTOOLS_SCM_OVERRIDES_FOR_COPIER='{local_scheme="no-local-version"}'
+          >> $GITHUB_ENV
+
       - name: Build project for distribution
         run: uv build
 


### PR DESCRIPTION
Uploading distributions to PyPI fails when the version contains a local version identifier. For example:

```
Uploading distributions to https://test.pypi.org/legacy/
Uploading copier-9.7.2.dev12+gf82a0a5-py3-none-any.whl
WARNING  Error during upload. Retry with the --verbose option for more details. 
ERROR    HTTPError: 400 Bad Request from https://test.pypi.org/legacy/          
         Bad Request
```

This is, in fact, stated in [PEP 440](https://peps.python.org/pep-0440/#local-version-identifiers):

> Local version identifiers SHOULD NOT be used when publishing upstream projects to a public index server, [...]

Publishing test releases on pushing to the `master` branch doesn't require a local version identifier though, so I've added an override to omit it. The override can be applied unconditionally for simplicity, as release versions contain no local version identifier anyway.

See https://setuptools-scm.readthedocs.io/en/stable/overrides/#config-overrides for more details on overriding version generation. We can use the `setuptools-scm` override, as `hatch-vcs` uses `setuptools-scm` internally.

Follow-up of #2108.