### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -311,7 +311,7 @@ class Worker:
 
         # Given those values are lazily rendered on 1st access then cached
         # the phase value is irrelevant and could be misleading.
-        # As a consequence it is explicitely set to "undefined".
+        # As a consequence it is explicitly set to "undefined".
         return LazyDict(
             {
                 name: lambda path=path: load_answersfile_data(  # type: ignore[misc]

--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -290,7 +290,7 @@ class Question:
 
         The questionary lib expects some specific data types, and returns
         it when the user answers. Sometimes you need to compare the response
-        to the rendered one, or viceversa.
+        to the rendered one, or vice-versa.
 
         This helper allows such usages.
         """

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -975,7 +975,7 @@ Each pattern can be templated using Jinja.
     ```
 
     The difference with [skip_if_exists][] is that it will never be rendered during
-    an update, no matter if it exitsts or not.
+    an update, no matter if it exists or not.
 
 !!! info
 
@@ -1194,7 +1194,7 @@ The message is suppressed when Copier is run in [quiet mode][quiet].
 
            $ cd {{ _copier_conf.dst_path }}
 
-        2. Read "CONTRIBUING.md" and start coding.
+        2. Read "CONTRIBUTING.md" and start coding.
     ```
 
 ### `message_after_update`

--- a/flake.nix
+++ b/flake.nix
@@ -95,6 +95,14 @@
           pre-commit.gitPackage = pkgs.git;
           pre-commit.hooks = {
             alejandra.enable = true;
+            codespell = {
+              enable = true;
+              package = null;
+              name = "codespell";
+              description = "Checks for common misspellings in text files.";
+              entry = "uv run codespell";
+              types = ["text"];
+            };
             commitizen = {
               enable = true;
               package = null;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,6 +180,13 @@ tag_format = "v$version"
 update_changelog_on_bump = true
 version = "9.7.1"
 
+[tool.codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = '.git*,*.svg,*.lock,*.css,pyproject.toml,.mypy_cache,.venv'
+check-hidden = true
+ignore-regex = '\bla vie\b'
+ignore-words-list = 'ans'
+
 [tool.hatch.version]
 source = "vcs"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ copier = "copier.__main__:CopierApp.run"
 
 [dependency-groups]
 dev = [
+  "codespell[toml]==2.4.1",
   "commitizen==4.8.0",
   "mypy==1.15.0",
   "pexpect==4.9.0",

--- a/tests/test_answersfile_templating.py
+++ b/tests/test_answersfile_templating.py
@@ -85,7 +85,7 @@ def test_answersfile_templating_with_message_before_copy(
 ) -> None:
     """Test templated `_answers_file` setting with `_message_before_copy`.
 
-    Checks that the tempated answers file name is rendered correctly while
+    Checks that the templated answers file name is rendered correctly while
     having printing a message before the "copy" operation, which uses the render
     context before including any answers from the questionnaire.
     """

--- a/uv.lock
+++ b/uv.lock
@@ -147,6 +147,20 @@ wheels = [
 ]
 
 [[package]]
+name = "codespell"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/e0/709453393c0ea77d007d907dd436b3ee262e28b30995ea1aa36c6ffbccaf/codespell-2.4.1.tar.gz", hash = "sha256:299fcdcb09d23e81e35a671bbe746d5ad7e8385972e65dbb833a2eaac33c01e5", size = 344740, upload-time = "2025-01-28T18:52:39.411Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/01/b394922252051e97aab231d416c86da3d8a6d781eeadcdca1082867de64e/codespell-2.4.1-py3-none-any.whl", hash = "sha256:3dadafa67df7e4a3dbf51e0d7315061b80d265f9552ebd699b3dd6834b47e425", size = 344501, upload-time = "2025-01-28T18:52:37.057Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -201,6 +215,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "codespell", extra = ["toml"] },
     { name = "commitizen" },
     { name = "mypy" },
     { name = "pexpect" },
@@ -245,6 +260,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "codespell", extras = ["toml"], specifier = "==2.4.1" },
     { name = "commitizen", specifier = "==4.8.0" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "pexpect", specifier = "==4.9.0" },


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

TODOs
- [x] remove `TEMP` commit after confirming that CI picks up typos