### PR TITLE
Fix cast_to_bool to treat whitespace-only strings as False

### DIFF
--- a/copier/_tools.py
+++ b/copier/_tools.py
@@ -127,19 +127,15 @@ def cast_to_bool(value: Any) -> bool:
     # Assume it's a number
     with suppress(TypeError, ValueError):
         return bool(float(value))
-    
-    # Treat whitespace-only string  as False
-    if isinstance(value,str) and not value.strip():
-        return False
-    
     # Assume it's a string
     with suppress(AttributeError):
-        lower = value.lower()
+        stripped = value.strip()
+        lower = stripped.lower()
         if lower in {"y", "yes", "t", "true", "on"}:
             return True
-        elif lower in {"n", "no", "f", "false", "off", "~", "null", "none"}:
+        elif lower in {"n", "no", "f", "false", "off", "~", "null", "none", ""}:
             return False
-    # Assume nothing
+    # Fallback
     return bool(value)
 
 

--- a/copier/_tools.py
+++ b/copier/_tools.py
@@ -127,6 +127,11 @@ def cast_to_bool(value: Any) -> bool:
     # Assume it's a number
     with suppress(TypeError, ValueError):
         return bool(float(value))
+    
+    # Treat whitespace-only string  as False
+    if isinstance(value,str) and not value.strip():
+        return False
+    
     # Assume it's a string
     with suppress(AttributeError):
         lower = value.lower()

--- a/copier/_tools.py
+++ b/copier/_tools.py
@@ -127,14 +127,19 @@ def cast_to_bool(value: Any) -> bool:
     # Assume it's a number
     with suppress(TypeError, ValueError):
         return bool(float(value))
+
+    # Handle whitespace-only strings first
+    if isinstance(value, str) and not value.strip():
+        return False
+
     # Assume it's a string
     with suppress(AttributeError):
-        stripped = value.strip()
-        lower = stripped.lower()
+        lower = value.lower().strip()
         if lower in {"y", "yes", "t", "true", "on"}:
             return True
-        elif lower in {"n", "no", "f", "false", "off", "~", "null", "none", ""}:
+        elif lower in {"n", "no", "f", "false", "off", "~", "null", "none"}:
             return False
+
     # Fallback
     return bool(value)
 

--- a/tests/test_cast_to_bool.py
+++ b/tests/test_cast_to_bool.py
@@ -1,8 +1,0 @@
-from copier._tools import cast_to_bool
-
-
-def test_cast_to_bool_whitespace_only_strings_are_false() -> None:
-    assert cast_to_bool("") is False
-    assert cast_to_bool(" ") is False
-    assert cast_to_bool("\n") is False
-    assert cast_to_bool("   \n\t") is False

--- a/tests/test_cast_to_bool.py
+++ b/tests/test_cast_to_bool.py
@@ -1,0 +1,8 @@
+from copier._tools import cast_to_bool
+
+
+def test_cast_to_bool_whitespace_only_strings_are_false() -> None:
+    assert cast_to_bool("") is False
+    assert cast_to_bool(" ") is False
+    assert cast_to_bool("\n") is False
+    assert cast_to_bool("   \n\t") is False

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -54,7 +54,19 @@ def test_normalizing_git_paths(path: str, normalized: str) -> None:
     assert normalize_git_path(path) == normalized
 
 def test_cast_to_bool_whitespace_only_strings_are_false() -> None:
+    """Test that whitespace-only strings are False and valid keywords with surrounding whitespace still work."""
+    # Whitespace-only strings should be False
     assert cast_to_bool("") is False
     assert cast_to_bool(" ") is False
     assert cast_to_bool("\n") is False
     assert cast_to_bool("   \n\t") is False
+
+    # Whitespace around valid keywords should still work
+    assert cast_to_bool(" yes ") is True
+    assert cast_to_bool(" YES ") is True
+    assert cast_to_bool(" no ") is False
+    assert cast_to_bool(" NO ") is False
+    assert cast_to_bool(" true ") is True
+    assert cast_to_bool(" false ") is False
+
+

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryDirectory
 import pytest
 from poethepoet.app import PoeThePoet
 
-from copier._tools import normalize_git_path
+from copier._tools import cast_to_bool, normalize_git_path
 
 from .helpers import git
 
@@ -52,3 +52,9 @@ def test_temporary_directory_with_git_repo_deletion() -> None:
 )
 def test_normalizing_git_paths(path: str, normalized: str) -> None:
     assert normalize_git_path(path) == normalized
+
+def test_cast_to_bool_whitespace_only_strings_are_false() -> None:
+    assert cast_to_bool("") is False
+    assert cast_to_bool(" ") is False
+    assert cast_to_bool("\n") is False
+    assert cast_to_bool("   \n\t") is False


### PR DESCRIPTION
### What does this change?

`cast_to_bool` was treating whitespace-only strings (e.g. `" "`, `"\n"`) as `True` due to Python’s default `bool(str)` behavior.

This PR adds an explicit check to treat empty and whitespace-only strings as `False`.

### What was done?

- Added a guard to return `False` for whitespace-only strings.
- Added a unit test covering this behavior.

### Why this approach?

The change is minimal and does not alter existing behavior for numbers, YAML booleans, or standard truthy values.
