### PR TITLE
ci: limit number of pytest workers on macOS to 3 to avoid random `pexpect` timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,14 @@ jobs:
           - ubuntu-latest
           - windows-latest
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          # HACK: Limit the number of pytest workers on macOS to 3 to avoid a
+          #   timeout for a few test cases. For unknown reasons, the number of
+          #   auto-configured workers on macOS runners increased from 3 to 6 on
+          #   2025-07-08.
+          # FIXME: Remove this hack when the issue has been fixed.
+          - os: macos-latest
+            pytest-xdist-maxprocesses: 3
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -51,7 +59,11 @@ jobs:
       - name: Install dependencies
         run: uv sync --frozen
       - name: Run pytest
-        run: uv run poe test --cov=./ --cov-report=xml -ra .
+        run:
+          uv run poe test --cov=./ --cov-report=xml -ra
+          ${PYTEST_XDIST_MAXPROCESSES:+--maxprocesses=$PYTEST_XDIST_MAXPROCESSES} .
+        env:
+          PYTEST_XDIST_MAXPROCESSES: ${{ matrix.pytest-xdist-maxprocesses }}
       - name: Upload coverage to Codecov
         continue-on-error: true
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
This is an attempt to fix sudden and random CI job failures on macOS because of occasional `pexpect` timeouts. According to my research, `pytest-xdist` is auto-detecting 6 instead of 3 workers on GitHub macOS runners since 2025-07-08. I suspect that too many parallel processes are slowing down each process beyond the timeout. I couldn't find a [GitHub Changelog](https://github.blog/changelog/) entry about a related topic, so I'm not sure why this is happening.