### PR TITLE
feat: add `--vcs-ref=:current:` feature to reference the current ref when updating

### DIFF
--- a/copier/__init__.py
+++ b/copier/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from . import _main
 from ._deprecation import deprecate_member_as_internal
+from ._types import VcsRef as VcsRef
 
 if TYPE_CHECKING:
     from ._main import *  # noqa: F403

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -403,6 +403,7 @@ class CopierUpdateSubApp(_Subcommand):
         ["-O", "--only-answers"],
         default=False,
         help="Only update copier answers, do not update the template version",
+        excludes=["--vcs-ref"],
     )
 
     def main(self, destination_path: cli.ExistingDirectory = ".") -> int:
@@ -424,7 +425,6 @@ class CopierUpdateSubApp(_Subcommand):
                 context_lines=self.context_lines,
                 defaults=self.defaults,
                 skip_answered=self.skip_answered,
-                update_answers_only=self.only_answers,
                 overwrite=True,
             ) as worker:
                 worker.run_update()

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -399,8 +399,8 @@ class CopierUpdateSubApp(_Subcommand):
         default=False,
         help="Skip questions that have already been answered",
     )
-    answers_only = cli.Flag(
-        ["-u", "--answers-only"],
+    only_answers = cli.Flag(
+        ["-u", "--only-answers"],
         default=False,
         help="Only update copier answers, do not update the template version",
     )
@@ -424,7 +424,7 @@ class CopierUpdateSubApp(_Subcommand):
                 context_lines=self.context_lines,
                 defaults=self.defaults,
                 skip_answered=self.skip_answered,
-                update_answers_only=self.answers_only,
+                update_answers_only=self.only_answers,
                 overwrite=True,
             ) as worker:
                 worker.run_update()

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -399,6 +399,11 @@ class CopierUpdateSubApp(_Subcommand):
         default=False,
         help="Skip questions that have already been answered",
     )
+    answers_only = cli.Flag(
+        ["-u", "--answers-only"],
+        default=False,
+        help="Only update copier answers, do not update the template version",
+    )
 
     def main(self, destination_path: cli.ExistingDirectory = ".") -> int:
         """Call [run_update][copier.main.Worker.run_update].
@@ -419,6 +424,7 @@ class CopierUpdateSubApp(_Subcommand):
                 context_lines=self.context_lines,
                 defaults=self.defaults,
                 skip_answered=self.skip_answered,
+                update_answers_only=self.answers_only,
                 overwrite=True,
             ) as worker:
                 worker.run_update()

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -60,7 +60,7 @@ from plumbum import cli, colors
 
 from ._main import Worker
 from ._tools import copier_version
-from ._types import AnyByStrDict
+from ._types import AnyByStrDict, VcsRef
 from .errors import UnsafeTemplateError, UserMessageError
 
 
@@ -417,6 +417,8 @@ class CopierUpdateSubApp(_Subcommand):
                 The subproject must exist. If not specified, the currently
                 working directory is used.
         """
+        if self.only_answers:
+            self.vcs_ref = VcsRef.CURRENT
 
         def inner() -> None:
             with self._worker(

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -59,7 +59,7 @@ import yaml
 from plumbum import cli, colors
 
 from ._main import Worker
-from ._tools import copier_version
+from ._tools import copier_version, try_enum
 from ._types import AnyByStrDict, VcsRef
 from .errors import UnsafeTemplateError, UserMessageError
 
@@ -222,7 +222,7 @@ class _Subcommand(cli.Application):  # type: ignore[misc]
             skip_if_exists=self.skip,
             quiet=self.quiet,
             src_path=src_path,
-            vcs_ref=VcsRef.try_parse(self.vcs_ref),
+            vcs_ref=try_enum(VcsRef, self.vcs_ref),
             use_prereleases=self.prereleases,
             unsafe=self.unsafe,
             skip_tasks=self.skip_tasks,

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -135,7 +135,7 @@ class _Subcommand(cli.Application):  # type: ignore[misc]
             "If you do not specify it, it will try to checkout the latest git tag, "
             "as sorted using the PEP 440 algorithm. If you want to checkout always "
             "the latest version, use `--vcs-ref=HEAD`. "
-            "Use the special value `:CURRENT` to refer to the current reference "
+            "Use the special value `:current:` to refer to the current reference "
             "of the template if it already exists."
         ),
     )

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -400,7 +400,7 @@ class CopierUpdateSubApp(_Subcommand):
         help="Skip questions that have already been answered",
     )
     only_answers = cli.Flag(
-        ["-u", "--only-answers"],
+        ["-O", "--only-answers"],
         default=False,
         help="Only update copier answers, do not update the template version",
     )

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -399,10 +399,10 @@ class CopierUpdateSubApp(_Subcommand):
         default=False,
         help="Skip questions that have already been answered",
     )
-    only_answers = cli.Flag(
-        ["--only-answers"],
+    keep_version = cli.Flag(
+        ["--keep-version"],
         default=False,
-        help="Only update answers, do not update the template version",
+        help="Do not update the template version and keep the current one.",
         excludes=["--vcs-ref"],
     )
 
@@ -417,7 +417,7 @@ class CopierUpdateSubApp(_Subcommand):
                 The subproject must exist. If not specified, the currently
                 working directory is used.
         """
-        if self.only_answers:
+        if self.keep_version:
             self.vcs_ref = VcsRef.CURRENT
 
         def inner() -> None:

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -400,9 +400,9 @@ class CopierUpdateSubApp(_Subcommand):
         help="Skip questions that have already been answered",
     )
     only_answers = cli.Flag(
-        ["-O", "--only-answers"],
+        ["--only-answers"],
         default=False,
-        help="Only update copier answers, do not update the template version",
+        help="Only update answers, do not update the template version",
         excludes=["--vcs-ref"],
     )
 

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -212,7 +212,7 @@ class Worker:
         skip_answered:
             When `True`, skip questions that have already been answered.
 
-        answers_only:
+        update_answers_only:
             Only update the answers, use the template version that was
             used in the last interaction.
 

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1061,9 +1061,9 @@ class Worker:
         with replace(self, src_path=self.subproject.template.url) as new_worker:
             new_worker.run_copy()
 
-    def _print_template_update_info(self) -> None:
+    def _print_template_update_info(self, subproject_template: Template) -> None:
         # TODO Unify printing tools
-        if not self.quiet and self.subproject.template.version == self.template.version:
+        if not self.quiet and subproject_template.version == self.template.version:
             print(f"Keeping template version {self.template.version}", file=sys.stderr)
         elif not self.quiet:
             print(
@@ -1113,7 +1113,7 @@ class Worker:
             # asking for confirmation
             raise UserMessageError("Enable overwrite to update a subproject.")
         self._print_message(self.template.message_before_update)
-        self._print_template_update_info()
+        self._print_template_update_info(self.subproject.template)
         with suppress(AttributeError):
             # We might have switched operation context, ensure the cached property
             # is regenerated to re-render templates.

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -964,8 +964,8 @@ class Worker:
     def resolved_vcs_ref(self) -> str | None:
         """Get the resolved VCS reference to use.
 
-        This is either vcs_ref or the subproject template ref
-        if vcs_ref is CURRENT.
+        This is either `vcs_ref` or the subproject template ref
+        if `vcs_ref` is `VcsRef.CURRENT`.
         """
         if self.vcs_ref is VcsRef.CURRENT:
             if self.subproject.template is None:
@@ -1063,12 +1063,12 @@ class Worker:
 
     def _print_template_update_info(self, subproject_template: Template) -> None:
         # TODO Unify printing tools
-        if not self.quiet and subproject_template.version == self.template.version:
-            print(f"Keeping template version {self.template.version}", file=sys.stderr)
-        elif not self.quiet:
-            print(
-                f"Updating to template version {self.template.version}", file=sys.stderr
-            )
+        if not self.quiet:
+            if subproject_template.version == self.template.version:
+                message = f"Keeping template version {self.template.version}"
+            else:
+                message = f"Updating to template version {self.template.version}"
+            print(message, file=sys.stderr)
 
     @as_operation("update")
     def run_update(self) -> None:

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -212,6 +212,10 @@ class Worker:
         skip_answered:
             When `True`, skip questions that have already been answered.
 
+        answers_only:
+            Only update the answers, use the template version that was
+            used in the last interaction.
+
         skip_tasks:
             When `True`, skip template tasks execution.
     """
@@ -235,6 +239,7 @@ class Worker:
     context_lines: PositiveInt = 3
     unsafe: bool = False
     skip_answered: bool = False
+    update_answers_only: bool = False
     skip_tasks: bool = False
 
     answers: AnswersMap = field(default_factory=AnswersMap, init=False)
@@ -971,7 +976,15 @@ class Worker:
 
     @cached_property
     def template(self) -> Template:
-        """Get related template."""
+        """Get related template.
+
+        If `update_answers_only` is set, return the template from the subproject
+        (with identical URL and commit).
+        """
+        if self.update_answers_only:
+            if self.subproject.template is None:
+                raise TypeError("Template not found")
+            return self.subproject.template
         url = self.src_path
         if not url:
             if self.subproject.template is None:

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -399,7 +399,7 @@ class Worker:
                 "src_path": lambda: self.template.local_abspath,
                 "dst_path": lambda: self.dst_path,
                 "answers_file": lambda: self.answers_relpath,
-                "vcs_ref": lambda: self.vcs_ref,
+                "vcs_ref": lambda: self.resolved_vcs_ref,
                 "vcs_ref_hash": lambda: self.template.commit_hash,
                 "data": lambda: self.data,
                 "settings": lambda: self.settings,

--- a/copier/_tools.py
+++ b/copier/_tools.py
@@ -15,7 +15,7 @@ from enum import Enum
 from importlib.metadata import version
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Callable, Literal, TextIO, cast
+from typing import Any, Callable, Literal, TextIO, TypeVar, cast
 
 import colorama
 from packaging.version import Version
@@ -265,3 +265,18 @@ def scantree(path: str, follow_symlinks: bool) -> Iterator[os.DirEntry[str]]:
         yield entry
         if entry.is_dir(follow_symlinks=follow_symlinks):
             yield from scantree(entry.path, follow_symlinks)
+
+
+_T = TypeVar("_T")
+_E = TypeVar("_E", bound=Enum)
+
+
+def try_enum(enum_type: type[_E], value: _T) -> _E | _T:
+    """Try to convert a value into an enum.
+
+    If the value is not a valid enum member, return the original value.
+    """
+    try:
+        return enum_type(value)
+    except ValueError:
+        return value

--- a/copier/_types.py
+++ b/copier/_types.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Iterator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
-from enum import Enum, auto
+from enum import Enum
 from pathlib import Path
 from typing import (
     Annotated,
@@ -128,7 +128,20 @@ _phase: ContextVar[Phase] = ContextVar("phase", default=Phase.UNDEFINED)
 
 
 class VcsRef(Enum):
-    CURRENT = auto()
+    CURRENT = ":CURRENT"
     """A special value to indicate that the current ref of the existing
     template should be used.
     """
+
+    @classmethod
+    def try_parse(cls, value: str | None) -> VcsRef | str | None:
+        """Try to parse a string into a special VcsRef value or return the string.
+
+        None is returned as is.
+        """
+        if value is None:
+            return None
+        try:
+            return cls(value.upper())
+        except ValueError:
+            return value

--- a/copier/_types.py
+++ b/copier/_types.py
@@ -128,20 +128,7 @@ _phase: ContextVar[Phase] = ContextVar("phase", default=Phase.UNDEFINED)
 
 
 class VcsRef(Enum):
-    CURRENT = ":CURRENT:"
+    CURRENT = ":current:"
     """A special value to indicate that the current ref of the existing
     template should be used.
     """
-
-    @classmethod
-    def try_parse(cls, value: str | None) -> VcsRef | str | None:
-        """Try to parse a string into a special VcsRef value or return the string.
-
-        None is returned as is.
-        """
-        if value is None:
-            return None
-        try:
-            return cls(value.upper())
-        except ValueError:
-            return value

--- a/copier/_types.py
+++ b/copier/_types.py
@@ -128,7 +128,7 @@ _phase: ContextVar[Phase] = ContextVar("phase", default=Phase.UNDEFINED)
 
 
 class VcsRef(Enum):
-    CURRENT = ":CURRENT"
+    CURRENT = ":CURRENT:"
     """A special value to indicate that the current ref of the existing
     template should be used.
     """

--- a/copier/_types.py
+++ b/copier/_types.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Iterator, Mapping, MutableMapping, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
-from enum import Enum
+from enum import Enum, auto
 from pathlib import Path
 from typing import (
     Annotated,
@@ -125,3 +125,10 @@ class Phase(str, Enum):
 
 
 _phase: ContextVar[Phase] = ContextVar("phase", default=Phase.UNDEFINED)
+
+
+class VcsRef(Enum):
+    CURRENT = auto()
+    """A special value to indicate that the current ref of the existing
+    template should be used.
+    """

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1726,11 +1726,9 @@ _commit: v1.0.0
     Not supported in `copier.yml`.
 
 The special value `VcsRef.CURRENT` is set to indicate that the template version should
-be identical to the version already present. It is set by the CLI when invoking
-`copier update --keep-version`.
-
-By default, Copier will copy from the last release found in template Git tags, sorted as
-[PEP 440][].
+be identical to the version already present. It is set when using `--vcs-ref=:current:`
+in the CLI. By default, Copier will copy from the last release found in template Git
+tags, sorted as [PEP 440][].
 
 ## Patterns syntax
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1708,7 +1708,7 @@ the `v2.0.0a1` tag unless this flag is enabled.
 
 ### `vcs_ref`
 
--   Format: `str`
+-   Format: `str | VcsRef`
 -   CLI flags: `-r`, `--vcs-ref`
 -   Default value: N/A (use latest release)
 
@@ -1724,6 +1724,10 @@ _commit: v1.0.0
 !!! info
 
     Not supported in `copier.yml`.
+
+The special value `VcsRef.CURRENT` is set to indicate that the template version should
+be identical to the version already present. It is set by the CLI when invoking
+`copier update --only-answers`.
 
 By default, Copier will copy from the last release found in template Git tags, sorted as
 [PEP 440][].

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1727,7 +1727,7 @@ _commit: v1.0.0
 
 The special value `VcsRef.CURRENT` is set to indicate that the template version should
 be identical to the version already present. It is set by the CLI when invoking
-`copier update --only-answers`.
+`copier update --keep-version`.
 
 By default, Copier will copy from the last release found in template Git tags, sorted as
 [PEP 440][].

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -142,6 +142,12 @@ copier update --defaults --data-file /tmp/data-file.yaml
     it is not yet possible to update a multiselect choice using ˋ--dataˋ.
     Use ˋ--data-fileˋ instead for now.
 
+If you want to update the answers to all questions, but not the template:
+
+```shell
+copier update --answers-only
+```
+
 ## How the update works
 
 To understand how the updating process works, take a look at this diagram:

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -145,10 +145,10 @@ copier update --defaults --data-file /tmp/data-file.yaml
 If you want to update the answers to all questions, but not the template:
 
 ```shell
-copier update --only-answers
+copier update --keep-version
 ```
 
-The `--only-answers` flag is mutually exclusive with `--vcs-ref`.
+The `--keep-version` flag is mutually exclusive with `--vcs-ref`.
 
 ## How the update works
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -145,10 +145,8 @@ copier update --defaults --data-file /tmp/data-file.yaml
 If you want to update the answers to all questions, but not the template:
 
 ```shell
-copier update --keep-version
+copier update --vcs-ref=:current:
 ```
-
-The `--keep-version` flag is mutually exclusive with `--vcs-ref`.
 
 ## How the update works
 

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -145,8 +145,10 @@ copier update --defaults --data-file /tmp/data-file.yaml
 If you want to update the answers to all questions, but not the template:
 
 ```shell
-copier update --answers-only
+copier update --only-answers
 ```
+
+The `--only-answers` flag is mutually exclusive with `--vcs-ref`.
 
 ## How the update works
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -380,7 +380,7 @@ def test_update_help() -> None:
     assert "-o, --conflict" in _help
     assert "copier update [SWITCHES] [destination_path=.]" in _help
     assert "--skip-answered" in _help
-    assert "--only-answers" in _help
+    assert "--keep-version" in _help
 
 
 def test_python_run() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -380,7 +380,6 @@ def test_update_help() -> None:
     assert "-o, --conflict" in _help
     assert "copier update [SWITCHES] [destination_path=.]" in _help
     assert "--skip-answered" in _help
-    assert "--keep-version" in _help
 
 
 def test_python_run() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -380,7 +380,7 @@ def test_update_help() -> None:
     assert "-o, --conflict" in _help
     assert "copier update [SWITCHES] [destination_path=.]" in _help
     assert "--skip-answered" in _help
-    assert "--answers-only" in _help
+    assert "--only-answers" in _help
 
 
 def test_python_run() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -380,6 +380,7 @@ def test_update_help() -> None:
     assert "-o, --conflict" in _help
     assert "copier update [SWITCHES] [destination_path=.]" in _help
     assert "--skip-answered" in _help
+    assert "--answers-only" in _help
 
 
 def test_python_run() -> None:

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1648,7 +1648,7 @@ def test_update_vcs_ref_current(
                     "update",
                     "--data",
                     "boolean=true",
-                    "--vcs-ref=:CURRENT",
+                    "--vcs-ref=:CURRENT:",
                 ],
                 exit=False,
             )

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1606,7 +1606,7 @@ def test_update_with_skip_answered_and_new_answer(
 
 
 @pytest.mark.parametrize("cli", [True, False])
-def test_update_only_answers(
+def test_update_keep_version(
     tmp_path_factory: pytest.TempPathFactory,
     cli: bool,
 ) -> None:
@@ -1648,7 +1648,7 @@ def test_update_only_answers(
                     "update",
                     "--data",
                     "boolean=true",
-                    "--only-answers",
+                    "--keep-version",
                 ],
                 exit=False,
             )

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1606,7 +1606,7 @@ def test_update_with_skip_answered_and_new_answer(
 
 
 @pytest.mark.parametrize("cli", [True, False])
-def test_update_keep_version(
+def test_update_vcs_ref_current(
     tmp_path_factory: pytest.TempPathFactory,
     cli: bool,
 ) -> None:
@@ -1648,7 +1648,7 @@ def test_update_keep_version(
                     "update",
                     "--data",
                     "boolean=true",
-                    "--keep-version",
+                    "--vcs-ref=:CURRENT",
                 ],
                 exit=False,
             )

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1630,6 +1630,7 @@ def test_update_only_answers(
     else:
         run_copy(str(src), dst, defaults=True, overwrite=True)
     answers = load_answersfile_data(dst)
+    assert answers["_commit"] == "v1"
     assert answers["boolean"] is False
 
     with local.cwd(dst):
@@ -1656,6 +1657,7 @@ def test_update_only_answers(
             dst, data={"boolean": "true"}, vcs_ref=VcsRef.CURRENT, overwrite=True
         )
     answers = load_answersfile_data(dst)
+    assert answers["_commit"] == "v1"
     assert answers["boolean"] is True
 
     # assert that the README.md file was not created

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1648,7 +1648,7 @@ def test_update_vcs_ref_current(
                     "update",
                     "--data",
                     "boolean=true",
-                    "--vcs-ref=:CURRENT:",
+                    "--vcs-ref=:current:",
                 ],
                 exit=False,
             )


### PR DESCRIPTION
Sometimes, a user might only want to update the answers to their questions, but not the template version.
As far as I am aware, copier does not support that currently.

In this PR, I add a `--answers-only` flag to `copier update` which fills exactly this gap.

Note about tests: I am a bit overwhelmed by your testing setup, could you maybe please point me to the right places to add corresponding tests? Thanks in advance!

Cc @pavelzw