### PR TITLE
fix: disable default answer validator for secret questions

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1163,13 +1163,6 @@ class Worker:
                 src_path=self.subproject.template.url,  # type: ignore[union-attr]
                 vcs_ref=self.subproject.template.commit,  # type: ignore[union-attr]
             ) as old_worker:
-                # HACK: Remove the validator from a secret question when replaying
-                # a fresh copy using the old template because only the default value
-                # is available which may not pass validation.
-                assert old_worker.template is not self.template
-                for q in old_worker.template.questions_data.values():
-                    if q.get("secret", False):
-                        q.pop("validator", None)
                 old_worker.run_copy()
             # Run pre-migration tasks
             with Phase.use(Phase.MIGRATE):

--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -281,7 +281,7 @@ class Question:
         # at the moment.
         # https://github.com/copier-org/copier/issues/1779#issuecomment-2365006990
         # https://github.com/copier-org/copier/pull/1785
-        if self.get_when():
+        if self.get_when() and not self.secret:
             self.validate_answer(result)
         return result
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -506,10 +506,13 @@ def test_value_with_forward_slash(tmp_path_factory: pytest.TempPathFactory) -> N
             {
                 "type": "str",
                 "secret": True,
+                "default": "",
                 "validator": "[% if q|length < 3 %]too short[% endif %]",
             },
             "",
-            pytest.raises(ValueError),
+            pytest.raises(
+                ValueError, match=r"^Validation error for question '\w+': too short$"
+            ),
         ),
         ({"type": "bool"}, "true", does_not_raise()),
         ({"type": "bool"}, "false", does_not_raise()),
@@ -936,7 +939,7 @@ def test_required_choice_question_without_data(
             },
             pytest.raises(ValueError),
         ),
-        (
+        pytest.param(
             {
                 "type": "str",
                 "default": "",
@@ -944,6 +947,9 @@ def test_required_choice_question_without_data(
                 "validator": "[% if q|length < 3 %]too short[% endif %]",
             },
             pytest.raises(ValueError),
+            marks=pytest.mark.xfail(
+                reason="Default values of secrets are currently not validated"
+            ),
         ),
         ({"type": "int", "default": 1}, does_not_raise()),
         ({"type": "int", "default": 1.0}, does_not_raise()),

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1050,11 +1050,11 @@ def test_multiselect_choices_validator(
     assert answers["question"] == ["one"]
 
 
+@pytest.mark.parametrize("default", ["s3cret", ""])
 def test_secret_validator(
-    question_tree: QuestionTreeFixture, copier: CopierFixture
+    question_tree: QuestionTreeFixture, copier: CopierFixture, default: str
 ) -> None:
     """Secret question answer is validated."""
-    default = "s3cret"
     src, dst = question_tree(
         type="str",
         default=default,
@@ -1069,8 +1069,8 @@ def test_secret_validator(
         tui.send(Keyboard.Backspace)
     tui.sendline()
     tui.expect_exact("too short")
-    # Enter default value again to pass validation
-    tui.sendline(default)
+    # Enter the valid answer again to pass validation
+    tui.sendline("s3cret")
     tui.expect_exact("******")
     tui.expect_exact(pexpect.EOF)
 

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -2011,10 +2011,10 @@ def test_disable_secret_validator_on_replay(
         git_init("v1")
         git("tag", "v1")
 
-    run_copy(str(src), dst, data={"token": "$3cr3t"})
+    run_copy(str(src), dst, defaults=True)
     answers = load_answersfile_data(dst)
     assert answers == {"_src_path": str(src), "_commit": "v1"}
-    assert (dst / ".env").read_text() == "TOKEN=$3cr3t"
+    assert (dst / ".env").read_text() == "TOKEN="
 
     with local.cwd(dst):
         git_init("v1")


### PR DESCRIPTION
I've fixed a bug introduced by #2145 (and not fully fixed by #2254) which breaks secret questions. Since #2145, default answers have been validated when a `validator` expression is provided, but secret questions are special. Copier's current update algorithm replays a fresh project based on an old template version, and secret answers aren't recorded, so a default answer is required for the replay. At the same time, it typically makes little sense to have a real default answer for a secret question because it wouldn't be very secret. So, the default answer is typically an empty string for secret `type: str` questions. If a template author would like to validate a secret question's answer, the default value would need to pass validation as of #2145. This is typically not desired behavior.

For this reason, I've decided to disable validation of default answers to secret questions, which restores pre-#2145 behavior for secret questions. This solution is not ideal, but I don't want to break existing templates because of a current deficiency in Copier's interplay between the update algorithm, default answer validation, and secret questions.

For future reference, these are my thoughts about a better solution:

Secret questions should not require a default answer. In fact, most – if not all – secret questions have no natural default answer because it wouldn't be secret then. To support secret questions without default answers, I see two options:
- [Change Copier's update algorithm to not require replay](https://github.com/copier-org/copier/issues/1170#issuecomment-2917409441). The exact implementation is still under discussion though.
- Introduce a new field `fallback` in the question spec of a secret question which provides the fallback answer during an update. This solution still leaks the replay step of the update algorithm but decouples the default answer (and associated validation) from the need for a fallback answer during an update.

Fixes #2253 #2293.
Follow-up of #2254.