### PR TITLE
ci(nix): run `cachix/install-nix-action` with `nixos-24.11` channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       # Install Nix
       - uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixos-24.11
       # Set up Cachix
       - uses: cachix/cachix-action@v16
         with:


### PR DESCRIPTION
It seems a recent update of `hercules-ci-cnix-store` installed from `nixos-unstable` is causing our `flake-check` CI job on macOS to fail (see, e.g., https://github.com/copier-org/copier/pull/2112#issuecomment-2862243847). Perhaps `nixos-unstable` isn't a good channel to install from because its – well – unstable and a moving target, which harms reproducibility. I'm not sure whether switching to the latest stable channel is the best solution, but it seems to fix the problem for now.