### PR TITLE
chore: add `uvx+pypi`/`uvx+git` installation method choices to problem issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/problem.yml
+++ b/.github/ISSUE_TEMPLATE/problem.yml
@@ -104,6 +104,8 @@ body:
     attributes:
       label: Installation method
       options:
+        - uvx+pypi
+        - uvx+git
         - pipx+pypi
         - pipx+git
         - pip+pypi


### PR DESCRIPTION
I've added `uvx`-based installation method choices to the problem issue template, as uv has gained massive popularity. Thanks, @henryiii, for pointing this out! :bow: