### PR TITLE
fix(updating): avoid circular reference when rendering JSON-serialized `_copier_conf` variable

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1244,8 +1244,8 @@ class Worker:
                 dst_path=new_copy / subproject_subdir,
                 data={
                     k: v
-                    for k, v in self.answers.combined.items()
-                    if k not in self.answers.hidden
+                    for k, v in self._answers_to_remember().items()
+                    if not k.startswith("_")
                 },
                 defaults=True,
                 quiet=True,


### PR DESCRIPTION
I've fixed a circular reference bug when rendering the JSON-serialized `_copier_conf` variable during an update. According to my debugging attempt, the problem is caused by [assigning more than just actual answers to the `new_worker`'s `data`](https://github.com/copier-org/copier/blob/6b5939dea45bcccfb629e566337f9b02cfc432b2/copier/_main.py#L1245-L1249) attribute, specifically [`copier._user_data.DEFAULT_DATA`](https://github.com/copier-org/copier/blob/6b5939dea45bcccfb629e566337f9b02cfc432b2/copier/_user_data.py#L64-L67) which is part of `self.answers.combined` and not filtered out. Assigning only actual answers fixes the problem. Hopefully #2376 will also resolve this problem more fundamentally. :crossed_fingers:

Fixes #2448.