### PR TITLE
chore(devcontainer): add VS Code extension for Devbox

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,13 +7,13 @@
   "mounts": [
     "type=bind,source=${localEnv:HOME}${localEnv:USERPROFILE}/.ssh,target=/home/devbox/.ssh,readonly"
   ],
-  "postCreateCommand": "devbox shell",
   "customizations": {
     "vscode": {
       "extensions": [
         "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
         "editorconfig.editorconfig",
         "elagil.pre-commit-helper",
+        "jetpack-io.devbox",
         "ms-python.python"
       ],
       "settings": {


### PR DESCRIPTION
I've added the official VS Code extension for Devbox to the list of extensions installed in the dev container. It auto-activates the Devbox shell in VS Code's integrated terminal and replaces running `devbox shell` as a post-create command, which leads to random distortions when typing in the shell.