### PR TITLE
fix(updating): disable secret question validator when replaying old copy

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1154,6 +1154,13 @@ class Worker:
                 src_path=self.subproject.template.url,  # type: ignore[union-attr]
                 vcs_ref=self.subproject.template.commit,  # type: ignore[union-attr]
             ) as old_worker:
+                # HACK: Remove the validator from a secret question when replaying
+                # a fresh copy using the old template because only the default value
+                # is available which may not pass validation.
+                assert old_worker.template is not self.template
+                for q in old_worker.template.questions_data.values():
+                    if q.get("secret", False):
+                        q.pop("validator", None)
                 old_worker.run_copy()
             # Run pre-migration tasks
             with Phase.use(Phase.MIGRATE):

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1982,3 +1982,44 @@ def test_conditional_computed_value(tmp_path_factory: pytest.TempPathFactory) ->
     assert answers["first"] is True
     assert answers["second"] is True
     assert (dst / "log.txt").read_text() == "True True"
+
+
+def test_disable_secret_validator_on_replay(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    build_file_tree(
+        {
+            src / "copier.yml": (
+                """\
+                token:
+                    type: str
+                    secret: true
+                    default: ""
+                    validator: "{% if token == '' %}Must not be empty{% endif %}"
+                """
+            ),
+            src / "{{ _copier_conf.answers_file }}.jinja": (
+                "{{ _copier_answers|to_nice_yaml }}"
+            ),
+            src / ".gitignore": ".env",
+            src / ".env.jinja": "TOKEN={{ token }}",
+        }
+    )
+    with local.cwd(src):
+        git_init("v1")
+        git("tag", "v1")
+
+    run_copy(str(src), dst, data={"token": "$3cr3t"})
+    answers = load_answersfile_data(dst)
+    assert answers == {"_src_path": str(src), "_commit": "v1"}
+    assert (dst / ".env").read_text() == "TOKEN=$3cr3t"
+
+    with local.cwd(dst):
+        git_init("v1")
+
+    run_update(dst, data={"token": "$up3r-$3cr3t"}, overwrite=True)
+    answers = load_answersfile_data(dst)
+    assert answers == {"_src_path": str(src), "_commit": "v1"}
+    assert (dst / ".env").read_text() == "TOKEN=$up3r-$3cr3t"


### PR DESCRIPTION
I've fixed a bug introduced by #2145 which breaks `copier update` when the questionnaire (of the old template version to be precise) contains a secret question with a validator and a default value that does _not_ pass validation.

Since #2145, default values have been validated which makes sense in general. But with the current implementation of Copier's update algorithm, which replays a fresh copy using the old template version and the recorded answers, the answer to a secret question is not available because it isn't recorded in the answers file. Therefore, a default answer has been required which, prior to #2145, hadn't been validated, so `copier update` was working fine in this regard.

I think there are two solutions to this problem:

1. [Enhance the update algorithm](https://github.com/copier-org/copier/issues/1170) to avoid the need for replaying a fresh copy of the old template version. But we haven't found a perfect solution yet. /cc @yajo :smile:
1. Disable the validator of a secret question when replaying a fresh copy of the old template version. This is a hack – I'm not overly proud –, but it solves the problem until we have a better solution. That's what I've done in this PR.

In case you're available for a second opinion, @pawamoy: WDYT?

Fixes #2253.