### PR TITLE
fix: remove incorrect import deprecation warnings for `types.Phase` and `types.VcsRef` enums

### DIFF
--- a/copier/types.py
+++ b/copier/types.py
@@ -5,19 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from copier import _types
-from copier._deprecation import (
-    deprecate_member_as_internal,
-    deprecate_module_as_internal,
-)
+from copier._deprecation import deprecate_member_as_internal
 
 if TYPE_CHECKING:
     from copier._types import *  # noqa: F403
 
 
-deprecate_module_as_internal(__name__)
-
-
 def __getattr__(name: str) -> Any:
-    if not name.startswith("_"):
+    if not name.startswith("_") and name not in {"Phase", "VcsRef"}:
         deprecate_member_as_internal(name, __name__)
     return getattr(_types, name)


### PR DESCRIPTION
I've removed the module-level deprecation warning for the `types` module, thereby restoring it as a public module, and excluded the `Phase` and `VcsRef` enums from raising import deprecation warnings. The `Phase` enum is useful for running a context hook using [copier-template-extensions](https://github.com/copier-org/copier-template-extensions) only in a subset of the rendering phases (see #2485). The `VcsRef` enum is necessary for running Copier programmatically with `vcs_ref=VcsRef.CURRENT`.

Fixes #2485.