### PR TITLE
fix(updating): ignore paths added to the `_exclude` list in new template version when updating

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1162,6 +1162,10 @@ class Worker:
                 quiet=True,
                 src_path=self.subproject.template.url,  # type: ignore[union-attr]
                 vcs_ref=self.subproject.template.commit,  # type: ignore[union-attr]
+                # Exclude also paths listed in the new template version, so they
+                # won't be included in the diff as deleted paths to prevent deletion.
+                # https://github.com/orgs/copier-org/discussions/2345
+                exclude=[*self.template.exclude, *self.exclude],
             ) as old_worker:
                 old_worker.run_copy()
             # Run pre-migration tasks


### PR DESCRIPTION
I've fixed a bug in the update algorithm that deletes paths added to the `_exclude` list in a new template version although these paths should be ignored.

Copier's update algorithm relies on generating fresh copies based on old and new template versions. When generating a fresh copy based on the old template version, the template doesn't contain the `_exclude` path yet, so it's rendered in the fresh copy. When generating copies based on the new template version, the `_exclude` path is added and thus the path is ignored. To fix this problem, the `_exclude` list of the new template version is now passed to the `run_copy` call for generating the fresh copy based on the old template version, so the path exists in neither of the fresh copies and doesn't contribute to the list of files to be deleted or the patch applied to the existing project.

Fixes #2345.

/cc @savtrip