### PR TITLE
refactor: deprecate `VcsRef` import from `copier` root module

### DIFF
--- a/copier/__init__.py
+++ b/copier/__init__.py
@@ -6,12 +6,12 @@ Docs: https://copier.readthedocs.io/
 import importlib.metadata
 from typing import TYPE_CHECKING, Any
 
-from . import _main
-from ._deprecation import deprecate_member_as_internal
-from ._types import VcsRef as VcsRef
+from . import _main, _types
+from ._deprecation import deprecate_member, deprecate_member_as_internal
 
 if TYPE_CHECKING:
     from ._main import *  # noqa: F403
+    from ._types import VcsRef  # noqa: F401
 
 try:
     __version__ = importlib.metadata.version(__name__)
@@ -20,6 +20,10 @@ except importlib.metadata.PackageNotFoundError:
 
 
 def __getattr__(name: str) -> Any:
+    if name == "VcsRef":
+        deprecate_member(name, __name__, f"{__name__}.types.{name}")
+        return getattr(_types, name)
+
     if not name.startswith("_") and name not in {
         "run_copy",
         "run_recopy",


### PR DESCRIPTION
I've deprecated importing `VcsRef` directly from `copier` in favor of importing from `copier.types`. This change aligns with the [revised public `types` module structure](https://github.com/copier-org/copier/pull/2490) while maintaining backward compatibility through a deprecation warning.

Follow-up of #2490.