### PR TITLE
ci: override Python version from `.python-version` with matrix version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
         uses: astral-sh/setup-uv@v6
         with:
           version: ${{ env.UV_VERSION }}
+          python-version: ${{ matrix.python-version }}
           enable-cache: "true"
           cache-suffix: ${{ matrix.python-version }}
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
I just stumbled over a CI bug that has prevented testing against Python versions other than 3.9 for the past ~1 month. :see_no_evil: Since adding `.python-version` to declare the Python version to use for development of Copier, our matrix tests have been ineffective, as uv downloads the Python version specified in this file instead of using the Python interpreter found on the search path. For example, the `build (ubuntu-latest, 3.13)` job's log contains the following snippet:

```
Run uv sync --frozen
Downloading cpython-3.9.23-linux-x86_64-gnu (download) (28.3MiB)
Downloading cpython-3.9.23-linux-x86_64-gnu (download)
Using CPython 3.9.23
```

To fix this, I've added

```yaml
with:
  python-version: ${{ matrix.python-version }}
```

to the `astral-sh/setup-uv` action config according to [uv's documentation on matrix testing](https://docs.astral.sh/uv/guides/integration/github/#multiple-python-versions).