### PR TITLE
feat: add support for providing serialized answers to multiselect choice questions

### DIFF
--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -486,6 +486,12 @@ class Question:
     def parse_answer(self, answer: Any) -> Any:
         """Parse the answer according to the question's type."""
         if self.multiselect:
+            # If the answer to a multiselect question is a string (typically because
+            # the default value is templated), then it must be a serialized YAML-style
+            # list of choice items. Thus, we shallowly parse the outermost list first,
+            # then we parse the items according to the `type: <type>` field.
+            if isinstance(answer, str):
+                answer = parse_yaml_list(answer)
             answer = [self._parse_answer(a) for a in answer]
             choices = (
                 self.cast_answer(choice.value) for choice in self._formatted_choices
@@ -521,6 +527,44 @@ def parse_yaml_string(string: str) -> Any:
         return yaml.safe_load(string)
     except yaml.error.YAMLError as error:
         raise ValueError(str(error))
+
+
+def parse_yaml_list(string: str) -> list[str]:
+    """Shallowly parse a YAML string that contains a list of items.
+
+    All items remain raw strings, only the outermost list is parsed.
+
+    Args:
+        string: The YAML string.
+
+    Returns:
+        The parsed list of raw items.
+
+    Raises:
+        ValueError: If the YAML string is not a list.
+    """
+    node = yaml.compose(string, Loader=yaml.SafeLoader)
+
+    if not isinstance(node, yaml.nodes.SequenceNode):
+        raise ValueError(f"Not a YAML list: {string!r}")
+
+    items = []
+    for item in node.value:
+        raw = string[item.start_mark.index : item.end_mark.index].strip()
+
+        if (
+            isinstance(item, yaml.nodes.ScalarNode)
+            and item.tag == "tag:yaml.org,2002:str"
+        ):
+            # Strip quotes if the value is quoted to avoid double-quoting.
+            if (raw.startswith('"') and raw.endswith('"')) or (
+                raw.startswith("'") and raw.endswith("'")
+            ):
+                raw = raw[1:-1]
+
+        items.append(raw)
+
+    return items
 
 
 def load_answersfile_data(

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -192,6 +192,25 @@ Supported keys:
     choice _value_, not its _key_, and it must match its _type_. If values are quite
     long, you can use
     [YAML anchors](https://confluence.atlassian.com/bitbucket/yaml-anchors-960154027.html).
+
+    !!! note "Dynamic default value of a multiselect choice question"
+
+        The default value of a multiselect choice question can be created dynamically by
+        using a templated string which renders a YAML-style list of choice values. List
+        items are parsed according to the question's `type` and don't need to be quoted
+        unless there is ambiguity with the surrounding list brackets. For example:
+
+        ```diff title="copier.yml"
+         brackets:
+             type: str
+             choices:
+                 - "["
+                 - "]"
+             multiselect: true
+        -    default: '[[, ]]'     # ❌ WRONG
+        +    default: '["[", "]"]' # ✔️ RIGHT
+        ```
+
 -   **secret**: When `true`, it hides the prompt displaying asterisks (`*****`) and
     doesn't save the answer in [the answers file][the-copier-answersyml-file]. When
     `true`, a default value is required.
@@ -793,6 +812,23 @@ questions with default answers.
 
     ```shell
     copier copy -fd 'user_name=Manuel Calavera' template destination
+    ```
+
+!!! example "Give an answer to a multiselect choice question"
+
+    The answer to a multiselect choice question is a YAML-style list of choice values.
+    For example:
+
+    ```shell
+    copier copy -fd 'python_versions=[3.10, 3.11, 3.12]'
+    ```
+
+    List items are parsed according to the question's `type` and don't need to be quoted
+    unless there is ambiguity with the surrounding list brackets. For example:
+
+    ```shell
+    copier copy -fd 'brackets=[[, ]]'     # ❌ WRONG
+    copier copy -fd 'brackets=["[", "]"]' # ✔️ RIGHT
     ```
 
 ### `data_file`

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -434,3 +434,41 @@ def test_skip_fileexists(template_path: str, tmp_path: Path) -> None:
     assert a_txt.read_text() == "PREVIOUS_CONTENT"
     answers = load_answersfile_data(tmp_path, "altered-answers.yml")
     assert answers["_src_path"] == str(template_path)
+
+
+def test_data_with_multiselect_choice_question(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    build_file_tree(
+        {
+            (src / "copier.yml"): (
+                """\
+                q:
+                    type: int
+                    choices: [1, 2, 3]
+                    multiselect: true
+                """
+            ),
+            (src / "{{ _copier_conf.answers_file }}.jinja"): (
+                """\
+                # Changes here will be overwritten by Copier
+                {{ _copier_answers|to_nice_yaml }}
+                """
+            ),
+        }
+    )
+
+    run_result = CopierApp.run(
+        [
+            "copier",
+            "copy",
+            "--data=q=[1, 3]",
+            str(src),
+            str(dst),
+        ],
+        exit=False,
+    )
+    assert run_result[1] == 0
+    assert load_answersfile_data(dst) == {"_src_path": str(src), "q": [1, 3]}


### PR DESCRIPTION
I've added support for providing serialized answers to multiselect choice questions.

This feature enables two use cases:

1. The default value can be templated by rendering default choice items as a YAML-style list.
2. An answer can be passed via the CLI flag `--data` as a YAML-style list. Resolves #1474.

The answer to a multiselect choice question is a list of choice items. While it seems that the most obvious solution is to parse the answer using a YAML parser, I think it's not the right approach because the list items should be parsed according to `type: <type>` and not necessarily using a YAML parser, and it's inconsistent with other question types to first parse them as YAML and afterwards parse according to `type: <type>`. But I've found a way to shallowly parse the serialized answer as a YAML-style list without parsing the items. This way, the items remain raw strings, delegating their parsing to the parser according to `type: <type>`. There is one subtlety: YAML strings may be quoted or (sometimes) unquoted. To avoid double-quoting after the shallow list parsing, the quotes of a YAML string are stripped.