### PR TITLE
test(test_config.py): add tests for circular transclusion failure case

### DIFF
--- a/tests/demo_transclude_circular/copier_files/include_me.yml
+++ b/tests/demo_transclude_circular/copier_files/include_me.yml
@@ -1,0 +1,6 @@
+---
+!include ../copier_files/include_me_also.yml
+---
+
+_exclude:
+  - "exclude1"

--- a/tests/demo_transclude_circular/copier_files/include_me_also.yml
+++ b/tests/demo_transclude_circular/copier_files/include_me_also.yml
@@ -1,0 +1,6 @@
+---
+!include ../copier_files/include_me.yml
+---
+
+_exclude:
+  - "exclude2"

--- a/tests/demo_transclude_circular/demo/copier.yml
+++ b/tests/demo_transclude_circular/demo/copier.yml
@@ -1,0 +1,7 @@
+---
+!include ../copier_files/include_me.yml
+---
+
+project_name:
+  type: str
+  help: What is the project name

--- a/tests/demo_transclude_circular_bis/copier_files/include_me.yml
+++ b/tests/demo_transclude_circular_bis/copier_files/include_me.yml
@@ -1,0 +1,1 @@
+!include ../copier_files/include_me_also.yml

--- a/tests/demo_transclude_circular_bis/copier_files/include_me_also.yml
+++ b/tests/demo_transclude_circular_bis/copier_files/include_me_also.yml
@@ -1,0 +1,2 @@
+!include ../copier_files/include_me.yml
+

--- a/tests/demo_transclude_circular_bis/demo/copier.yml
+++ b/tests/demo_transclude_circular_bis/demo/copier.yml
@@ -1,0 +1,7 @@
+---
+!include ../copier_files/include_me.yml
+---
+
+_exclude:
+  - "exclude1"
+  - "exclude2"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -383,6 +383,22 @@ def test_config_data_transclusion() -> None:
     assert config.all_exclusions == ("exclude1", "exclude2")
 
 
+@pytest.mark.skip(
+    "TODO: Catch circular transclusions instead of causing a `RecursionError` and provide a comprehensive error with files that collide"
+)
+@pytest.mark.parametrize(
+    "demo_path",
+    ["tests/demo_transclude_circular/demo", "tests/demo_transclude_circular_bis/demo"],
+)
+def test_config_circular_transclusions(demo_path: str) -> None:
+    config = Worker(demo_path)
+    with pytest.raises(RecursionError):
+        assert config.all_exclusions == ("exclude1", "exclude2")
+    raise ValueError(
+        "Error should be custom, and caught before exceeding recursion limit."
+    )
+
+
 @pytest.mark.parametrize(
     "user_defaults, data, expected",
     [


### PR DESCRIPTION
# Issue

Circular transclusions lead to:
```bash
E           RecursionError: maximum recursion depth exceeded while calling a Python object

/home/gitpod/.local/share/uv/python/cpython-3.9.23-linux-x86_64-gnu/lib/python3.9/pathlib.py:646: RecursionError
```
It might be nice to catch it as soon as it happens, and provide a more comprehensive error message including the names of the files that collide.

---

# This PR

This PR introduces tests for circular transclusions that shows that these are not really dealt with in a user-friendly manner in addition to taking some unnecessary time.
The tests are currently skipped to not interfere with normal condition testing, and commented with a TODO line similar to the last one in the previous section **Issue**.

> NOTE: The test with `demo_transclude_circular_bis` will fail because of the circular recursion.
> The test with `demo_transclude_circular` will:
> - currently fail with a `yaml.composer.ComposerError: expected a single document in the stream`
> - if `https://github.com/copier-org/copier/pull/2251` is accepted, also fail because of the circular recursion.
>   But it might be a better test as it needs to go to the deepest transclusion to get the `_excludes`.

