### PR TITLE
chore(renovate): don't update Prettier to v3.4.0+ (again)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
     {
       "description": "Don't update Prettier to v3.4.0+ because it breaks some Markdown syntax extensions (https://github.com/prettier/prettier/issues/16929)",
       "matchDatasources": ["devbox"],
-      "matchPackageNames": ["prettier"],
+      "matchPackageNames": ["nodePackages.prettier"],
       "allowedVersions": "<3.4.0"
     },
     {


### PR DESCRIPTION
I've fixed the package name to `nodePackages.prettier` (which is the name used in the Nix registry) in the Renovate package rule.

Follow-up of #2225.