### PR TITLE
chore(renovate): disabled `pyenv` manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
     "enabled": true,
     "schedule": "every 4 week on Monday"
   },
+  "pyenv": {
+    "enabled": false
+  },
   "rangeStrategy": "update-lockfile",
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
I've disabled Renovate's `pyenv` manager to avoid Python interpreter version updates in the `.python-version` file, as we want to keep our lowest supported Python version there for setting up the dev environment.