### PR TITLE
feat: Add postrender tasks phase

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -246,6 +246,7 @@ class Worker:
 
     answers: AnswersMap = field(default_factory=AnswersMap, init=False)
     _cleanup_hooks: list[Callable[[], None]] = field(default_factory=list, init=False)
+    _update_stage: str = field(default="current", init=False)
 
     def __enter__(self) -> Worker:
         """Allow using worker as a context manager."""
@@ -363,6 +364,7 @@ class Worker:
         for i, task in enumerate(tasks):
             extra_context = {f"_{k}": v for k, v in task.extra_vars.items()}
             extra_context["_copier_operation"] = operation
+            extra_context["_update_stage"] = self._update_stage
 
             if not cast_to_bool(self._render_value(task.condition, extra_context)):
                 continue
@@ -1062,6 +1064,8 @@ class Worker:
                 # TODO Unify printing tools
                 print("")  # padding space
             if not self.skip_tasks:
+                with Phase.use(Phase.POSTRENDER):
+                    self._execute_tasks(self.template.postrender_tasks)
                 with Phase.use(Phase.TASKS):
                     self._execute_tasks(self.template.tasks)
         except Exception:
@@ -1179,6 +1183,7 @@ class Worker:
                 # https://github.com/orgs/copier-org/discussions/2345
                 exclude=[*self.template.exclude, *self.exclude],
             ) as old_worker:
+                old_worker._update_stage = "previous"
                 old_worker.run_copy()
             # Run pre-migration tasks
             with Phase.use(Phase.MIGRATE):
@@ -1236,6 +1241,7 @@ class Worker:
                 # TODO
                 quiet=True,
             ) as current_worker:
+                current_worker._update_stage = "current"
                 current_worker.run_copy()
                 self.answers = current_worker.answers
                 self.answers.external = self._external_data()
@@ -1254,6 +1260,7 @@ class Worker:
                 exclude=exclude_plus_removed,
                 vcs_ref=self.resolved_vcs_ref,
             ) as new_worker:
+                new_worker._update_stage = "new"
                 new_worker.run_copy()
             with local.cwd(new_copy):
                 self._git_initialize_repo()

--- a/copier/_template.py
+++ b/copier/_template.py
@@ -535,6 +535,32 @@ class Template:
         return tasks
 
     @cached_property
