### PR TITLE
fix(updating): normalize user-deleted paths before skip-if-exists pattern matching during updates

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1235,17 +1235,9 @@ class Worker:
                 ).splitlines()
                 exclude_plus_removed = list(
                     set(self.exclude).union(
-                        map(
-                            escape_git_path,
-                            map(
-                                normalize_git_path,
-                                (
-                                    path
-                                    for path in files_removed
-                                    if not self.match_skip(path)
-                                ),
-                            ),
-                        )
+                        escape_git_path(path)
+                        for path in map(normalize_git_path, files_removed)
+                        if not self.match_skip(Path(path))
                     )
                 )
             # Clear last answers cache to load possible answers migration, if skip_answered flag is not set

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -655,6 +655,13 @@ def test_skip_update(tmp_path_factory: pytest.TempPathFactory) -> None:
                 reason="Disallowed characters in file name",
             ),
         ),
+        pytest.param(
+            "sk\\ip_with_backslash_in_skip_pattern",
+            marks=pytest.mark.skipif(
+                platform.system() == "Windows",
+                reason="Disallowed characters in file name",
+            ),
+        ),
     ),
 )
 def test_skip_update_deleted(
@@ -669,7 +676,7 @@ def test_skip_update_deleted(
     with local.cwd(src):
         build_file_tree(
             {
-                "copier.yaml": "_skip_if_exists: ['*skip*']",
+                "copier.yaml": "_skip_if_exists: ['*skip*', '*sk\\ip*']",
                 "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
                 file_name: "1",
                 "another_file": "foobar",


### PR DESCRIPTION
I've fixed a bug in the update algorithm related to the recreation of user-deleted files that match a skip-if-exists pattern when both contain certain special characters like backslashes.

Previously, user-deleted file paths were not normalized before matching against skip-if-exists patterns. This caused mismatches when paths contained special characters, as the path representation differed from the gitignore-style pattern representation.

The fix applies `normalize_git_path` to user-deleted file paths _before_ matching them against skip-if-exists patterns, ensuring consistent path representation and correct pattern matching.

Fixes missing recreation of user-deleted files that should match skip-if-exists patterns during project updates.

Follow-up of #1719.