### PR TITLE
Make spawn timeout into a pytest argument to solve false negative in tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,17 +131,17 @@ Ready to contribute? Here's how to set up the project for local development.
 
     !!! note
 
-        If you get fails due to `pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x............>`, you can adjust the timeout to a longer one (default: `10`), or remove the timeout (`None`).
+        If you get fails due to `pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x............>`, you can adjust the timeout to a longer one (default: `10`), or remove the timeout (`0`).
         Either add it as an argument in your command:
         ```shell
-        uv run poe test --spawn-timeout None
+        uv run poe test --spawn-timeout 0
         ```
-        Or modify pytest arguments in VSCode Workspace settings:
+        Or modify pytest arguments in VS Code workspace settings:
         ```json title=".vscode/settings.json"
         {
           ...
           "python.testing.pytestArgs": [
-            "--spawn-timeout=None"
+            "--spawn-timeout=0"
           ]
         }
         ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,12 +131,17 @@ Ready to contribute? Here's how to set up the project for local development.
 
     !!! note
 
-        If you get fails due to `pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x............>`, you can adjust the timeout to a longer one (default: `10`), or remove the timeout (`0`).
-        Either add it as an argument in your command:
+        If you get fails due to
+        `pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x............>`,
+        you can adjust the timeout to a longer one (default: `10`), or remove the
+        timeout (`0`). Either add it as an argument in your command:
+
         ```shell
         uv run poe test --spawn-timeout 0
         ```
+
         Or modify pytest arguments in VS Code workspace settings:
+
         ```json title=".vscode/settings.json"
         {
           ...

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,23 @@ Ready to contribute? Here's how to set up the project for local development.
     uv run poe lint
     ```
 
+    !!! note
+
+        If you get fails due to `pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x............>`, you can adjust the timeout to a longer one (default: `10`), or remove the timeout (`None`).
+        Either add it as an argument in your command:
+        ```shell
+        uv run poe test --spawn-timeout None
+        ```
+        Or modify pytest arguments in VSCode Workspace settings:
+        ```json title=".vscode/settings.json"
+        {
+          ...
+          "python.testing.pytestArgs": [
+            "--spawn-timeout=None"
+          ]
+        }
+        ```
+
 1.  Optionally, use pyclean to remove Python bytecode and build artifacts, e.g.
 
     ```shell

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import platform
 import sys
+from argparse import ArgumentTypeError
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -18,16 +19,18 @@ from .helpers import Spawn
 
 
 def pytest_addoption(parser: Parser) -> None:
+    def timeout_type(value: Any) -> int:
+        _value = int(value)
+        if _value >= 0:
+            return _value
+        raise ArgumentTypeError(f"Timeout must be a non-negative integer: '{_value}'")
+
     parser.addoption(
         "--spawn-timeout",
         action="store",
         default=10,
         help="timeout for spawn of pexpect",
-        type=lambda x: int(x)
-        if int(x) >= 0
-        else sys.exit(
-            f"\033[31mERROR: usage: pytest --spawn-timeout <int>\npytest: error: argument --spawn-timeout: should be positive or `0`: `{x}`\n\33[0m"
-        ),
+        type=timeout_type,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ import pytest
 from coverage.tracer import CTracer
 from pexpect.popen_spawn import PopenSpawn
 from plumbum import local
+from pytest import FixtureRequest, Parser
 from pytest_gitconfig.plugin import DELETE, GitConfig
 
 from .helpers import Spawn
@@ -93,3 +94,19 @@ def settings_path(config_path: Path) -> Path:
     config_path.mkdir()
     settings_path = config_path / "settings.yml"
     return settings_path
+
+
+def pytest_addoption(parser: Parser) -> None:
+    parser.addoption(
+        "--spawn-timeout",
+        action="store",
+        default=10,
+        help="timeout for spawn of pexpect",
+        type=lambda x: int(x) if x != "None" else None,
+    )
+
+
+@pytest.fixture
+def spawn_timeout(request: FixtureRequest) -> int | None:
+    _spawn_timeout: Any = request.config.getoption("--spawn-timeout")
+    return int(_spawn_timeout) if _spawn_timeout else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,7 +27,7 @@ def pytest_addoption(parser: Parser) -> None:
     )
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def spawn_timeout(request: FixtureRequest) -> int | None:
     _spawn_timeout: Any = request.config.getoption("--spawn-timeout")
     return int(_spawn_timeout) if _spawn_timeout else None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,7 +23,11 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         default=10,
         help="timeout for spawn of pexpect",
-        type=int,
+        type=lambda x: int(x)
+        if int(x) >= 0
+        else sys.exit(
+            f"\033[31mERROR: usage: pytest --spawn-timeout <int>\npytest: error: argument --spawn-timeout: should be positive or `0`: `{x}`\n\33[0m"
+        ),
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,18 +23,17 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         default=10,
         help="timeout for spawn of pexpect",
-        type=lambda x: int(x) if x != "None" else None,
+        type=int,
     )
 
 
 @pytest.fixture(scope="session")
-def spawn_timeout(request: FixtureRequest) -> int | None:
-    _spawn_timeout: Any = request.config.getoption("--spawn-timeout")
-    return int(_spawn_timeout) if _spawn_timeout else None
+def spawn_timeout(request: FixtureRequest) -> int:
+    return int(request.config.getoption("--spawn-timeout"))
 
 
 @pytest.fixture
-def spawn(spawn_timeout: int | None) -> Spawn:
+def spawn(spawn_timeout: int) -> Spawn:
     """Spawn a copier process TUI to interact with."""
     if platform.system() == "Windows":
         # HACK https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1243#issuecomment-706668723
@@ -49,7 +48,7 @@ def spawn(spawn_timeout: int | None) -> Spawn:
         # Disable subprocess timeout if debugging (except coverage), for commodity
         # See https://stackoverflow.com/a/67065084/1468388
         tracer = getattr(sys, "gettrace", lambda: None)()
