### PR TITLE
chore(renovate): don't update Prettier to v3.4.0+

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,12 @@
       "rangeStrategy": "pin"
     },
     {
+      "description": "Don't update Prettier to v3.4.0+ because it breaks some Markdown syntax extensions (https://github.com/prettier/prettier/issues/16929)",
+      "matchDatasources": ["devbox"],
+      "matchPackageNames": ["prettier"],
+      "allowedVersions": "<3.4.0"
+    },
+    {
       "matchCategories": ["python"],
       "addLabels": ["python"]
     },


### PR DESCRIPTION
I've added a Renovate package rule that constrains Prettier to versions prior to v3.4.0. This (hopefully temporary) workaround is necessary to retain compatibility with some Markdown syntax extensions. See https://github.com/prettier/prettier/issues/16929 for more details.