### PR TITLE
docs: add `skip_answered` setting

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1426,6 +1426,19 @@ configuring `secret: true` in the [advanced prompt format][advanced-prompt-forma
     password: s3cr3t
     ```
 
+### `skip_answered`
+
+-   Format: `bool`
+-   CLI flags: `-A`, `--skip-answered` (only available in `copier update` subcommand)
+-   Default value: `False`
+
+When updating a project, skip asking questions that have already been answered and keep
+the recorded answer.
+
+!!! info
+
+    Not supported in `copier.yml`.
+
 ### `skip_if_exists`
 
 -   Format: `List[str]`


### PR DESCRIPTION
I've added missing documentation of the `skip_answered` setting.