### PR TITLE
build(renovate): use range strategy `update-lockfile` for runtime and `pin` for dev dependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,9 +12,14 @@
     "enabled": true,
     "schedule": "every 4 week on Monday"
   },
-  "rangeStrategy": "replace",
+  "rangeStrategy": "update-lockfile",
   "labels": ["dependencies"],
   "packageRules": [
+    {
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["dependency-groups"],
+      "rangeStrategy": "pin"
+    },
     {
       "matchCategories": ["python"],
       "addLabels": ["python"]


### PR DESCRIPTION
I've updated Renovate's range strategy to `update-lockfile` for runtime and `pin` for dev dependencies. Previously, Renovate was bumping the pins of dev dependencies, but it didn't update the lock file for direct runtime dependencies (except when performing lock file maintenance). I think it's preferable to update direct dependencies in the lock file to (a) discover incompatibilities as early as possible and (b) receive isolated updates for better problem resolution.