### PR TITLE
fix: validate default answer only after user input

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -607,6 +607,12 @@ class Worker:
                 raise CopierAnswersInterrupt(
                     self.answers, question, self.template
                 ) from err
+            # Computed values (i.e., `when: false`) are intentionally not
+            # validated at the moment.
+            # https://github.com/copier-org/copier/issues/1779#issuecomment-2365006990
+            # https://github.com/copier-org/copier/pull/1785
+            if question.get_when():
+                question.validate_answer(new_answer)
             self.answers.user[var_name] = new_answer
 
         # Reload external data, which may depend on answers

--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -276,14 +276,7 @@ class Question:
                     result = self.render_value(
                         self.settings.defaults.get(self.var_name, self.default)
                     )
-        result = self.parse_answer(result)
-        # Computed values (i.e., `when: false`) are intentionally not validated
-        # at the moment.
-        # https://github.com/copier-org/copier/issues/1779#issuecomment-2365006990
-        # https://github.com/copier-org/copier/pull/1785
-        if self.get_when():
-            self.validate_answer(result)
-        return result
+        return self.parse_answer(result)
 
     def get_default_rendered(self) -> bool | str | Choice | None | MissingType:
         """Get default answer rendered for the questionary lib.


### PR DESCRIPTION
Follow up to #2145. Copier versions before 9.8.0 used to allow invalid defaults as long as the user would modify them to make them valid before continuing. This PR restores that old behavior while still ensuring that `validator` checks are still run on default when `--defaults` is used. 

The rational for using a `default` instead of a `placeholder` in this case is to provide partial input to the answer to reduce the amount of typing required during interactive use.