### PR TITLE
feat: add support for conditionally unsetting a question's default value

### DIFF
--- a/copier/_jinja_ext.py
+++ b/copier/_jinja_ext.py
@@ -122,3 +122,6 @@ class YieldExtension(Extension):
             res = ""
 
         return res
+
+
+class UnsetError(UndefinedError): ...

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -573,7 +573,7 @@ class Worker:
                     del self.answers.last[var_name]
                 # Skip immediately to the next question when it has no default
                 # value.
-                if question.default is MISSING:
+                if question.get_default() is MISSING:
                     continue
             if var_name in self.answers.init:
                 # Try to parse and validate (if the question has a validator)

--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from typing import Any, Callable, Literal
 
 import yaml
-from jinja2 import UndefinedError
+from jinja2 import StrictUndefined, UndefinedError
 from jinja2.sandbox import SandboxedEnvironment
 from prompt_toolkit.lexers import PygmentsLexer
 from pydantic import ConfigDict, Field, field_validator
@@ -25,6 +25,7 @@ from pydantic_core.core_schema import ValidationInfo
 from pygments.lexers.data import JsonLexer, YamlLexer
 from questionary.prompts.common import Choice
 
+from copier._jinja_ext import UnsetError
 from copier.settings import Settings
 
 from ._tools import cast_to_bool, cast_to_str, force_str_end
@@ -273,9 +274,15 @@ class Question:
                 except KeyError:
                     if self.default is MISSING:
                         return MISSING
-                    result = self.render_value(
-                        self.settings.defaults.get(self.var_name, self.default)
-                    )
+                    try:
+                        result = self.render_value(
+                            self.settings.defaults.get(self.var_name, self.default),
+                            extra_answers={
+                                "UNSET": StrictUndefined("UNSET", exc=UnsetError)
+                            },
+                        )
+                    except UnsetError:
+                        return MISSING
         result = self.parse_answer(result)
         # Computed values (i.e., `when: false`) are intentionally not validated
         # at the moment.
@@ -482,6 +489,8 @@ class Question:
             )
         try:
             return template.render({**self.context, **(extra_answers or {})})
+        except UnsetError:
+            raise
         except UndefinedError as error:
             raise UserMessageError(str(error)) from error
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -267,6 +267,38 @@ Supported keys:
             when: "{{ project_license != 'Public domain' }}"
         ```
 
+    If the default value of a skipped question is not meaningful, then it can be unset
+    by rendering the special `UNSET` variable, so the question's variable is undefined
+    in the render context:
+
+    !!! example
+
+        ```yaml title="copier.yml"
+        database_engine:
+            type: str
+            help: Database engine
+            choices:
+                - postgres
+                - mysql
+                - none
+            default: postgres
+
+        database_url:
+            type: str
+            help: Database URL
+            default: >-
+                {%- if database_engine == 'postgres' -%}
+                postgresql://user:pass@localhost:5432/dbname
+                {%- elif database_engine == 'mysql' -%}
+                mysql://user:pass@localhost:3306/dbname
+                {%- else -%}
+                {{ UNSET }}
+                {%- endif -%}
+            when: "{{ database_engine != 'none' }}"
+            # Simplified for illustration purposes
+            validator: "{% if '://' not in database_url %}Invalid{% endif %}"
+        ```
+
 !!! example
 
     ```yaml title="copier.yml"


### PR DESCRIPTION
Currently, if a question is skipped, its answer is not recorded, but its default value is available in the render context. This makes sense for computed values and conditionally skipped questions with meaningful default values, but there are use cases where a question should be skipped and its Jinja variable should be undefined (i.e., not present in the render context) because there is no meaningful default value. For example:

```yaml
database_engine:
  type: str
  help: Database engine
  choices:
    - postgres
    - mysql
    - none
  default: postgres

database_url:
  type: str
  help: Database URL
  default: >-
    {%- if database_engine == 'postgres' -%}
    postgresql://user:pass@localhost:5432/dbname
    {%- elif database_engine == 'mysql' -%}
    mysql://user:pass@localhost:3306/dbname
    {%- endif -%}
  when: "{{ database_engine != 'none' }}"
  # Simplified for illustration purposes
  validator: "{% if '://' not in database_url %}Invalid{% endif %}"
```

Here, the default value of the `database_url` question is only defined for the database engines "postgres" and "mysql" but not for "none", and we can't render, e.g., an empty string as the default value for "none" because the validator would fail. We could surround the actual validator condition with `{% if database_engine != 'none' %}...{% endif %}`, but that feels hacky and redundant with the `when` expression. What we'd actually want is to fully skip this question – I'd say by declaring the default value as _unset_. An unset default value of a skipped question means that there is no answer, so the validator isn't applied. Copier already behaves this way when the `default` field is not present.

To support this scenario, I've added a special Jinja variable `UNSET` which is available in the render context of the `default` field. When this value is rendered, Copier behaves as if the `default` field isn't present. The example from above would look like this now:

```diff
 database_engine:
   type: str
   help: Database engine
   choices:
     - postgres
     - mysql
     - none
   default: postgres

 database_url:
   type: str
   help: Database URL
   default: >-
     {%- if database_engine == 'postgres' -%}
     postgresql://user:pass@localhost:5432/dbname
     {%- elif database_engine == 'mysql' -%}
     mysql://user:pass@localhost:3306/dbname
+    {%- else -%}
+    {{ UNSET }}
     {%- endif -%}
   when: "{{ database_engine != 'none' }}"
   # Simplified for illustration purposes
   validator: "{% if '://' not in database_url %}Invalid{% endif %}"
```

Related to https://github.com/copier-org/copier/pull/2278#issuecomment-3215344381.

WDYT, @copier-org/maintainers?