### PR TITLE
docs: add filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ To create a template:
 ```
 
 Content of the `copier.yml` file:
+
 ```yaml title="copier.yml"
 # questions
 project_name:
@@ -64,11 +65,13 @@ module_name:
 ```
 
 Content of the `{{project_name}}/{{module_name}}.py.jinja` file:
+
 ```python+jinja title="{{project_name}}/{{module_name}}.py.jinja"
 print("Hello from {{module_name}}!")
 ```
 
 Content of the `{{_copier_conf.answers_file}}.jinja` file:
+
 ```yaml+jinja title="{{_copier_conf.answers_file}}.jinja"
 # Changes here will be overwritten by Copier
 {{ _copier_answers|to_nice_yaml -}}


### PR DESCRIPTION
Code blocks showing the content of files don't show the filename of the files being shown. This patch fixes it in `README.md` and `docs/creating.md`.

This is a screenshot of the current state:
<img width="951" height="686" alt="image" src="https://github.com/user-attachments/assets/7b112437-4a45-4ff6-b623-db48e132f41c" />

And this is a screenshot of the result with my patch:
<img width="940" height="829" alt="image" src="https://github.com/user-attachments/assets/9e94f623-ea7c-423d-aa68-c58ec65c9ffa" />
