### PR TITLE
fix: fix answers file override/setting to use full path and not only filename

### DIFF
--- a/copier/_deprecation.py
+++ b/copier/_deprecation.py
@@ -55,3 +55,15 @@ def deprecate_member(member: str, module: str, new_import: str) -> None:
         DeprecationWarning,
         stacklevel=3,
     )
+
+
+def deprecate_answers_file_template_path() -> None:
+    """Deprecate answers file template paths in template's non-root directory."""
+    warnings.warn(
+        "Answers file template locations other than the template root directory are "
+        "deprecated. Specify a non-default answers file name/location via the "
+        "`_answers_file` setting in the `copier.yaml` file instead. "
+        f"{_issue_note}",
+        DeprecationWarning,
+        stacklevel=3,
+    )

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1040,22 +1040,7 @@ class Worker:
             dst_abspath = self.subproject.local_abspath / dst_relpath
             dst_abspath.mkdir(parents=True, exist_ok=True)
 
-    def _adjust_rendered_part(self, rendered_part: str) -> str:
-        """Adjust the rendered part if necessary.
-
-        If `{{ _copier_conf.answers_file }}` becomes the full path,
-        restore part to be just the end leaf.
-
-        Args:
-            rendered_part:
-                The rendered part of the path to adjust.
-
-        """
-        if str(self.answers_relpath) == rendered_part:
-            return Path(rendered_part).name
-        return rendered_part
-
-    def _render_parts(
+    def _render_parts(  # noqa: C901
         self,
         parts: tuple[str, ...],
         rendered_parts: tuple[str, ...] | None = None,
@@ -1098,7 +1083,9 @@ class Worker:
             for value in ctx.yield_iterable or ():
                 new_context = {**extra_context, yield_name: value}
                 rendered_part = self._render_string(part, extra_context=new_context)
-                rendered_part = self._adjust_rendered_part(rendered_part)
+                if str(self.answers_relpath) == rendered_part:
+                    yield self.answers_relpath, new_context
+                    continue
 
                 # Skip if any part is rendered as an empty string
                 if not rendered_part:
@@ -1114,7 +1101,9 @@ class Worker:
         if not rendered_part:
             return
 
-        rendered_part = self._adjust_rendered_part(rendered_part)
+        if str(self.answers_relpath) == rendered_part:
+            yield (self.answers_relpath, extra_context)
+            return
 
         yield from self._render_parts(
             parts, rendered_parts + (rendered_part,), extra_context, is_template

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -42,6 +42,7 @@ from pydantic.dataclasses import dataclass
 from pydantic_core import to_jsonable_python
 from questionary import confirm, unsafe_prompt
 
+from ._deprecation import deprecate_answers_file_template_path
 from ._jinja_ext import YieldExtension, get_yield_context
 from ._settings import Settings, SettingsModel, is_trusted_repository
 from ._subproject import Subproject
@@ -1084,6 +1085,8 @@ class Worker:
                 new_context = {**extra_context, yield_name: value}
                 rendered_part = self._render_string(part, extra_context=new_context)
                 if str(self.answers_relpath) == rendered_part:
+                    if rendered_parts:
+                        deprecate_answers_file_template_path()
                     yield self.answers_relpath, new_context
                     continue
 
@@ -1102,6 +1105,8 @@ class Worker:
             return
 
         if str(self.answers_relpath) == rendered_part:
+            if rendered_parts:
+                deprecate_answers_file_template_path()
             yield (self.answers_relpath, extra_context)
             return
 

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -135,6 +135,73 @@ def test_answersfile(
     assert "password_2" not in log
 
 
+@pytest.mark.parametrize(
+    "user_answers_file",
+    [
+        None,
+        Path(".copier-answers.user.yml"),
+        Path(".config", ".copier-answers.user.yml"),
+    ],
+)
+@pytest.mark.parametrize(
+    "template_answers_file",
+    [
+        None,
+        Path(".copier-answers.template.yml"),
+        Path(".config", ".copier-answers.template.yml"),
+    ],
+)
+def test_answersfile_with_custom_path(
+    tmp_path_factory: pytest.TempPathFactory,
+    template_answers_file: Path | None,
+    user_answers_file: Path | None,
+) -> None:
+    """Test specifying the answers file path via template or user setting."""
+    answers_file = (
+        user_answers_file or template_answers_file or Path(".copier-answers.yml")
+    )
+
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    build_file_tree(
+        {
+            (src / "copier.yml"): (
+                f"_answers_file: {template_answers_file}"
+                if template_answers_file
+                else ""
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+            (src / "version.txt.jinja"): "v1",
+        }
+    )
+    git_save(src, message="v1", tag="v1")
+
+    build_file_tree({(src / "version.txt.jinja"): "v2"})
+    git_save(src, message="v2", tag="v2")
+
+    copier.run_copy(
+        str(src), dst, vcs_ref="v1", answers_file=user_answers_file, overwrite=True
+    )
+    assert (dst / "version.txt").read_text() == "v1"
+    assert load_answersfile_data(dst, answers_file) == {
+        "_src_path": str(src),
+        "_commit": "v1",
+    }
+    git_save(dst, message="v1")
+
+    copier.run_update(dst, vcs_ref="v2", answers_file=answers_file, overwrite=True)
+    assert (dst / "version.txt").read_text() == "v2"
+    assert load_answersfile_data(dst, answers_file) == {
+        "_src_path": str(src),
+        "_commit": "v2",
+    }
+
+
 def test_external_data(tmp_path_factory: pytest.TempPathFactory) -> None:
     parent1, parent2, child, dst = map(
         tmp_path_factory.mktemp, ("parent1", "parent2", "child", "dst")

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -202,6 +202,63 @@ def test_answersfile_with_custom_path(
     }
 
 
+def test_answersfile_template_in_subdirectory_is_deprecated(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """Test that the answers file template in a subdirectory is deprecated.
+
+    NOTE: The answers file is *not* rendered in the subdirectory but in the location
+    specified by:
+
+    1. The user-provided answers file location (via `-a,--answers-file` CLI flag or
+        equivalent API argument)
+    2. The `_answers_file` setting in `copier.yml`
+    3. The default answers file name and location at `.copier-answers.yml`
+    """
+    deprecated = pytest.deprecated_call(
+        match=(
+            r"Answers file template locations other than the template root "
+            r"directory are deprecated"
+        )
+    )
+    answers_file = Path(".copier-answers.yml")
+
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    build_file_tree(
+        {
+            (src / ".config" / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+            (src / "version.txt.jinja"): "v1",
+        }
+    )
+    git_save(src, message="v1", tag="v1")
+
+    build_file_tree({(src / "version.txt.jinja"): "v2"})
+    git_save(src, message="v2", tag="v2")
+
+    with deprecated:
+        copier.run_copy(str(src), dst, vcs_ref="v1", overwrite=True)
+    assert (dst / "version.txt").read_text() == "v1"
+    assert load_answersfile_data(dst, answers_file) == {
+        "_src_path": str(src),
+        "_commit": "v1",
+    }
+    git_save(dst, message="v1")
+
+    with deprecated:
+        copier.run_update(dst, vcs_ref="v2", answers_file=answers_file, overwrite=True)
+    assert (dst / "version.txt").read_text() == "v2"
+    assert load_answersfile_data(dst, answers_file) == {
+        "_src_path": str(src),
+        "_commit": "v2",
+    }
+
+
 def test_external_data(tmp_path_factory: pytest.TempPathFactory) -> None:
     parent1, parent2, child, dst = map(
         tmp_path_factory.mktemp, ("parent1", "parent2", "child", "dst")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import sys
 from collections.abc import Callable, Generator
+from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 from unittest.mock import patch
 
@@ -311,24 +312,35 @@ def test_good_cli_run_dot_config(
 
     Added based on the discussion: https://github.com/copier-org/copier/discussions/859
     """
+    deprecated = (
+        does_not_raise()
+        if config_folder == Path()
+        else pytest.deprecated_call(
+            match=(
+                r"Answers file template locations other than the template root "
+                r"directory are deprecated"
+            )
+        )
+    )
 
     src = template_path_with_dot_config(str(config_folder))
 
     with local.cwd(src):
         git_commands()
 
-    run_result = CopierApp.run(
-        [
-            "copier",
-            "copy",
-            "--quiet",
-            "-a",
-            str(config_folder / "altered-answers.yml"),
-            src,
-            str(tmp_path),
-        ],
-        exit=False,
-    )
+    with deprecated:
+        run_result = CopierApp.run(
+            [
+                "copier",
+                "copy",
+                "--quiet",
+                "-a",
+                str(config_folder / "altered-answers.yml"),
+                src,
+                str(tmp_path),
+            ],
+            exit=False,
+        )
     a_txt = tmp_path / "a.txt"
     assert run_result[1] == 0
     assert a_txt.exists()
@@ -340,17 +352,18 @@ def test_good_cli_run_dot_config(
     with local.cwd(str(tmp_path)):
         git_commands()
 
-    run_update = CopierApp.run(
-        [
-            "copier",
-            "update",
-            str(tmp_path),
-            "--answers-file",
-            str(config_folder / "altered-answers.yml"),
-            "--quiet",
-        ],
-        exit=False,
-    )
+    with deprecated:
+        run_update = CopierApp.run(
+            [
+                "copier",
+                "update",
+                str(tmp_path),
+                "--answers-file",
+                str(config_folder / "altered-answers.yml"),
+                "--quiet",
+            ],
+            exit=False,
+        )
     assert run_update[1] == 0
     assert answers["_src_path"] == src
 


### PR DESCRIPTION
I've fixed a problem that prevents especially Copier _users_ from overriding the answers file location via the `-a,--answers-file` CLI flag (or equivalent API argument) with a file path in a different directory.

I think the root of the problem is the ability to place the `{{ _copier_conf.answers_file }}.jinja` file in any subdirectory of the Copier template, added via #927. As it turns out, the changes of that PR prevent _rendering_ the answers file in a different subdirectory; only its rendered name can be overridden while the location corresponds to that of the `{{ _copier_conf.answers_file }}.jinja` file in the Copier template. According to my research, placing the `{{ _copier_conf.answers_file }}.jinja` file in any directory other than the Copier template's root directory isn't documented or tested behavior. In fact, our documentation even states that the answers file template must be in the template's root directory:

> The file **must be called exactly `{{ _copier_conf.answers_file }}.jinja`** [...] in your template's root folder [...].
>
> https://copier.readthedocs.io/en/stable/configuring/#the-copier-answersyml-file

Unless I've missed something, only the test added via #927 places the `{{ _copier_conf.answers_file }}.jinja` file in a subdirectory, but the same custom path is also passed via `-a,--answers-file`.

I think Copier should only allow the `{{ _copier_conf.answers_file }}.jinja` file in the Copier template's root directory, so all of the answers file settings/overrides can be paths relative to the root directory with well-defined behavior. Also, there would only be one way for Copier template authors to change the location/name of the answers file via the `_answers_file` setting in `copier.yml`.

The first commit of this PR restores the ability to specify a full relative path of the answers file (relative to the destination path) via `_answers_file` setting in `copier.yml` and via `-a,--answers-file` CLI flag (or equivalent API argument), no matter the location of the `{{ _copier_conf.answers_file }}.jinja` file in the Copier template. Although it's not very intuitive to place `{{ _copier_conf.answers_file }}.jinja` file in an arbitrary subdirectory and override it with another arbitrary path relative to the destination path, it retains compatibility with Copier templates that are currently placing the `{{ _copier_conf.answers_file }}.jinja` file in a non-root directory.

The second commit of this PR adds a deprecation warning that gets raised when the `{{ _copier_conf.answers_file }}.jinja` file is discovered in a non-root directory of the Copier template when rendering it.

I've also added tests to ensure the correct behavior and check for deprecation warnings where expected.

Fixes #2183.
Related to #927.

/cc @nilsdebruin as the author of #927