### PR TITLE
docs: Move example for special UNSET variable to default section

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -210,9 +210,11 @@ Supported keys:
         -    default: '[[, ]]'     # ❌ WRONG
         +    default: '["[", "]"]' # ✔️ RIGHT
         ```
-    
-    If the default value does not apply to all cases, i.e., an answer is required under certain conditions, then the default can be unset by rendering the special `UNSET` variable to force the user to provide an answer:
-    
+
+    If the default value does not apply to all cases, i.e., an answer is required under
+    certain conditions, then the default can be unset by rendering the special `UNSET`
+    variable to force the user to provide an answer:
+
     !!! example
 
         ```yaml title="copier.yml"
@@ -311,8 +313,8 @@ Supported keys:
 
     If the default value of a skipped question is not meaningful, then it can be unset
     by rendering the special `UNSET` variable, so the question's variable is undefined
-    in the render context.
-    See an example using `UNSET` in the section for `default` above.
+    in the render context. See an example using `UNSET` in the section for `default`
+    above.
 
 !!! example
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -210,6 +210,35 @@ Supported keys:
         -    default: '[[, ]]'     # ❌ WRONG
         +    default: '["[", "]"]' # ✔️ RIGHT
         ```
+    
+    If the default value does not apply to all cases, i.e., an answer is required under certain conditions, then the default can be unset by rendering the special `UNSET` variable to force the user to provide an answer:
+    
+    !!! example
+
+        ```yaml title="copier.yml"
+        database_engine:
+            type: str
+            help: Database engine
+            choices:
+                - postgres
+                - mysql
+                - other
+            default: postgres
+
+        database_url:
+            type: str
+            help: Database URL
+            default: >-
+                {%- if database_engine == 'postgres' -%}
+                postgresql://user:pass@localhost:5432/dbname
+                {%- elif database_engine == 'mysql' -%}
+                mysql://user:pass@localhost:3306/dbname
+                {%- else -%}
+                {{ UNSET }}
+                {%- endif -%}
+            # Simplified for illustration purposes
+            validator: "{% if '://' not in database_url %}Invalid{% endif %}"
+        ```
 
 -   **secret**: When `true`, it hides the prompt displaying asterisks (`*****`) and
     doesn't save the answer in [the answers file][the-copier-answersyml-file]. When
@@ -282,35 +311,8 @@ Supported keys:
 
     If the default value of a skipped question is not meaningful, then it can be unset
     by rendering the special `UNSET` variable, so the question's variable is undefined
-    in the render context:
-
-    !!! example
-
-        ```yaml title="copier.yml"
-        database_engine:
-            type: str
-            help: Database engine
-            choices:
-                - postgres
-                - mysql
-                - none
-            default: postgres
-
-        database_url:
-            type: str
-            help: Database URL
-            default: >-
-                {%- if database_engine == 'postgres' -%}
-                postgresql://user:pass@localhost:5432/dbname
-                {%- elif database_engine == 'mysql' -%}
-                mysql://user:pass@localhost:3306/dbname
-                {%- else -%}
-                {{ UNSET }}
-                {%- endif -%}
-            when: "{{ database_engine != 'none' }}"
-            # Simplified for illustration purposes
-            validator: "{% if '://' not in database_url %}Invalid{% endif %}"
-        ```
+    in the render context.
+    See an example using `UNSET` in the section for `default` above.
 
 !!! example
 


### PR DESCRIPTION
Had to change the logic in the example and remove the `when` condition. Hope this still makes sense for documenting `when`. Otherwise we could have an example in both sections.

Closes #2475