### PR TITLE
chore(devcontainer): create virtual env outside mounted workspace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,3 +9,7 @@ COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock
 
 # Install the Devbox environment
 RUN devbox install && nix-store --gc
+
+# Configure the project's virtual env path to be outside the mounted workspace
+# to avoid conflicts with the host env.
+ENV UV_PROJECT_ENVIRONMENT=/code/.venv


### PR DESCRIPTION
I've added the environment variable `UV_PROJECT_ENVIRONMENT` to the `Dockerfile` to create the virtual env outside the mounted workspace to

- avoid any conflicts with the host environment (e.g., symbolic links to executables in `.venv/bin/` are likely broken on the host), and

- avoid a uv warning related to hardlinking files during dependency installation

    ```
    warning: Failed to hardlink files; falling back to full copy. This may lead to degraded performance.
         If the cache and target directories are on different filesystems, hardlinking may not be supported.
         If this is intentional, set `export UV_LINK_MODE=copy` or use `--link-mode=copy` to suppress this warning.
    ```

    which doesn't work when the virtual env is located in a bind-mounted volume.