### PR TITLE
fix(external_data): replay old external data before updating

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,7 +3,7 @@
   "configurations": [
     {
       "name": "Python: debug tests",
-      "type": "python",
+      "type": "debugpy",
       "request": "launch",
       "program": "${file}",
       "console": "internalConsole",

--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -368,7 +368,7 @@ class CopierUpdateSubApp(_Subcommand):
         from the last Copier execution, including the source template
         (it must be a key called `_src_path`).
 
-        If that file contains also `_commit`, and `destination_path` is a git
+        If that file contains also `_commit`, `_dst_commit` and `destination_path` is a git
         repository, this command will do its best to respect the diff that you have
         generated since the last `copier` execution. To avoid that, use `copier recopy`
         instead.

--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -126,7 +126,7 @@ class AnswersMap:
         )
 
     def old_commit(self) -> str | None:
-        """Commit when the project was updated from this template the last time."""
+        """Template commit targeted when the project was updated the last time."""
         return self.last.get("_commit")
 
     def hide(self, key: str) -> None:

--- a/copier/errors.py
+++ b/copier/errors.py
@@ -195,6 +195,10 @@ class MissingFileWarning(UserWarning, CopierWarning):
     """I still couldn't find what I'm looking for."""
 
 
+class WorktreeCreationWarning(UserWarning, CopierWarning):
+    """Worktree creation failed, some replay actions might not be exact."""
+
+
 class InteractiveSessionError(UserMessageError):
     """An interactive session is required to run this program."""
 

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -90,8 +90,8 @@ suitable to [autoupdate your project safely][the-copier-answersyml-file]:
 
 -   It doesn't contain secret answers.
 -   It doesn't contain any data that is not easy to render to JSON or YAML.
--   It contains special keys like `_commit` and `_src_path`, indicating how the last
-    template update was done.
+-   It contains special keys like `_commit`, `_dst_commit` and `_src_path`, indicating
+    how the last template update was done.
 
 ### `_copier_conf`
 

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -10,6 +10,7 @@ import yaml
 
 import copier
 from copier._user_data import load_answersfile_data
+from copier._vcs import get_current_commit
 
 from .helpers import BRACKET_ENVOPS_JSON, SUFFIX_TMPL, build_file_tree, git_save
 
@@ -194,11 +195,13 @@ def test_external_data(tmp_path_factory: pytest.TempPathFactory) -> None:
         overwrite=True,
         answers_file=".parent2-answers.yml",
     )
+    head = get_current_commit(dst)
     git_save(dst)
     assert (dst / "parent2.txt").read_text() == "P2"
     expected_parent2_answers = {
         "_commit": "v1.0+parent2",
         "_src_path": str(parent2),
+        "_dst_commit": head,
         "name": "P2",
     }
     assert (
@@ -212,10 +215,12 @@ def test_external_data(tmp_path_factory: pytest.TempPathFactory) -> None:
         overwrite=True,
         answers_file=".child-answers.yml",
     )
+    head = get_current_commit(dst)
     git_save(dst)
     assert load_answersfile_data(dst, ".child-answers.yml") == {
         "_commit": "v1.0+child",
         "_src_path": str(child),
+        "_dst_commit": head,
         "name": "C1",
         "parent2_answers": ".parent2-answers.yml",
     }

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -13,6 +13,7 @@ from plumbum import local
 
 from copier import run_copy, run_update
 from copier._user_data import load_answersfile_data
+from copier._vcs import get_current_commit
 
 from .helpers import (
     BRACKET_ENVOPS,
@@ -432,6 +433,7 @@ def test_tui_inherited_default(
         git("add", "--all")
         git("commit", "--message", "init project")
     # After a forced update, answers stay the same
+    result["_dst_commit"] = get_current_commit(dst)
     run_update(dst, defaults=True, overwrite=True)
     assert json.loads((dst / "answers.json").read_text()) == result
 

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -84,6 +84,7 @@ def test_task_templating_with_operation(
         git_save()
 
     copier.run_recopy(dst, defaults=True, overwrite=True, unsafe=True)
+    git_save(dst)
     assert len(task_counter.read_text().splitlines()) == 2
 
     copier.run_update(dst, defaults=True, overwrite=True, unsafe=True)

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -13,6 +13,7 @@ from plumbum import local
 from copier._main import Worker
 from copier._types import AnyByStrDict
 from copier._user_data import load_answersfile_data
+from copier._vcs import get_current_commit
 from copier.errors import InvalidTypeError
 
 from .helpers import (
@@ -486,6 +487,7 @@ def test_templated_prompt_update_previous_answer_disabled(
 
     with local.cwd(dst):
         git_init("v1")
+        head = get_current_commit()
 
     tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
     expect_prompt(tui, "cloud", "str", help="Which cloud provider do you use?")
@@ -497,6 +499,7 @@ def test_templated_prompt_update_previous_answer_disabled(
     assert load_answersfile_data(dst) == {
         "_src_path": str(src),
         "_commit": "v1",
+        "_dst_commit": head,
         "cloud": "Azure",
         "iac": "tf",
     }

--- a/tests/test_tmpdir.py
+++ b/tests/test_tmpdir.py
@@ -5,7 +5,7 @@ import pytest
 from copier._cli import CopierApp
 from copier._main import run_copy, run_recopy, run_update
 
-from .helpers import build_file_tree, git
+from .helpers import build_file_tree, git, git_save
 
 
 @pytest.fixture(scope="module")
@@ -62,6 +62,7 @@ def test_api(
     assert not (dst / "v2").exists()
     empty_dir(tmp)
     # Update
+    git_save(dst)
     run_update(dst, quiet=True, defaults=True, overwrite=True)
     assert (dst / "fav.txt").read_text() == "Copier"
     assert (dst / "v2").read_text() == "true"
@@ -102,6 +103,7 @@ def test_cli(
     assert not (dst / "v2").exists()
     empty_dir(tmp)
     # Update
+    git_save(dst)
     run_result = CopierApp.run(["copier", "update", "-fq", str(dst)], exit=False)
     assert run_result[1] == 0
     assert (dst / "fav.txt").read_text() == "Copier"


### PR DESCRIPTION
Before this fix, when a template used local `_external_data`, it could never again be cleanly updated. It always gave conflicts.

This was happening because the old worker that did the replay always happened on an empty directory. Thus it never had external data available. Since external data can alter the render result (just like any other answer), the replay was never reliable.

Now, new data is saved in the answers file to be able to reliably replay including that context. Then, updates can work again as expected and result in meaningful diffs only when there should be.

BREAKING CHANGE: A new `_dst_commit` is added to the answers file, pointing to the commit just before the last template update. This is needed for reliable replays. This means that any copy or update operation will always produce diff when the subproject is git-tracked.
