### PR TITLE
feat: Support `--diff3` flag in `update` command

### DIFF
--- a/copier/_cli.py
+++ b/copier/_cli.py
@@ -392,6 +392,13 @@ class CopierUpdateSubApp(_Subcommand):
             "accuracy, decrease for resilience."
         ),
     )
+    diff3 = cli.Flag(
+        ["--diff3"],
+        help=(
+            "Use diff3-style conflict markers that include the base version "
+            "(from last update) in addition to 'before updating' and 'after updating'."
+        ),
+    )
     defaults = cli.Flag(
         ["-l", "-f", "--defaults"],
         help="Use default answers to questions, which might be null if not specified.",
@@ -419,6 +426,7 @@ class CopierUpdateSubApp(_Subcommand):
                 dst_path=destination_path,
                 conflict=self.conflict,
                 context_lines=self.context_lines,
+                diff3=self.diff3,
                 defaults=self.defaults,
                 skip_answered=self.skip_answered,
                 overwrite=True,

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -212,6 +212,11 @@ class Worker:
             With less lines, context resolution is less accurate, but it will
             respect better the evolution of your subproject.
 
+        diff3:
+            When `True`, use diff3-style conflict markers that include
+            the base version (from last update) in addition to
+            "before updating" and "after updating".
+
         unsafe:
             When `True`, allow usage of unsafe templates.
 
@@ -244,6 +249,7 @@ class Worker:
     quiet: bool = False
     conflict: Literal["inline", "rej"] = "inline"
     context_lines: PositiveInt = 3
+    diff3: bool = False
     unsafe: bool = False
     skip_answered: bool = False
     skip_tasks: bool = False
@@ -1379,6 +1385,7 @@ class Worker:
                         # 3-way-merge the file directly
                         git(
                             "merge-file",
+                            *(["--diff3"] if self.diff3 else []),
                             "-L",
                             "before updating",
                             "-L",

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -48,6 +48,30 @@ conflict in one of two ways, controlled with the `--conflict` option:
     conflict. For more information, see the "Checking Out Conflicts" section of the
     [`git` documentation](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging).
 
+When using `--conflict inline`, you can additionally specify `--diff3` to include the
+base version (from the last update) in conflict markers:
+
+```shell
+copier update --conflict inline --diff3
+```
+
+This produces conflict markers like:
+
+```text
+<<<<<<< before updating
+your local changes
+||||||| last update
+original base content
+=======
+template's new changes
+>>>>>>> after updating
+```
+
+The base version can help you understand what the original content was before both you
+and the template made changes, making conflict resolution easier. This format is also
+useful for tools like [mergiraf](https://mergiraf.org/) that can perform semantic
+merging based on the three-way diff.
+
 If the update results in conflicts, _you should review those manually_ before
 committing.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,6 +375,7 @@ def test_update_help() -> None:
     assert "-o, --conflict" in _help
     assert "copier update [SWITCHES] [destination_path=.]" in _help
     assert "--skip-answered" in _help
+    assert "--diff3" in _help
 
 
 def test_python_run() -> None:


### PR DESCRIPTION
## Background

We want to use mergiraf with `copier update` in an automated copier update workflow. Mergiraf cannot be directly configured as a merge driver for our use case because `copier update` uses `git merge-file` internally. Hence, we rely on executing mergiraf in [interactive mode](https://mergiraf.org/usage.html#interactive-use-after-encountering-a-merge-conflict) after `copier update` has been run. We need diff3-style conflict markers for this. `git merge-file` cannot be globally configured to generate diff3-styled conflict markers; hence `copier` needs to pass the `--diff3` flag to it.

I am aware of https://github.com/copier-org/copier/pull/2376, but this PR implements a quicker solution for immediate use with mergiraf.

## Summary
- Add `--diff3` flag to the `copier update` command that produces diff3-style conflict markers including the base version (from last update)
- This makes conflict resolution easier by showing what the original content was before both local and template changes
- Particularly useful for semantic merge tools like [mergiraf](https://mergiraf.org/)

## AI Note

I generated this PR with assistance from Claude Code, but reviewed it manually.