### PR TITLE
ci(release): fix building distributions without local version identifier

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,14 @@ jobs:
 
       # See https://peps.python.org/pep-0440/#local-version-identifiers
       - name: Omit local version for publishing to test.pypi.org
-        run: >
-          echo SETUPTOOLS_SCM_OVERRIDES_FOR_COPIER='{local_scheme="no-local-version"}'
-          >> $GITHUB_ENV
+        if: github.ref == 'refs/heads/master'
+        # HACK: https://github.com/ofek/hatch-vcs/issues/43
+        run: |
+          cat << EOF >> pyproject.toml
+
+          [tool.hatch.version.raw-options]
+          local_scheme = "no-local-version"
+          EOF
 
       - name: Build project for distribution
         run: uv build


### PR DESCRIPTION
I've fixed the override to omit local version identifiers when building distributions for publication on test.pypi.org. It turns out that `hatch-vcs` doesn't support all environment variables from `setuptools-scm`. :disappointed: The workaround is to patch `pyproject.toml` with the appropriate `hatch-vcs` setting that is passed through to `setuptools-scm`.