### PR TITLE
fix(updating): anchor removed file paths to project root in update algorithm

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1235,7 +1235,7 @@ class Worker:
                 ).splitlines()
                 exclude_plus_removed = list(
                     set(self.exclude).union(
-                        escape_git_path(path)
+                        f"/{escape_git_path(path)}"
                         for path in map(normalize_git_path, files_removed)
                         if not self.match_skip(Path(path))
                     )


### PR DESCRIPTION
I've fixed a bug in the update algorithm after a user had deleted a file that caused unintentional deletion of file paths with matching subpaths (e.g., `foo/test.txt` was deleted by the update algorithm when `test.txt` had been deleted by the user). This happened because the user-deleted file paths (i.e., relative paths) were used as exclude patterns when generating a fresh copy of the new template, and exclude patterns are gitignore-style patterns which match subpaths unless prefixed with `/`.

Now, user-deleted file paths are prefixed with `/` to treat them as absolute paths anchored at the project root, turning them into gitignore-style patterns that match only the exact paths. This prevents unintended deletion of files with the same name in subdirectories during project updates.

This bug was revealed while debugging an update problem with @Lorilatschki and @kinkelpk. Thanks for bringing the problem to my attention! :+1: