### PR TITLE
fix(vcs): git checkout after clone must contains `-- .`

### DIFF
--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -212,8 +212,7 @@ def clone(url: str, ref: str | None = None) -> str:
                 )
 
     with local.cwd(location):
-        git("checkout", "-f", ref or "HEAD")
-        # git("checkout", "-f", ref or "HEAD", "--", location) ## TODO: This is the fix
+        git("checkout", "-f", ref or "HEAD", "--", location)
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 
     return location

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -212,7 +212,8 @@ def clone(url: str, ref: str | None = None) -> str:
                 )
 
     with local.cwd(location):
-        git("checkout", "-f", ref or "HEAD", "--", location)
+        git("checkout", "-f", ref or "HEAD")
+        # git("checkout", "-f", ref or "HEAD", "--", location)
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 
     return location

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -212,7 +212,7 @@ def clone(url: str, ref: str | None = None) -> str:
                 )
 
     with local.cwd(location):
-        git("checkout", "-f", ref or "HEAD", "--", location)
+        git("-c", "core.fsmonitor=false", "checkout", "-f", ref or "HEAD")
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 
     return location

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -213,6 +213,7 @@ def clone(url: str, ref: str | None = None) -> str:
 
     with local.cwd(location):
         ## The `git checkout -f <ref>` command doesn't works when repo is local, dirty and core.fsmonitor is enabled
+        ## ref: https://github.com/copier-org/copier/issues/1887
         git("-c", "core.fsmonitor=false", "checkout", "-f", ref or "HEAD")
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -212,7 +212,7 @@ def clone(url: str, ref: str | None = None) -> str:
                 )
 
     with local.cwd(location):
-        git("checkout", "-f", ref or "HEAD")
+        git("checkout", "-f", ref or "HEAD", "--", location)
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 
     return location

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -213,7 +213,7 @@ def clone(url: str, ref: str | None = None) -> str:
 
     with local.cwd(location):
         git("checkout", "-f", ref or "HEAD")
-        # git("checkout", "-f", ref or "HEAD", "--", location)
+        # git("checkout", "-f", ref or "HEAD", "--", location) ## TODO: This is the fix
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 
     return location

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -212,6 +212,7 @@ def clone(url: str, ref: str | None = None) -> str:
                 )
 
     with local.cwd(location):
+        ## The `git checkout -f <ref>` command doesn't works when repo is local, dirty and core.fsmonitor is enabled
         git("-c", "core.fsmonitor=false", "checkout", "-f", ref or "HEAD")
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -93,7 +93,7 @@ def test_local_dirty_clone(
     tmp_path_factory: pytest.TempPathFactory, gitconfig: GitConfig
 ) -> None:
     """
-    When core.fsmonitor is enabled, dirty clone required specific git clone command to works properly.
+    When core.fsmonitor is enabled, normal `git checkout` command won't works.
     """
 
     gitconfig.set({"core.fsmonitor": "true"})

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -5,9 +5,9 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
-from pytest_gitconfig.plugin import GitConfig
 from packaging.version import Version
 from plumbum import local
+from pytest_gitconfig.plugin import GitConfig
 
 from copier import run_copy, run_update
 from copier._main import Worker
@@ -89,7 +89,9 @@ def test_local_clone() -> None:
     shutil.rmtree(local_tmp, ignore_errors=True)
 
 
-def test_local_dirty_clone(tmp_path_factory: pytest.TempPathFactory, gitconfig: GitConfig) -> None:
+def test_local_dirty_clone(
+    tmp_path_factory: pytest.TempPathFactory, gitconfig: GitConfig
+) -> None:
     """
     When core.fsmonitor is enabled, dirty clone required specific git clone command to works properly.
     """

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Callable
 
 import pytest
+from pytest_gitconfig.plugin import GitConfig
 from packaging.version import Version
 from plumbum import local
 
@@ -88,7 +89,12 @@ def test_local_clone() -> None:
     shutil.rmtree(local_tmp, ignore_errors=True)
 
 
-def test_local_dirty_clone(tmp_path_factory: pytest.TempPathFactory) -> None:
+def test_local_dirty_clone(tmp_path_factory: pytest.TempPathFactory, gitconfig: GitConfig) -> None:
+    """
+    When core.fsmonitor is enabled, dirty clone required specific git clone command to works properly.
+    """
+
+    gitconfig.set({"core.fsmonitor": "true"})
     src = tmp_path_factory.mktemp("src")
     print(src)
 


### PR DESCRIPTION
Without `-- .` on the end cause git to not checkout latest changes from **.git** directory.

![CleanShot 2025-05-16 at 16 27 55@2x](https://github.com/user-attachments/assets/aa173aa7-2393-4242-9504-92387883589e)

[fixes #1887]