+    def postrender_tasks(self) -> Sequence[Task]:
+        """Get postrender tasks defined in the template.
+
+        These run after template rendering is complete but before regular
+        tasks execute. During updates, they run on both old_copy and new_copy
+        to ensure consistent transformations before diff calculation.
+
+        See [postrender_tasks][].
+        """
+        extra_vars = {"stage": "postrender"}
+        tasks = []
+        for task in self.config_data.get("postrender_tasks", []):
+            if isinstance(task, dict):
+                tasks.append(
+                    Task(
+                        cmd=task["command"],
+                        extra_vars=extra_vars,
+                        condition=task.get("when", "true"),
+                        working_directory=Path(task.get("working_directory", ".")),
+                    )
+                )
+            else:
+                tasks.append(Task(cmd=task, extra_vars=extra_vars))
+        return tasks
+
+    @cached_property
     def templates_suffix(self) -> str:
         """Get the suffix defined for templates.
 

--- a/copier/_types.py
+++ b/copier/_types.py
@@ -108,9 +108,10 @@ class Phase(str, Enum):
     """The known execution phases."""
 
     PROMPT = "prompt"
+    RENDER = "render"
+    POSTRENDER = "postrender"
     TASKS = "tasks"
     MIGRATE = "migrate"
-    RENDER = "render"
     UNDEFINED = "undefined"
 
     def __str__(self) -> str:

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -151,7 +151,8 @@ The name of the project root directory.
 
 ### `_copier_phase`
 
-The current phase, one of `"prompt"`,`"tasks"`, `"migrate"` or `"render"`.
+The current phase, one of `"prompt"`, `"render"`, `"postrender"`, `"tasks"`, or
+`"migrate"`.
 
 !!! note
 
@@ -167,7 +168,33 @@ Some variables are only available in select contexts:
 
 The current operation, either `"copy"` or `"update"`.
 
-Availability: [`exclude`](configuring.md#exclude), [`tasks`](configuring.md#tasks)
+Availability: [`exclude`](configuring.md#exclude),
+[`postrender_tasks`](configuring.md#postrender_tasks), [`tasks`](configuring.md#tasks)
+
+### `_update_stage`
+
+The current update stage, indicating which rendering context is active.
+
+**Values:**
+
+-   `"current"` - Rendering to the actual destination (always during copy operations)
+-   `"previous"` - Rendering the old template version to temporary directory (update
+    only)
+-   `"new"` - Rendering the new template version to temporary directory (update only)
+
+Available as `UPDATE_STAGE` environment variable.
+
+Availability: [`postrender_tasks`](configuring.md#postrender_tasks),
+[`tasks`](configuring.md#tasks)
+
+!!! example
+
+    ```yaml title="copier.yml"
+    _postrender_tasks:
+        # Run expensive operation only on actual destination
+        - command: "python refactor.py"
+          when: "{{ _update_stage == 'current' }}"
+    ```
 
 ## Variables (context-specific)
 

--- a/tests/test_postrender.py
+++ b/tests/test_postrender.py
@@ -1,0 +1,353 @@
+"""Tests for postrender tasks."""
+
+import platform
+from pathlib import Path
+
+import pytest
+
+import copier
+
+from .helpers import build_file_tree, git_save
+
+
+@pytest.fixture
+def template_with_postrender(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Create a template with postrender tasks."""
+    template_path = tmp_path_factory.mktemp("template")
+    build_file_tree(
+        {
+            template_path / "copier.yml": """\
+                package:
+                  type: str
+                  default: boilerplate
+
+                _postrender_tasks:
+                  - "echo 'Postrender task executed' > postrender.log"
+                  - command: "echo '{{ package }}' > package.txt"
+                """,
+            template_path / "README.md.jinja": "# Project {{ package }}",
+            template_path / "src" / "main.txt.jinja": "package: {{ package }}",
+        }
+    )
+    return template_path
+
+
+def test_postrender_tasks_execute_on_copy(
+    template_with_postrender: Path, tmp_path: Path
+) -> None:
+    """Test that postrender tasks execute during initial copy."""
+    copier.run_copy(
+        str(template_with_postrender),
+        tmp_path,
+        data={"package": "myproject"},
+        defaults=True,
+        unsafe=True,
+    )
+
+    # Verify postrender tasks executed
+    assert (tmp_path / "postrender.log").exists()
+    log_content = (tmp_path / "postrender.log").read_text().strip()
+    assert "Postrender task executed" in log_content
+
+    # Verify templated postrender task
+    assert (tmp_path / "package.txt").exists()
+    assert (tmp_path / "package.txt").read_text().strip() == "myproject"
+
+    # Verify regular template rendering also worked
+    assert (tmp_path / "README.md").read_text() == "# Project myproject"
+
+
+def test_postrender_tasks_execute_before_regular_tasks(
+    tmp_path_factory: pytest.TempPathFactory, tmp_path: Path
+) -> None:
+    """Test that postrender tasks execute before regular tasks."""
+    template_path = tmp_path_factory.mktemp("template")
+    build_file_tree(
+        {
+            template_path / "copier.yml": """\
+                _postrender_tasks:
+                  - "echo 'postrender' >> execution_order.log"
+
+                _tasks:
+                  - "echo 'task' >> execution_order.log"
+                """,
+            template_path / "README.md": "# Test",
+        }
+    )
+    copier.run_copy(str(template_path), tmp_path, unsafe=True)
+
+    # Verify execution order
+    log = (tmp_path / "execution_order.log").read_text()
+    assert log == "postrender\ntask\n"
+
+
+def test_postrender_task_features(
+    tmp_path_factory: pytest.TempPathFactory, tmp_path: Path
+) -> None:
+    """Test postrender task features: working_directory, when clause, and _copier_phase."""
+    template_path = tmp_path_factory.mktemp("template")
+    build_file_tree(
+        {
+            template_path / "copier.yml": """\
+enable_feature:
+  type: bool
+  default: false
+
+_postrender_tasks:
+  # Test working_directory
+  - command: "pwd > cwd.txt"
+  - command: "pwd > subdir_cwd.txt"
+    working_directory: ./subdir
+  # Test when clause
+  - command: "echo 'feature enabled' > feature.txt"
+    when: "{{ enable_feature }}"
+  # Test _copier_phase variable
+  - command: "echo '{{ _copier_phase }}' > phase.txt"
+""",
+            template_path / "README.md": "# Test",
+            template_path / "subdir" / ".gitkeep": "",
+        }
+    )
+
+    # Test with feature disabled
+    copier.run_copy(
+        str(template_path),
+        tmp_path,
+        data={"enable_feature": False},
+        unsafe=True,
+    )
+
+    # Verify working_directory
+    assert (tmp_path / "cwd.txt").exists()
+    assert (tmp_path / "subdir" / "subdir_cwd.txt").exists()
+
+    # Verify when clause - feature should be disabled
+    assert not (tmp_path / "feature.txt").exists()
+
+    # Verify _copier_phase
+    assert (tmp_path / "phase.txt").read_text().strip() == "postrender"
+
+    # Test with feature enabled
+    copier.run_copy(
+        str(template_path),
+        tmp_path,
+        data={"enable_feature": True},
+        unsafe=True,
+        overwrite=True,
+    )
+
+    # Verify when clause - feature should now be enabled
+    assert (tmp_path / "feature.txt").exists()
+    assert (tmp_path / "feature.txt").read_text().strip() == "feature enabled"
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Uses Unix shell syntax",
+)
+def test_postrender_on_update_with_git(
+    tmp_path_factory: pytest.TempPathFactory, tmp_path: Path
+) -> None:
+    """Test postrender directory renaming with mixed file types and updates.
+
+    This test verifies:
+    - Directory renaming via postrender (src/example/ -> src/{{ package }}/)
+    - Mix of templated (.jinja) and non-templated files
+    - New files added in template v2 end up in renamed directory
+    - User files in renamed directory are preserved during update
+    - Template changes are merged with user changes
+    """
+    template_path = tmp_path_factory.mktemp("template")
+
+    # INITIAL TEMPLATE (v1)
+    build_file_tree(
+        {
+            template_path / "copier.yml": """\
+                _version: "1.0.0"
+
+                package:
+                  type: str
+                  default: boilerplate
+
+                _postrender_tasks:
+                  # Temp directories (old_copy, new_copy): simple rename
+                  - command: "[ -d src/example ] && mv src/example src/{{ package }} || true"
+                    when: "{{ _update_stage in ['previous', 'new'] }}"
+
+                  # Destination: handle both initial copy and updates
+                  - command: |
+                      if [ -d src/example ]; then
+                        if [ ! -d "src/{{ package }}" ]; then
+                          # Initial copy: simple rename
+                          mv src/example "src/{{ package }}"
+                        else
+                          # Update: merge new template files into existing directory
+                          mkdir -p "src/{{ package }}"
+                          cp -R src/example/* "src/{{ package }}/"
+                          rm -rf src/example
+                        fi
+                      fi
+                    when: "{{ _update_stage == 'current' }}"
+                """,
+            template_path / "README.md.jinja": "# {{ package }} Project",
+            template_path
+            / ".copier-answers.yml.jinja": "{{ _copier_answers|to_nice_yaml }}",
+            template_path / "src" / "example" / "plain.txt": "non-templated content",
+            template_path
+            / "src"
+            / "example"
+            / "file1.txt.jinja": "one {{ package }} one",
+            template_path
+            / "src"
+            / "example"
+            / "file2.txt.jinja": "two {{ package }} two",
+        }
+    )
+    git_save(template_path, "v1.0.0", tag="1.0.0")
+
+    # INITIAL COPY
+    copier.run_copy(
+        str(template_path),
+        tmp_path,
+        data={"package": "myproject"},
+        vcs_ref="1.0.0",
+        unsafe=True,
+    )
+    git_save(tmp_path, "Initial commit")
+
+    # Verify initial copy: directory should be renamed
+    assert not (tmp_path / "src" / "example").exists()
+    assert (tmp_path / "src" / "myproject").exists()
+
+    # Non-templated file should be copied as-is
+    plain_txt = tmp_path / "src" / "myproject" / "plain.txt"
+    assert plain_txt.exists()
+    assert plain_txt.read_text() == "non-templated content"
+
+    # Templated files should have rendered content
+    file1 = tmp_path / "src" / "myproject" / "file1.txt"
+    assert file1.exists()
+    assert file1.read_text() == "one myproject one"
+
+    file2 = tmp_path / "src" / "myproject" / "file2.txt"
+    assert file2.exists()
+    assert file2.read_text() == "two myproject two"
+
+    # USER MODIFICATIONS
+    build_file_tree(
+        {
+            tmp_path / "src" / "myproject" / "user.txt": "user custom content",
+        }
+    )
+    # User modifies an existing template file
+    file1.write_text("one myproject one\nuser added line")
+    git_save(tmp_path, "User modifications")
+
+    # UPDATE TEMPLATE (v2)
+    build_file_tree(
+        {
+            template_path
+            / "src"
+            / "example"
+            / "file3.txt.jinja": "three {{ package }} three",
+            template_path
+            / "src"
+            / "example"
+            / "file1.txt.jinja": "one {{ package }} one\ntemplate added line",
+            template_path / "README.md.jinja": "# {{ package }} Project v2",
+        }
+    )
+    git_save(template_path, "v2.0.0", tag="2.0.0")
+
+    # RUN UPDATE
+    copier.run_update(
+        dst_path=tmp_path,
+        vcs_ref="2.0.0",
+        defaults=True,
+        unsafe=True,
+        overwrite=True,
+    )
+
+    # VERIFY UPDATE RESULTS
+
+    # 1. Directory should still be renamed (not nested)
+    assert not (tmp_path / "src" / "example").exists()
+    assert (tmp_path / "src" / "myproject").exists()
+    assert not (tmp_path / "src" / "myproject" / "example").exists()
+
+    # 2. New template file should be in renamed directory
+    file3 = tmp_path / "src" / "myproject" / "file3.txt"
+    assert file3.exists()
+    assert file3.read_text() == "three myproject three"
+
+    # 3. User's custom file should be preserved
+    user_file = tmp_path / "src" / "myproject" / "user.txt"
+    assert user_file.exists()
+    assert user_file.read_text() == "user custom content"
+
+    # 4. Modified files should be merged (3-way merge)
+    file1_updated = file1.read_text()
+    assert "one myproject one" in file1_updated
+    assert "template added line" in file1_updated
+    assert "user added line" in file1_updated
+
+    # 5. Non-templated file should still exist unchanged
+    assert plain_txt.exists()
+    assert plain_txt.read_text() == "non-templated content"
+
+    # 6. Other templated files should still exist
+    assert file2.exists()
+
+    # 7. Root files should be updated
+    assert (tmp_path / "README.md").read_text() == "# myproject Project v2"
+
+
+def test_postrender_with_skip_tasks_flag(
+    template_with_postrender: Path, tmp_path: Path
+) -> None:
+    """Test that skip_tasks flag also skips postrender tasks."""
+    copier.run_copy(
+        str(template_with_postrender),
+        tmp_path,
+        data={"package": "myproject"},
+        skip_tasks=True,
+        unsafe=True,
+    )
+
+    # Verify postrender tasks were skipped
+    assert not (tmp_path / "postrender.log").exists()
+    assert not (tmp_path / "package.txt").exists()
+
+    # Verify template rendering still worked
+    assert (tmp_path / "README.md").exists()
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="Uses Unix shell syntax",
+)
+def test_postrender_conditional_on_update_stage(
+    tmp_path_factory: pytest.TempPathFactory, tmp_path: Path
+) -> None:
+    """Test using _update_stage in when conditions."""
+    template_path = tmp_path_factory.mktemp("template")
+
+    (template_path / "copier.yml").write_text(
+        """\
+_postrender_tasks:
+  - command: "echo 'expensive' > expensive.txt"
+    when: "{{ _update_stage == 'current' }}"
+  - command: "echo '{{ _update_stage }}' > all_stages.txt"
+"""
+    )
+    (template_path / "README.md").write_text("# Test")
+
+    copier.run_copy(str(template_path), tmp_path, unsafe=True)
+
+    # Verify conditional task only ran on "current"
+    assert (tmp_path / "expensive.txt").exists()
+    assert (tmp_path / "expensive.txt").read_text().strip() == "expensive"
+
+    # Verify unconditional task also ran
+    assert (tmp_path / "all_stages.txt").exists()
+    assert (tmp_path / "all_stages.txt").read_text().strip() == "current"


