### PR TITLE
fix: avoid infinite recursion when accessing `_copier_conf.answers_file` via Jinja context hook

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -626,7 +626,12 @@ class Worker:
         """
         path = self.answers_file or self.template.answers_relpath
         template = self.jinja_env.from_string(str(path))
-        return Path(template.render(self._render_context()))
+        # HACK: Override `_copier_conf.answers_file` in the render context to
+        # avoid infinite recursion when accessing it in a Jinja context hook via
+        # `copier-templates-extensions`.
+        context = self._render_context()
+        context["_copier_conf"]["answers_file"] = ""
+        return Path(template.render(**context))
 
     @cached_property
     def all_exclusions(self) -> Sequence[str]:

--- a/copier/_types.py
+++ b/copier/_types.py
@@ -77,17 +77,25 @@ _V = TypeVar("_V")
 
 
 # HACK https://github.com/copier-org/copier/pull/1880#discussion_r1887491497
-class LazyDict(Mapping[_K, _V]):
+class LazyDict(MutableMapping[_K, _V]):
     """A dict where values are functions that get evaluated only once when requested."""
 
     def __init__(self, mapping: Mapping[_K, Callable[[], _V]] | None = None):
-        self._pending = mapping or {}
+        self._pending = dict(mapping or {})
         self._done: dict[_K, _V] = {}
 
     def __getitem__(self, key: _K) -> _V:
         if key not in self._done:
             self._done[key] = self._pending[key]()
         return self._done[key]
+
+    def __setitem__(self, key: _K, value: _V) -> None:
+        self._pending[key] = lambda: value
+        self._done.pop(key, None)
+
+    def __delitem__(self, key: _K) -> None:
+        del self._pending[key]
+        del self._done[key]
 
     def __iter__(self) -> Iterator[_K]:
         return iter(self._pending)


### PR DESCRIPTION
I've fixed a regression introduced by #2023 which causes infinite recursion when accessing `_copier_conf.answers_file` via Jinja context hook with `copier-templates-extensions`.

When rendering the answers file path in [`Worker.answers_relpath`](https://github.com/sisp/copier/blob/263aa10fa7ef09152933721f2ec951d968a1d671/copier/_main.py#L617-L629), which is accessible in the render context as `_copier_conf.answers_file`, the render context also includes `_copier_conf.answers_file` as a lazy dict value of `_copier_conf`. That's no problem when simply rendering the answers file path exposed as `_copier_conf.answers_file` because the answers file template never uses this variable itself. But when a context hook accesses `_copier_conf.answers_file` (e.g. in [github.com/scientific-python/cookie:helpers/extensions.py#L17](https://github.com/scientific-python/cookie/blob/4eb108f08bc8866108b8b31974a08cccd124cade/helpers/extensions.py#L17)), then one invocation of the context hook intercepts the render context for rendering the template for that same value, which results in an infinite recursion. To avoid it, I've extended the `LazyDict` class to support setting entries and overwrote the `answers_file` entry with `""`. This is a bit of a hack, but I don't see another way to avoid this problem. I'll also submit a PR to `copier-templates-extensions` with a new test case for this scenario once we've agreed on the path forward here, @pawamoy.

Until v9.4.0, this problem never occurred because the [render context of the answers file template consisted only of answers](https://github.com/copier-org/copier/blob/59f13c079864b0cdc7aabc1bca3babb2f95f9ba0/copier/main.py#L535) and didn't include additional variables such as `_copier_conf`. One would think that a context hook that accessed `_copier_conf.answers_file` would have failed because `_copier_conf` wasn't included in the render context of the answers file template, but no error occurred. That's because the [context hook is invoked _only_ when `_copier_conf` exists](https://github.com/copier-org/copier-templates-extensions/blob/e3fe3793fe44f41e198ce90e5a63723bf9571aa8/src/copier_templates_extensions/_internal/context.py#L48). Thus, while a context hook accessing, e.g., `_copier_conf.*` was working with Copier until v9.4.0 – in the sense that no error occurred –, the behavior wasn't entirely correct, as _not all_ rendering contexts were updated because `_copier_conf` wasn't present in all of them until recent Copier versions.

Now, to the best of my knowledge, all rendering contexts include `_copier_conf`, so the context hook is invoked for _all_ rendering contexts including those prior to answering any questions. I believe that this is correct behavior and previous behavior was unintended. (WDYT, @pawamoy?) This means unconditional access of answers variables or other variables that require answers variables for rendering does not work. For example, [github.com/scientific-python/cookie:helpers/extensions.py#L18](https://github.com/scientific-python/cookie/blob/4eb108f08bc8866108b8b31974a08cccd124cade/helpers/extensions.py#L18) raises a `KeyError` when accessing the `url` variable, as all rendering contexts prior to answering the [`url` question](https://github.com/scientific-python/cookie/blob/4eb108f08bc8866108b8b31974a08cccd124cade/copier.yml#L27-L31) don't contain it (@henryiii). In this specific example, I think the correct behavior is to inject the `__ci` variable into the context only when the `url` variable exists. This is consistent with using a computed value in `copier.yaml`:

```yaml
url:
  type: str
  help: The url to your GitHub or GitLab repository
  # [[[end]]]
  default: "https://github.com/{{ org }}/{{ project_name }}"

ci: # Actually `__ci`, but we can't prefix questions (or computed values) with underscores
  type: str
  default: "{% if 'github.com' in url %}github{% else %}gitlab{% endif %}"
  when: false
```

I'm aware that this may be considered a breaking change. To restore previous behavior where context hooks are invoked only when rendering files/directories/paths, I believe we could add another condition in `copier-templates-extensions` to check for the value of `_copier_phase`, such that recent Copier versions that expose this variable don't cause a context hook invocation in other phases. However, I suggest to raise a deprecation warning and recommend to template authors to implement context updates with the different rendering phases in mind.

WDYT, @pawamoy @henryiii?

Fixes #2113.