### PR TITLE
fix(updating): include non-question answers when generating fresh copy of new template

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1273,8 +1273,11 @@ class Worker:
                 dst_path=new_copy / subproject_subdir,
                 data={
                     k: v
-                    for k, v in self._answers_to_remember().items()
+                    for k, v in self.answers.combined.items()
                     if not k.startswith("_")
+                    and k not in self.answers.hidden
+                    and isinstance(k, JSONSerializable)
+                    and isinstance(v, JSONSerializable)
                 },
                 defaults=True,
                 quiet=True,


### PR DESCRIPTION
I've fixed a regression introduced by #2449 which omits non-question answers from the answers context when generating a fresh copy of the new template as part of the update algorithm.

Fixes #2467.