-        if not isinstance(tracer, (CTracer, type(None))):
+        if not isinstance(tracer, (CTracer, type(None))) or timeout == 0:
             timeout = None
         # Using PopenSpawn, although probably it would be best to use pexpect.spawn
         # instead. However, it's working fine and it seems easier to fix in the

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -71,7 +71,9 @@ COPIER_ANSWERS_FILE: Mapping[StrOrPath, str | bytes | Path] = {
 
 
 class Spawn(Protocol):
-    def __call__(self, cmd: tuple[str, ...], *, timeout: int | None) -> PopenSpawn: ...
+    def __call__(
+        self, cmd: tuple[str, ...], *, timeout: int | None = ...
+    ) -> PopenSpawn: ...
 
 
 class Keyboard(str, Enum):

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -436,8 +436,7 @@ def test_tui_inherited_default(
 
 
 def test_tui_typed_default(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
 ) -> None:
     """Make sure a template defaults are typed as expected."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -476,8 +475,7 @@ def test_tui_typed_default(
 
 
 def test_selection_type_cast(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
 ) -> None:
     """Selection question with different types, properly casted."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -168,9 +168,13 @@ def test_api(template_path: str, tmp_path: Path) -> None:
     )
 
 
-def test_cli_interactive(template_path: str, tmp_path: Path, spawn: Spawn) -> None:
+def test_cli_interactive(
+    template_path: str, tmp_path: Path, spawn: Spawn, spawn_timeout: int | None
+) -> None:
     """Test copier correctly processes advanced questions and answers through CLI."""
-    tui = spawn(COPIER_PATH + ("copy", template_path, str(tmp_path)), timeout=10)
+    tui = spawn(
+        COPIER_PATH + ("copy", template_path, str(tmp_path)), timeout=spawn_timeout
+    )
     expect_prompt(tui, "love_me", "bool", help="I need to know it. Do you love me?")
     tui.send("y")
     expect_prompt(tui, "your_name", "str", help="Please tell me your name.")
@@ -308,7 +312,7 @@ def test_api_str_data(template_path: str, tmp_path: Path) -> None:
 
 
 def test_cli_interatively_with_flag_data_and_type_casts(
-    template_path: str, tmp_path: Path, spawn: Spawn
+    template_path: str, tmp_path: Path, spawn: Spawn, spawn_timeout: int | None
 ) -> None:
     """Assert how choices work when copier is invoked with --data interactively."""
     tui = spawn(
@@ -322,7 +326,7 @@ def test_cli_interatively_with_flag_data_and_type_casts(
             template_path,
             str(tmp_path),
         ),
-        timeout=10,
+        timeout=spawn_timeout,
     )
     expect_prompt(tui, "love_me", "bool", help="I need to know it. Do you love me?")
     tui.send("y")
@@ -377,6 +381,7 @@ def test_tui_inherited_default(
     spawn: Spawn,
     has_2_owners: bool,
     owner2: str,
+    spawn_timeout: int | None,
 ) -> None:
     """Make sure a template inherits default as expected."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -407,7 +412,7 @@ def test_tui_inherited_default(
         git("add", "--all")
         git("commit", "--message", "init template")
         git("tag", "1")
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
     expect_prompt(tui, "owner1", "str")
     tui.sendline("example")
     expect_prompt(tui, "has_2_owners", "bool")
@@ -437,7 +442,9 @@ def test_tui_inherited_default(
 
 
 def test_tui_typed_default(
-    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    spawn_timeout: int | None,
 ) -> None:
     """Make sure a template defaults are typed as expected."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -466,7 +473,7 @@ def test_tui_typed_default(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
     tui.expect_exact(pexpect.EOF)
     assert json.loads((dst / "answers.json").read_text()) == {"_src_path": str(src)}
     assert json.loads((dst / "context.json").read_text()) == {
@@ -476,7 +483,9 @@ def test_tui_typed_default(
 
 
 def test_selection_type_cast(
-    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    spawn_timeout: int | None,
 ) -> None:
     """Selection question with different types, properly casted."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -507,7 +516,7 @@ def test_selection_type_cast(
             (src / "answers.json.jinja"): "{{ _copier_answers|to_json }}",
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
     expect_prompt(
         tui, "postgres1", "yaml", help="Which PostgreSQL version do you want to deploy?"
     )

--- a/tests/test_complex_questions.py
+++ b/tests/test_complex_questions.py
@@ -168,13 +168,9 @@ def test_api(template_path: str, tmp_path: Path) -> None:
     )
 
 
-def test_cli_interactive(
-    template_path: str, tmp_path: Path, spawn: Spawn, spawn_timeout: int | None
-) -> None:
+def test_cli_interactive(template_path: str, tmp_path: Path, spawn: Spawn) -> None:
     """Test copier correctly processes advanced questions and answers through CLI."""
-    tui = spawn(
-        COPIER_PATH + ("copy", template_path, str(tmp_path)), timeout=spawn_timeout
-    )
+    tui = spawn(COPIER_PATH + ("copy", template_path, str(tmp_path)))
     expect_prompt(tui, "love_me", "bool", help="I need to know it. Do you love me?")
     tui.send("y")
     expect_prompt(tui, "your_name", "str", help="Please tell me your name.")
@@ -312,7 +308,7 @@ def test_api_str_data(template_path: str, tmp_path: Path) -> None:
 
 
 def test_cli_interatively_with_flag_data_and_type_casts(
-    template_path: str, tmp_path: Path, spawn: Spawn, spawn_timeout: int | None
+    template_path: str, tmp_path: Path, spawn: Spawn
 ) -> None:
     """Assert how choices work when copier is invoked with --data interactively."""
     tui = spawn(
@@ -326,7 +322,6 @@ def test_cli_interatively_with_flag_data_and_type_casts(
             template_path,
             str(tmp_path),
         ),
-        timeout=spawn_timeout,
     )
     expect_prompt(tui, "love_me", "bool", help="I need to know it. Do you love me?")
     tui.send("y")
@@ -381,7 +376,6 @@ def test_tui_inherited_default(
     spawn: Spawn,
     has_2_owners: bool,
     owner2: str,
-    spawn_timeout: int | None,
 ) -> None:
     """Make sure a template inherits default as expected."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -412,7 +406,7 @@ def test_tui_inherited_default(
         git("add", "--all")
         git("commit", "--message", "init template")
         git("tag", "1")
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "owner1", "str")
     tui.sendline("example")
     expect_prompt(tui, "has_2_owners", "bool")
@@ -444,7 +438,6 @@ def test_tui_inherited_default(
 def test_tui_typed_default(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     """Make sure a template defaults are typed as expected."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -473,7 +466,7 @@ def test_tui_typed_default(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     tui.expect_exact(pexpect.EOF)
     assert json.loads((dst / "answers.json").read_text()) == {"_src_path": str(src)}
     assert json.loads((dst / "context.json").read_text()) == {
@@ -485,7 +478,6 @@ def test_tui_typed_default(
 def test_selection_type_cast(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     """Selection question with different types, properly casted."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -516,7 +508,7 @@ def test_selection_type_cast(
             (src / "answers.json.jinja"): "{{ _copier_answers|to_json }}",
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(
         tui, "postgres1", "yaml", help="Which PostgreSQL version do you want to deploy?"
     )

--- a/tests/test_conditional_file_name.py
+++ b/tests/test_conditional_file_name.py
@@ -62,9 +62,7 @@ def test_dont_render_conditional_subdir(tmp_path_factory: TempPathFactory) -> No
 
 @pytest.mark.parametrize("interactive", [False, True])
 def test_answer_changes(
-    tmp_path_factory: TempPathFactory,
-    spawn: Spawn,
-    interactive: bool,
+    tmp_path_factory: TempPathFactory, spawn: Spawn, interactive: bool
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 

--- a/tests/test_conditional_file_name.py
+++ b/tests/test_conditional_file_name.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import pexpect
 import pytest
 from plumbum import local
@@ -67,7 +65,6 @@ def test_answer_changes(
     tmp_path_factory: TempPathFactory,
     spawn: Spawn,
     interactive: bool,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
@@ -88,7 +85,7 @@ def test_answer_changes(
         git("tag", "v1")
 
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
         expect_prompt(tui, "condition", "bool")
         tui.expect_exact("(y/N)")
         tui.sendline("y")
@@ -105,7 +102,7 @@ def test_answer_changes(
         git("commit", "-mv1")
 
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
+        tui = spawn(COPIER_PATH + ("update", str(dst)))
         expect_prompt(tui, "condition", "bool")
         tui.expect_exact("(Y/n)")
         tui.sendline("n")

--- a/tests/test_conditional_file_name.py
+++ b/tests/test_conditional_file_name.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pexpect
 import pytest
 from plumbum import local
@@ -62,7 +64,10 @@ def test_dont_render_conditional_subdir(tmp_path_factory: TempPathFactory) -> No
 
 @pytest.mark.parametrize("interactive", [False, True])
 def test_answer_changes(
-    tmp_path_factory: TempPathFactory, spawn: Spawn, interactive: bool
+    tmp_path_factory: TempPathFactory,
+    spawn: Spawn,
+    interactive: bool,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
 
@@ -83,7 +88,7 @@ def test_answer_changes(
         git("tag", "v1")
 
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
         expect_prompt(tui, "condition", "bool")
         tui.expect_exact("(y/N)")
         tui.sendline("y")
@@ -100,7 +105,7 @@ def test_answer_changes(
         git("commit", "-mv1")
 
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
         expect_prompt(tui, "condition", "bool")
         tui.expect_exact("(Y/n)")
         tui.sendline("n")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -143,9 +143,7 @@ def test_messages_with_inline_text(
 
     # copy
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)),
-        )
+        tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
@@ -285,9 +283,7 @@ def test_messages_with_included_text(
 
     # copy
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)),
-        )
+        tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
@@ -406,9 +402,7 @@ def test_messages_quiet(
 
     # copy
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("copy", "--quiet", "-r", "v1", str(src), str(dst)),
-        )
+        tui = spawn(COPIER_PATH + ("copy", "--quiet", "-r", "v1", str(src), str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
@@ -424,9 +418,7 @@ def test_messages_quiet(
 
     # recopy
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("recopy", "--quiet", "-r", "v1", str(dst)),
-        )
+        tui = spawn(COPIER_PATH + ("recopy", "--quiet", "-r", "v1", str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from pathlib import Path
 
@@ -97,6 +99,7 @@ def test_messages_with_inline_text(
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
 
@@ -143,7 +146,10 @@ def test_messages_with_inline_text(
 
     # copy
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)),
+            timeout=spawn_timeout,
+        )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
@@ -163,7 +169,9 @@ def test_messages_with_inline_text(
 
     # recopy
     if interactive:
-        tui = spawn(COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=spawn_timeout
+        )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)
@@ -191,7 +199,7 @@ def test_messages_with_inline_text(
 
     # update
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_update")
         tui.expect_exact(pexpect.EOF)
@@ -216,6 +224,7 @@ def test_messages_with_included_text(
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
 
@@ -283,7 +292,10 @@ def test_messages_with_included_text(
 
     # copy
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)),
+            timeout=spawn_timeout,
+        )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
         tui.expect_exact(pexpect.EOF)
@@ -303,7 +315,9 @@ def test_messages_with_included_text(
 
     # recopy
     if interactive:
-        tui = spawn(COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=spawn_timeout
+        )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)
@@ -331,7 +345,7 @@ def test_messages_with_included_text(
 
     # update
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
+        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_update")
         tui.expect_exact(pexpect.EOF)
@@ -356,6 +370,7 @@ def test_messages_quiet(
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
 
@@ -404,7 +419,7 @@ def test_messages_quiet(
     if interactive:
         tui = spawn(
             COPIER_PATH + ("copy", "--quiet", "-r", "v1", str(src), str(dst)),
-            timeout=10,
+            timeout=spawn_timeout,
         )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
@@ -422,7 +437,8 @@ def test_messages_quiet(
     # recopy
     if interactive:
         tui = spawn(
-            COPIER_PATH + ("recopy", "--quiet", "-r", "v1", str(dst)), timeout=10
+            COPIER_PATH + ("recopy", "--quiet", "-r", "v1", str(dst)),
+            timeout=spawn_timeout,
         )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
@@ -445,7 +461,9 @@ def test_messages_quiet(
 
     # update
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", "--quiet", str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("update", "--quiet", str(dst)), timeout=spawn_timeout
+        )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_update")
         tui.expect_exact(pexpect.EOF)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import re
 from pathlib import Path
 
@@ -99,7 +97,6 @@ def test_messages_with_inline_text(
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
 
@@ -148,7 +145,6 @@ def test_messages_with_inline_text(
     if interactive:
         tui = spawn(
             COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)),
-            timeout=spawn_timeout,
         )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
@@ -169,9 +165,7 @@ def test_messages_with_inline_text(
 
     # recopy
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=spawn_timeout
-        )
+        tui = spawn(COPIER_PATH + ("recopy", "-r", "v1", str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)
@@ -199,7 +193,7 @@ def test_messages_with_inline_text(
 
     # update
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
+        tui = spawn(COPIER_PATH + ("update", str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_update")
         tui.expect_exact(pexpect.EOF)
@@ -224,7 +218,6 @@ def test_messages_with_included_text(
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
 
@@ -294,7 +287,6 @@ def test_messages_with_included_text(
     if interactive:
         tui = spawn(
             COPIER_PATH + ("copy", "-r", "v1", str(src), str(dst)),
-            timeout=spawn_timeout,
         )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
@@ -315,9 +307,7 @@ def test_messages_with_included_text(
 
     # recopy
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("recopy", "-r", "v1", str(dst)), timeout=spawn_timeout
-        )
+        tui = spawn(COPIER_PATH + ("recopy", "-r", "v1", str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
         tui.expect_exact(pexpect.EOF)
@@ -345,7 +335,7 @@ def test_messages_with_included_text(
 
     # update
     if interactive:
-        tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
+        tui = spawn(COPIER_PATH + ("update", str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_update")
         tui.expect_exact(pexpect.EOF)
@@ -370,7 +360,6 @@ def test_messages_quiet(
     capsys: pytest.CaptureFixture[str],
     spawn: Spawn,
     interactive: bool,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
 
@@ -419,7 +408,6 @@ def test_messages_quiet(
     if interactive:
         tui = spawn(
             COPIER_PATH + ("copy", "--quiet", "-r", "v1", str(src), str(dst)),
-            timeout=spawn_timeout,
         )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("myproj")
@@ -438,7 +426,6 @@ def test_messages_quiet(
     if interactive:
         tui = spawn(
             COPIER_PATH + ("recopy", "--quiet", "-r", "v1", str(dst)),
-            timeout=spawn_timeout,
         )
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_new")
@@ -461,9 +448,7 @@ def test_messages_quiet(
 
     # update
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("update", "--quiet", str(dst)), timeout=spawn_timeout
-        )
+        tui = spawn(COPIER_PATH + ("update", "--quiet", str(dst)))
         expect_prompt(tui, "project_name", "str")
         tui.sendline("_update")
         tui.expect_exact(pexpect.EOF)

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -158,7 +158,12 @@ def test_copy_default_advertised(
         # Update subproject
         git_save()
         assert load_answersfile_data(".").get("_commit") == "v1"
-        tui = spawn(COPIER_PATH + ("update",), timeout=30)
+        tui = spawn(
+            COPIER_PATH + ("update",),
+            timeout=spawn_timeout * 3
+            if spawn_timeout is not None and spawn_timeout > 0
+            else None,
+        )
         # Check what was captured
         expect_prompt(tui, "in_love", "bool")
         tui.expect_exact("(Y/n)")
@@ -281,7 +286,9 @@ def test_update_skip_answered(
                 update_action,
                 "--skip-answered",
             ),
-            timeout=30,
+            timeout=spawn_timeout * 3
+            if spawn_timeout is not None and spawn_timeout > 0
+            else None,
         )
         # Check what was captured
         expect_prompt(tui, "your_enemy", "str", help="Secret enemy name")
@@ -346,7 +353,9 @@ def test_update_with_new_field_in_new_version_skip_answered(
                 "update",
                 "-A",
             ),
-            timeout=30,
+            timeout=spawn_timeout * 3
+            if spawn_timeout is not None and spawn_timeout > 0
+            else None,
         )
         # Check what was captured
         expect_prompt(tui, "your_enemy", "str", help="Secret enemy name")

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -458,10 +458,7 @@ def test_when(
     assert context == {"question_2": "something"}
 
 
-def test_placeholder(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
-) -> None:
+def test_placeholder(tmp_path_factory: pytest.TempPathFactory, spawn: Spawn) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
         {
@@ -500,9 +497,7 @@ def test_placeholder(
 
 @pytest.mark.parametrize("type_", ["str", "yaml", "json"])
 def test_multiline(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
-    type_: str,
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn, type_: str
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -631,8 +626,7 @@ def test_update_choice(
 
 @pytest.mark.skip("TODO: fix this")
 def test_multiline_defaults(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
 ) -> None:
     """Multiline questions with scalar defaults produce multiline defaults."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -726,8 +720,7 @@ def test_partial_interrupt(
 
 
 def test_var_name_value_allowed(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
 ) -> None:
     """Test that a question var name "value" causes no name collision.
 
@@ -809,8 +802,7 @@ def test_required_text_question(
 
 
 def test_required_bool_question(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -1044,8 +1036,7 @@ def test_update_multiselect_choices(
 
 
 def test_multiselect_choices_validator(
-    question_tree: QuestionTreeFixture,
-    copier: CopierFixture,
+    question_tree: QuestionTreeFixture, copier: CopierFixture
 ) -> None:
     """Multiple choices are validated."""
     src, dst = question_tree(
@@ -1067,8 +1058,7 @@ def test_multiselect_choices_validator(
 
 
 def test_secret_validator(
-    question_tree: QuestionTreeFixture,
-    copier: CopierFixture,
+    question_tree: QuestionTreeFixture, copier: CopierFixture
 ) -> None:
     """Secret question answer is validated."""
     default = "s3cret"

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -419,7 +419,6 @@ def test_when(
     question_1: str | int | float | bool,
     question_2_when: bool | str,
     asks: bool,
-    spawn_timeout: int | None,
 ) -> None:
     """Test that the 2nd question is skipped or not, properly."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -442,7 +441,7 @@ def test_when(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "question_1", type(question_1).__name__)
     tui.sendline()
     if asks:
@@ -462,7 +461,6 @@ def test_when(
 def test_placeholder(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -484,7 +482,7 @@ def test_placeholder(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     tui.sendline()
@@ -505,7 +503,6 @@ def test_multiline(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
     type_: str,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -532,7 +529,7 @@ def test_multiline(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     tui.sendline()
@@ -580,7 +577,6 @@ def test_update_choice(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
     choices: list[int] | list[list[str | int]] | dict[str, int],
-    spawn_timeout: int | None,
 ) -> None:
     """Choices are properly remembered and selected in TUI when updating."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -608,7 +604,7 @@ def test_update_choice(
         git("commit", "-m one")
         git("tag", "v1")
     # Copy
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "pick_one", "float")
     tui.sendline(Keyboard.Up)
     tui.expect_exact(pexpect.EOF)
@@ -624,8 +620,7 @@ def test_update_choice(
         + (
             "update",
             str(dst),
-        ),
-        timeout=spawn_timeout,
+        )
     )
     expect_prompt(tui, "pick_one", "float")
     tui.sendline(Keyboard.Down)
@@ -638,7 +633,6 @@ def test_update_choice(
 def test_multiline_defaults(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     """Multiline questions with scalar defaults produce multiline defaults."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -671,7 +665,7 @@ def test_multiline_defaults(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "yaml_single", "yaml")
     # This test will always fail here, because python prompt toolkit gives
     # syntax highlighting to YAML and JSON outputs, encoded into terminal
@@ -704,7 +698,6 @@ def test_multiline_defaults(
 def test_partial_interrupt(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -717,7 +710,7 @@ def test_partial_interrupt(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "question_1", "str")
     tui.expect_exact("answer 1")
     # Answer the first question using the default.
@@ -735,7 +728,6 @@ def test_partial_interrupt(
 def test_var_name_value_allowed(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     """Test that a question var name "value" causes no name collision.
 
@@ -759,7 +751,7 @@ def test_var_name_value_allowed(
         }
     )
     # Copy
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "value", "str")
     tui.expect_exact("string")
     tui.send(Keyboard.Alt + Keyboard.Enter)
@@ -784,7 +776,6 @@ def test_required_text_question(
     spawn: Spawn,
     type_name: str,
     expected_answer: str | None | ValueError,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -801,7 +792,7 @@ def test_required_text_question(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "question", type_name)
     tui.expect_exact("")
     tui.sendline()
@@ -820,7 +811,6 @@ def test_required_text_question(
 def test_required_bool_question(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -837,7 +827,7 @@ def test_required_bool_question(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "question", "bool")
     tui.expect_exact("(y/N)")
     tui.sendline()
@@ -865,7 +855,6 @@ def test_required_choice_question(
     type_name: str,
     choices: list[Any],
     expected_answer: Any,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -885,7 +874,7 @@ def test_required_choice_question(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "question", type_name)
     tui.sendline()
     tui.expect_exact(pexpect.EOF)
@@ -960,10 +949,9 @@ def test_multiselect_choices_question_single_answer(
     type_name: QuestionType,
     choices: QuestionChoices,
     values: ParsedValues,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = question_tree(type=type_name, choices=choices, multiselect=True)
-    tui = copier("copy", str(src), str(dst), timeout=spawn_timeout)
+    tui = copier("copy", str(src), str(dst))
     expect_prompt(tui, "question", type_name)
     tui.send(" ")  # select 1
     tui.sendline()
@@ -979,10 +967,9 @@ def test_multiselect_choices_question_multiple_answers(
     type_name: QuestionType,
     choices: QuestionChoices,
     values: ParsedValues,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = question_tree(type=type_name, choices=choices, multiselect=True)
-    tui = copier("copy", str(src), str(dst), timeout=spawn_timeout)
+    tui = copier("copy", str(src), str(dst))
     expect_prompt(tui, "question", type_name)
     tui.send(" ")  # select 0
     tui.send(Keyboard.Down)
@@ -1000,12 +987,11 @@ def test_multiselect_choices_question_with_default(
     type_name: QuestionType,
     choices: QuestionChoices,
     values: ParsedValues,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = question_tree(
         type=type_name, choices=choices, multiselect=True, default=values
     )
-    tui = copier("copy", str(src), str(dst), timeout=spawn_timeout)
+    tui = copier("copy", str(src), str(dst))
     expect_prompt(tui, "question", type_name)
     tui.send(" ")  # toggle first
     tui.sendline()
@@ -1021,7 +1007,6 @@ def test_update_multiselect_choices(
     type_name: QuestionType,
     choices: QuestionChoices,
     values: ParsedValues,
-    spawn_timeout: int | None,
 ) -> None:
     """Multiple choices are properly remembered and selected in TUI when updating."""
     src, dst = question_tree(
@@ -1035,7 +1020,7 @@ def test_update_multiselect_choices(
         git("tag", "v1")
 
     # Copy
-    tui = copier("copy", str(src), str(dst), timeout=spawn_timeout)
+    tui = copier("copy", str(src), str(dst))
     expect_prompt(tui, "question", type_name)
     tui.send(" ")  # toggle first
     tui.sendline()
@@ -1049,7 +1034,7 @@ def test_update_multiselect_choices(
         git("commit", "-m1")
 
     # Update
-    tui = copier("update", str(dst), timeout=spawn_timeout)
+    tui = copier("update", str(dst))
     expect_prompt(tui, "question", type_name)
     tui.send(" ")  # toggle first
     tui.sendline()
@@ -1061,7 +1046,6 @@ def test_update_multiselect_choices(
 def test_multiselect_choices_validator(
     question_tree: QuestionTreeFixture,
     copier: CopierFixture,
-    spawn_timeout: int | None,
 ) -> None:
     """Multiple choices are validated."""
     src, dst = question_tree(
@@ -1071,7 +1055,7 @@ def test_multiselect_choices_validator(
         validator=("[%- if not question -%]At least one choice required[%- endif -%]"),
     )
 
-    tui = copier("copy", str(src), str(dst), timeout=spawn_timeout)
+    tui = copier("copy", str(src), str(dst))
     expect_prompt(tui, "question", "str")
     tui.sendline()
     tui.expect_exact("At least one choice required")
@@ -1085,7 +1069,6 @@ def test_multiselect_choices_validator(
 def test_secret_validator(
     question_tree: QuestionTreeFixture,
     copier: CopierFixture,
-    spawn_timeout: int | None,
 ) -> None:
     """Secret question answer is validated."""
     default = "s3cret"
@@ -1096,7 +1079,7 @@ def test_secret_validator(
         validator="[% if question|length < 3 %]too short[% endif %]",
     )
 
-    tui = copier("copy", str(src), str(dst), timeout=spawn_timeout)
+    tui = copier("copy", str(src), str(dst))
     expect_prompt(tui, "question", "str")
     # Delete default value to fail validation
     for _ in range(len(default)):

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1089,7 +1089,7 @@ def test_interactive_session_required_for_question_prompt(
         (*COPIER_PATH, "copy", str(src), str(dst)),
         stdin=subprocess.PIPE,  # Prevents interactive input
         capture_output=True,
-        timeout=spawn_timeout if spawn_timeout != 0 else None,
+        timeout=spawn_timeout or None,
     )
     assert process.returncode == 1
     assert (
@@ -1117,7 +1117,7 @@ def test_interactive_session_required_for_overwrite_prompt(
         (*COPIER_PATH, "copy", str(src), str(dst)),
         stdin=subprocess.PIPE,  # Prevents interactive input
         capture_output=True,
-        timeout=spawn_timeout if spawn_timeout != 0 else None,
+        timeout=spawn_timeout or None,
     )
     assert process.returncode == 1
     assert (

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -425,8 +425,7 @@ def test_templated_prompt_with_templated_choices(
 
 
 def test_templated_prompt_update_previous_answer_disabled(
-    tmp_path_factory: pytest.TempPathFactory,
-    spawn: Spawn,
+    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -158,7 +158,6 @@ def test_templated_prompt(
     questions_data: AnyByStrDict,
     expected_value: str | int,
     expected_outputs: Sequence[str | Prompt],
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     questions_combined = {**main_question, **questions_data}
@@ -172,7 +171,7 @@ def test_templated_prompt(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "main", "str")
     tui.expect_exact(main_default)
     tui.sendline()
@@ -329,7 +328,6 @@ def test_templated_prompt_with_conditional_choices(
     spawn: Spawn,
     cloud: str,
     iac_choices: str,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -365,7 +363,6 @@ def test_templated_prompt_with_conditional_choices(
     )
     tui = spawn(
         COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)),
-        timeout=spawn_timeout,
     )
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
     for iac in iac_choices:
@@ -387,7 +384,6 @@ def test_templated_prompt_with_templated_choices(
     spawn: Spawn,
     cloud: str,
     iac_choices: str,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -421,10 +417,7 @@ def test_templated_prompt_with_templated_choices(
             ),
         }
     )
-    tui = spawn(
-        COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)),
-        timeout=spawn_timeout,
-    )
+    tui = spawn(COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)))
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
     for iac in iac_choices:
         tui.expect_exact(iac)
@@ -434,7 +427,6 @@ def test_templated_prompt_with_templated_choices(
 def test_templated_prompt_update_previous_answer_disabled(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -475,7 +467,7 @@ def test_templated_prompt_update_previous_answer_disabled(
         git_init("v1")
         git("tag", "v1")
 
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "cloud", "str", help="Which cloud provider do you use?")
     tui.sendline(Keyboard.Down)  # select "AWS"
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
@@ -492,7 +484,7 @@ def test_templated_prompt_update_previous_answer_disabled(
     with local.cwd(dst):
         git_init("v1")
 
-    tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("update", str(dst)))
     expect_prompt(tui, "cloud", "str", help="Which cloud provider do you use?")
     tui.sendline(Keyboard.Down)  # select "Azure"
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
@@ -510,7 +502,6 @@ def test_templated_prompt_update_previous_answer_disabled(
 def test_multiselect_choices_with_templated_default_value(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -547,7 +538,7 @@ def test_multiselect_choices_with_templated_default_value(
         }
     )
 
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(
         tui, "python_version", "str", help="What version of python are you targeting?"
     )
@@ -571,7 +562,6 @@ def test_multiselect_choices_with_templated_default_value(
 def test_copier_phase_variable(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -583,7 +573,7 @@ def test_copier_phase_variable(
             """
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)))
     expect_prompt(tui, "phase", "str")
     tui.expect_exact("prompt")
 
@@ -591,7 +581,6 @@ def test_copier_phase_variable(
 def test_copier_conf_variable(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -603,9 +592,6 @@ def test_copier_conf_variable(
             """
         }
     )
-    tui = spawn(
-        COPIER_PATH + ("copy", str(src), str(dst / "test_project")),
-        timeout=spawn_timeout,
-    )
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst / "test_project")))
     expect_prompt(tui, "project_name", "str")
     tui.expect_exact("test_project")

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -361,9 +361,7 @@ def test_templated_prompt_with_conditional_choices(
             ),
         }
     )
-    tui = spawn(
-        COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)),
-    )
+    tui = spawn(COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)))
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
     for iac in iac_choices:
         tui.expect_exact(iac)

--- a/tests/test_templated_prompt.py
+++ b/tests/test_templated_prompt.py
@@ -158,6 +158,7 @@ def test_templated_prompt(
     questions_data: AnyByStrDict,
     expected_value: str | int,
     expected_outputs: Sequence[str | Prompt],
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     questions_combined = {**main_question, **questions_data}
@@ -171,7 +172,7 @@ def test_templated_prompt(
             ),
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
     expect_prompt(tui, "main", "str")
     tui.expect_exact(main_default)
     tui.sendline()
@@ -328,6 +329,7 @@ def test_templated_prompt_with_conditional_choices(
     spawn: Spawn,
     cloud: str,
     iac_choices: str,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -363,7 +365,7 @@ def test_templated_prompt_with_conditional_choices(
     )
     tui = spawn(
         COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)),
-        timeout=10,
+        timeout=spawn_timeout,
     )
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
     for iac in iac_choices:
@@ -385,6 +387,7 @@ def test_templated_prompt_with_templated_choices(
     spawn: Spawn,
     cloud: str,
     iac_choices: str,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -420,7 +423,7 @@ def test_templated_prompt_with_templated_choices(
     )
     tui = spawn(
         COPIER_PATH + ("copy", f"--data=cloud={cloud}", str(src), str(dst)),
-        timeout=10,
+        timeout=spawn_timeout,
     )
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
     for iac in iac_choices:
@@ -429,7 +432,9 @@ def test_templated_prompt_with_templated_choices(
 
 
 def test_templated_prompt_update_previous_answer_disabled(
-    tmp_path_factory: pytest.TempPathFactory, spawn: Spawn
+    tmp_path_factory: pytest.TempPathFactory,
+    spawn: Spawn,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -470,7 +475,7 @@ def test_templated_prompt_update_previous_answer_disabled(
         git_init("v1")
         git("tag", "v1")
 
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
     expect_prompt(tui, "cloud", "str", help="Which cloud provider do you use?")
     tui.sendline(Keyboard.Down)  # select "AWS"
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
@@ -487,7 +492,7 @@ def test_templated_prompt_update_previous_answer_disabled(
     with local.cwd(dst):
         git_init("v1")
 
-    tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("update", str(dst)), timeout=spawn_timeout)
     expect_prompt(tui, "cloud", "str", help="Which cloud provider do you use?")
     tui.sendline(Keyboard.Down)  # select "Azure"
     expect_prompt(tui, "iac", "str", help="Which IaC tool do you use?")
@@ -505,6 +510,7 @@ def test_templated_prompt_update_previous_answer_disabled(
 def test_multiselect_choices_with_templated_default_value(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -541,7 +547,7 @@ def test_multiselect_choices_with_templated_default_value(
         }
     )
 
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
     expect_prompt(
         tui, "python_version", "str", help="What version of python are you targeting?"
     )
@@ -565,6 +571,7 @@ def test_multiselect_choices_with_templated_default_value(
 def test_copier_phase_variable(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -576,7 +583,7 @@ def test_copier_phase_variable(
             """
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=10)
+    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst)), timeout=spawn_timeout)
     expect_prompt(tui, "phase", "str")
     tui.expect_exact("prompt")
 
@@ -584,6 +591,7 @@ def test_copier_phase_variable(
 def test_copier_conf_variable(
     tmp_path_factory: pytest.TempPathFactory,
     spawn: Spawn,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(
@@ -595,6 +603,9 @@ def test_copier_conf_variable(
             """
         }
     )
-    tui = spawn(COPIER_PATH + ("copy", str(src), str(dst / "test_project")), timeout=10)
+    tui = spawn(
+        COPIER_PATH + ("copy", str(src), str(dst / "test_project")),
+        timeout=spawn_timeout,
+    )
     expect_prompt(tui, "project_name", "str")
     tui.expect_exact("test_project")

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -858,7 +858,10 @@ def test_file_removed(tmp_path_factory: pytest.TempPathFactory) -> None:
 
 @pytest.mark.parametrize("interactive", [True, False])
 def test_update_inline_changed_answers_and_questions(
-    tmp_path_factory: pytest.TempPathFactory, interactive: bool, spawn: Spawn
+    tmp_path_factory: pytest.TempPathFactory,
+    interactive: bool,
+    spawn: Spawn,
+    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     with local.cwd(src):
@@ -903,7 +906,9 @@ def test_update_inline_changed_answers_and_questions(
         git("tag", "2")
     # Init project
     if interactive:
-        tui = spawn(COPIER_PATH + ("copy", "-r1", str(src), str(dst)), timeout=10)
+        tui = spawn(
+            COPIER_PATH + ("copy", "-r1", str(src), str(dst)), timeout=spawn_timeout
+        )
         tui.expect_exact("b (bool)")
         tui.expect_exact("(y/N)")
         tui.send("y")
@@ -929,7 +934,9 @@ def test_update_inline_changed_answers_and_questions(
         git("commit", "-am2")
         # Update from template, inline, with answer changes
         if interactive:
-            tui = spawn(COPIER_PATH + ("update", "--conflict=inline"), timeout=10)
+            tui = spawn(
+                COPIER_PATH + ("update", "--conflict=inline"), timeout=spawn_timeout
+            )
             tui.expect_exact("b (bool)")
             tui.expect_exact("(Y/n)")
             tui.sendline()

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -861,7 +861,6 @@ def test_update_inline_changed_answers_and_questions(
     tmp_path_factory: pytest.TempPathFactory,
     interactive: bool,
     spawn: Spawn,
-    spawn_timeout: int | None,
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     with local.cwd(src):
@@ -906,9 +905,7 @@ def test_update_inline_changed_answers_and_questions(
         git("tag", "2")
     # Init project
     if interactive:
-        tui = spawn(
-            COPIER_PATH + ("copy", "-r1", str(src), str(dst)), timeout=spawn_timeout
-        )
+        tui = spawn(COPIER_PATH + ("copy", "-r1", str(src), str(dst)))
         tui.expect_exact("b (bool)")
         tui.expect_exact("(y/N)")
         tui.send("y")
@@ -934,9 +931,7 @@ def test_update_inline_changed_answers_and_questions(
         git("commit", "-am2")
         # Update from template, inline, with answer changes
         if interactive:
-            tui = spawn(
-                COPIER_PATH + ("update", "--conflict=inline"), timeout=spawn_timeout
-            )
+            tui = spawn(COPIER_PATH + ("update", "--conflict=inline"))
             tui.expect_exact("b (bool)")
             tui.expect_exact("(Y/n)")
             tui.sendline()

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -858,9 +858,7 @@ def test_file_removed(tmp_path_factory: pytest.TempPathFactory) -> None:
 
 @pytest.mark.parametrize("interactive", [True, False])
 def test_update_inline_changed_answers_and_questions(
-    tmp_path_factory: pytest.TempPathFactory,
-    interactive: bool,
-    spawn: Spawn,
+    tmp_path_factory: pytest.TempPathFactory, interactive: bool, spawn: Spawn
 ) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     with local.cwd(src):


### PR DESCRIPTION
# Issue

When running the tests for the repo on `gitpod.io`, I kept on running into failed tests due to timeout of the spawn from `pexpect`:
```bash
=================================================================================== short test summary info ====================================================================================
SKIPPED [1] tests/test_prompt.py:609: TODO: fix this
SKIPPED [1] tests/test_settings.py:30: Windows-only test
XFAIL tests/test_updatediff.py::test_update_needs_more_context[True-1] - Not enough context lines to resolve the conflict.
XFAIL tests/test_updatediff.py::test_update_needs_more_context[True-2] - Not enough context lines to resolve the conflict.
XFAIL tests/test_updatediff.py::test_update_needs_more_context[False-1] - Not enough context lines to resolve the conflict.
XFAIL tests/test_updatediff.py::test_update_needs_more_context[False-2] - Not enough context lines to resolve the conflict.
FAILED tests/test_output.py::test_messages_with_inline_text[True] - pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x7efffa74bc40>
FAILED tests/test_output.py::test_messages_with_included_text[True] - pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x7efffa7542e0>
FAILED tests/test_conditional_file_name.py::test_answer_changes[True] - pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x7f0a2420a640>
FAILED tests/test_prompt.py::test_update_multiselect_choices[float] - pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x7ff88dd7db50>
FAILED tests/test_prompt.py::test_update_multiselect_choices[str] - pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x7fd3b0ab83d0>
========================================================= 5 failed, 961 passed, 2 skipped, 4 xfailed, 2 warnings in 288.16s (0:04:48) ==========================================================
```
The cause is the hardcoded `timeout=10` and `timeout=30` when calling the `spawn` fixture, resulting in the same timeouts when the underlying `pexpect.popen_spawn` is called. And it seems more time is needed in the `gitpod.io` dev environment than in the github CI tests.

---

# This PR

## Description

Thus, to modify all of the timeout values easily at `pytest` launch, this PR soft-code these timeout values through a fixture `spawn_timeout` set by a newly defined `pytest` argument `--spawn-timeout` (whose `type` is `int| None` using a small `lambda` function checker type). This PR also documents the usage of this argument when facing the previously described issue above when trying to contribute.

`spawn_timeout` can be `None` or `-1` to follow the values of `timeout` in  `pexpect.popen_spawn` .

The default values for the timeouts are the same as the hard-coded ones. A choice have been made regarding the timeouts of `30` as the `spawn_timeout` default value is `10` to fit the majority of the values: the value for `30` is soft-coded as `spawn_timeout*3` (instead of an alternative `spawn_timeout+20`) when `spawn_timeout` is a positive `int` (to preserve the `-1`- and `None`-value use-cases).

Passing the `--spawn-timeout` pytest argument in the CLI or in the VSCode Workspace settings is described in the docs addition, along with the options it brings of either extending the timeout or removing it (when `None`).

Additional `from __future__ import annotations` have been added when needed to accommodate the type `int | None` of the `spawn_timeout` fixture, given that `.python-version` is `3.9`.

## Usage [As described in the doc]

If you get fails due to `pexpect.exceptions.TIMEOUT: <pexpect.popen_spawn.PopenSpawn object at 0x............>`, you can adjust the timeout to a longer one (default: `10`), or remove the timeout (`None`).
Either add it as an argument in your command:
```shell
uv run poe test --spawn-timeout None
```
Or modify pytest arguments in VSCode Workspace settings:
`.vscode/settings.json`
```json title=".vscode/settings.json"
{
  ...
  "python.testing.pytestArgs": [
    "--spawn-timeout=None"
  ]
}
```