### PR TITLE
ci: limit number of pytest workers on macOS to 3 for `devbox` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,14 @@ jobs:
         os:
           - macos-latest
           - ubuntu-latest
+        include:
+          # HACK: Limit the number of pytest workers on macOS to 3 to avoid a
+          #   timeout for a few test cases. For unknown reasons, the number of
+          #   auto-configured workers on macOS runners increased from 3 to 6 on
+          #   2025-07-08.
+          # FIXME: Remove this hack when the issue has been fixed.
+          - os: macos-latest
+            pytest-xdist-maxprocesses: 3
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write # Allow pushing back pre-commit changes
@@ -97,4 +105,8 @@ jobs:
           enable-cache: "true"
       - run: devbox run -- uv run copier --version
       - run: devbox run -- uv run pre-commit run --all-files --show-diff-on-failure
-      - run: devbox run test
+      - run:
+          devbox run test
+          ${PYTEST_XDIST_MAXPROCESSES:+--maxprocesses=$PYTEST_XDIST_MAXPROCESSES}
+        env:
+          PYTEST_XDIST_MAXPROCESSES: ${{ matrix.pytest-xdist-maxprocesses }}

--- a/devbox.json
+++ b/devbox.json
@@ -14,7 +14,7 @@
     "init_hook": ["uv sync --frozen", "uv run pre-commit install"],
     "scripts": {
       "test": [
-        "env GIT_AUTHOR_EMAIL=copier@example.com GIT_AUTHOR_NAME=copier GIT_COMMITTER_EMAIL=copier@example.com GIT_COMMITTER_NAME=copier PYTHONOPTIMIZE= uv run poe test"
+        "env GIT_AUTHOR_EMAIL=copier@example.com GIT_AUTHOR_NAME=copier GIT_COMMITTER_EMAIL=copier@example.com GIT_COMMITTER_NAME=copier PYTHONOPTIMIZE= uv run poe test $@"
       ]
     }
   }


### PR DESCRIPTION
I missed to apply the same workaround to the `devbox` job in #2228; adding it now.

Follow-up of #2228.