### PR TITLE
chore: add VS Code dev container setup

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+  "image": "docker.io/jetpackio/devbox:0.14.2",
+  "remoteUser": "devbox",
+  "mounts": [
+    "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/devbox/.ssh,readonly"
+  ],
+  "postCreateCommand": "devbox shell",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+        "editorconfig.editorconfig",
+        "elagil.pre-commit-helper",
+        "ms-python.python"
+      ],
+      "settings": {
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"
+      }
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,10 @@ The recommended way is:
 1. Wait until the terminal that pops up is ready.
 1. Accept the direnv pop-ups that appear.
 
+For local development with a similar experience, we also offer a
+[VS Code dev container](https://code.visualstudio.com/docs/devcontainers/containers)
+integration.
+
 For local or more complex setups, continue reading.
 
 We use some tools as part of our development workflow which you'll need to install into


### PR DESCRIPTION
I've added support for setting up our development environment using a VS Code dev container. This is a quite common tool stack and integrates very nicely with Devbox, so users who use dev containers will have a pleasant experience without the need to install Devbox on the host.