### PR TITLE
Insure git hooks are ignored on checkout during conflicts

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1335,7 +1335,15 @@ class Worker:
                         # Remove ".rej" suffix
                         fname = fname[:-4]
                         # Undo possible non-rejected chunks
-                        git("checkout", "--", fname)
+                        git(
+                            # Ignore hooks to avoid errors from them or
+                            # issues when .pre-commit-config.yaml is changed
+                            "-c",
+                            "core.hooksPath=/dev/null",
+                            "checkout",
+                            "--",
+                            fname,
+                        )
                         # 3-way-merge the file directly
                         git(
                             "merge-file",

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1339,7 +1339,7 @@ class Worker:
                             # Ignore hooks to avoid errors from them or
                             # issues when .pre-commit-config.yaml is changed
                             "-c",
-                            "core.hooksPath=/dev/null",
+                            f"core.hooksPath={os.devnull}",
                             "checkout",
                             "--",
                             fname,

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import platform
+import stat
 from pathlib import Path
 from shutil import rmtree
 from textwrap import dedent
@@ -321,7 +322,7 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
                     _templates_suffix: {SUFFIX_TMPL}
                     _tasks:
                         - git init
-                        - pre-commit install
+                        - pre-commit install -t pre-commit -t commit-msg
                         - pre-commit run -a || true
                     what: grog
                     """
@@ -333,10 +334,6 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
                 ),
                 ".pre-commit-config.yaml": (
                     r"""
-                    default_install_hook_types: [
-                        pre-commit,
-                        commit-msg,
-                    ]
                     repos:
                     -   repo: https://github.com/pre-commit/mirrors-prettier
                         rev: v2.0.4
@@ -484,16 +481,11 @@ def test_commit_hooks_respected(tmp_path_factory: pytest.TempPathFactory) -> Non
         assert Path(f"{life}.rej").is_file()
 
 
-# Checkout test_commit_hooks_respected
-# FIXME Some generous Windows power user please fix this test!
-@pytest.mark.xfail(
-    condition=platform.system() == "Windows", reason="Git broken on Windows?"
-)
 @pytest.mark.impure
 def test_post_checkout_hook_ignored(tmp_path_factory: pytest.TempPathFactory) -> None:
     """Ignore post-checkout hook when conflicts are encountered."""
     # Prepare source template v1
-    src, dst1 = map(tmp_path_factory.mktemp, ("src", "dst1"))
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     with local.cwd(src):
         build_file_tree(
             {
@@ -503,8 +495,6 @@ def test_post_checkout_hook_ignored(tmp_path_factory: pytest.TempPathFactory) ->
                     _templates_suffix: {SUFFIX_TMPL}
                     _tasks:
                         - git init
-                        - git config --local core.hooksPath hooks/
-                        - chmod +x hooks/post-checkout
                     """
                 ),
                 "[[ _copier_conf.answers_file ]].tmpl": (
@@ -513,11 +503,6 @@ def test_post_checkout_hook_ignored(tmp_path_factory: pytest.TempPathFactory) ->
                     """
                 ),
                 "test.txt": "This is a file",
-                "hooks/post-checkout": (
-                    r"""
-                    echo "Post-checkout hook executed"
-                    """
-                ),
             }
         )
         git("init")
@@ -527,30 +512,28 @@ def test_post_checkout_hook_ignored(tmp_path_factory: pytest.TempPathFactory) ->
     # Copy source template
     run_copy(
         src_path=str(src),
-        dst_path=dst1,
+        dst_path=dst,
         defaults=True,
         overwrite=False,
         unsafe=True,
     )
-    with local.cwd(dst1):
+    with local.cwd(dst):
         git("add", ".")
         # Commit initial copy
         git("commit", "-am", "feat: copied v1")
         # Introduce conflict
-        Path(f"{dst1}/test.txt").open(mode="w").write("This is a conflicting change")
+        Path(dst / "test.txt").open(mode="w").write("This is a conflicting change")
         git("add", ".")
         git("commit", "-am", "feat: edit test.txt")
+        # Add post-checkout hook that fails
+        hook_file = dst / ".git" / "hooks" / "post-checkout"
+        hook_file.write_text("exit 1")
+        hook_file.chmod(hook_file.stat().st_mode | stat.S_IXUSR)
     # Evolve source template to v2
-    # No errors should be raised due to post-checkout hook
     with local.cwd(src):
         build_file_tree(
             {
-                "test.txt": "This is a edited file in v2",
-                "hooks/post-checkout": (
-                    r"""
-                    exit 1
-                    """
-                ),
+                "test.txt": "This is an edited file in v2",
             }
         )
         git("init")
@@ -558,8 +541,9 @@ def test_post_checkout_hook_ignored(tmp_path_factory: pytest.TempPathFactory) ->
         git("commit", "-m", "feat: Update post-checkout")
         git("tag", "v2")
     # Update subproject to v2
+    # No errors should be raised due to post-checkout hook
     run_update(
-        dst_path=dst1,
+        dst_path=dst,
         defaults=True,
         overwrite=True,
         unsafe=True,


### PR DESCRIPTION
Issues arise when you have post-checkout hooks, and you have conflicts, and also updated `.pre-commit-hooks.yaml` file

```console
plumbum.commands.processes.ProcessExecutionError: Unexpected exit code: 1
Command line: | /usr/bin/git checkout -- .github/settings.yaml
Stderr:       | [ERROR] Your pre-commit configuration is unstaged.
              | `git add .pre-commit-config.yaml` to fix this.
```