### PR TITLE
fix(updating): exclude only Git-ignored files when applying patch

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1298,6 +1298,7 @@ class Worker:
                 extra_exclude = [
                     filename.split("!! ").pop()
                     for filename in ignored_files.splitlines()
+                    if filename.startswith("!! ")
                 ]
                 for skip_pattern in chain(
                     self.skip_if_exists, self.template.skip_if_exists, extra_exclude


### PR DESCRIPTION
I've fixed a minor error in the update algorithm related to [excluding _only_ Git-ignored](https://github.com/copier-org/copier/blob/42d4ff574fe0713fa76be15a68fb9af32b6f229f/copier/_main.py#L1298-L1301) files when [applying the computed patch](https://github.com/copier-org/copier/blob/42d4ff574fe0713fa76be15a68fb9af32b6f229f/copier/_main.py#L1306) to the destination project. Kudos to @lkubb for [discovering this error in a different discussion](https://github.com/orgs/copier-org/discussions/2345#discussioncomment-14639768).

When inspecting [`extra_exclude`](https://github.com/copier-org/copier/blob/42d4ff574fe0713fa76be15a68fb9af32b6f229f/copier/_main.py#L1298-L1301) during an update, the list includes filenames like ` M .copier-answers.yml` and other names of files modified by

https://github.com/copier-org/copier/blob/42d4ff574fe0713fa76be15a68fb9af32b6f229f/copier/_main.py#L1216-L1227

prefixed with ` M` due to the output format of [`git status --ignored --porcelain`](https://github.com/copier-org/copier/blob/42d4ff574fe0713fa76be15a68fb9af32b6f229f/copier/_main.py#L1295).

TBH, I haven't been able to come up with a test case where this incorrect behavior causes a problem, but it's clearly incorrect. In addition, this error is highly specific to the current implementation of the update algorithm. For these two reasons, I've decided to fix the error without a test case :face_with_peeking_eye: – I hope that's fine for everybody.