### PR TITLE
build: add support for Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           # HACK: Limit the number of pytest workers on macOS to 3 to avoid a
           #   timeout for a few test cases. For unknown reasons, the number of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
 ]
 authors = [{ name = "Ben Felder", email = "ben@felder.io" }]
 readme = "README.md"


### PR DESCRIPTION
I've added official support for [Python 3.14](https://docs.python.org/3.14/whatsnew/3.14.html).