### PR TITLE
Include Homebrew installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ nix profile install 'https://flakehub.com/f/copier-org/copier/*.tar.gz'
 
 ### Homebrew formula
 
-To install the latest Copier release using [its Homebrew formula](https://formulae.brew.sh/formula/copier)
-for macOS or Linux:
+To install the latest Copier release using
+[its Homebrew formula](https://formulae.brew.sh/formula/copier) for macOS or Linux:
 
 ```shell
 brew install copier


### PR DESCRIPTION
Copier was added in [October 2021][1].

[1]: https://github.com/Homebrew/homebrew-core/commit/395882c1627a43d23a961b5cd1a7c07b3ac61275