### PR DESCRIPTION
### Problem

A Copier template for Java applications requires every Java file to use `.jinja` extensions solely to template package names from `com.example.boilerplate` to `com.example.{{package}}`.  Ideally we'd have a way to keep most template files as plain `.java` with a fixed `com.example.boilerplate` package (`src/{test,main}/java/com/example/boilerplate/`), then execute a simple refactoring script at copy/update time to rename package directories (eg:`boilerplate/` → `myservice/`) and bulk-replace across files (eg: `com.example.boilerplate.` to `com.example.myservice.`). 

Copier's existing task system runs _after_ the diff calculation during updates, which breaks 3-way merge semantics. The diff compares `boilerplate` in the template vs `myservice` in the user's project, making changes undetectable.

### Solution

Solving this in a generic way (since directory-per-package isn't anything Java-specific), add a new `Phase.POSTRENDER` that executes _after_ template rendering but _before_ diff calculation during updates. This enables template authors to define tasks that transform rendered output without needing `.jinja` extensions on every file, while maintaining the 3-way merge semantics.

### Key changes

- Add `Phase.POSTRENDER` enum to execution phases
- Templates declare tasks in `copier.yml` using `_postrender_tasks` with support for conditional execution and custom working directories
- Execute postrender tasks in copy and update flows (on old-copy, new-copy, and destination)
- Add `_update_stage` variable to distinguish between previous, current, and new rendering contexts during updates
- Tests and documentation

Comments/suggestions most welcome!