### PR TITLE
feat: re-export `Phase` enum at package level

### DIFF
--- a/copier/__init__.py
+++ b/copier/__init__.py
@@ -6,12 +6,12 @@ Docs: https://copier.readthedocs.io/
 import importlib.metadata
 from typing import TYPE_CHECKING, Any
 
-from . import _main, _types
-from ._deprecation import deprecate_member, deprecate_member_as_internal
+from . import _main
+from ._deprecation import deprecate_member_as_internal
+from ._types import VcsRef as VcsRef
 
 if TYPE_CHECKING:
     from ._main import *  # noqa: F403
-    from ._types import VcsRef  # noqa: F401
 
 try:
     __version__ = importlib.metadata.version(__name__)
@@ -20,10 +20,6 @@ except importlib.metadata.PackageNotFoundError:
 
 
 def __getattr__(name: str) -> Any:
-    if name == "VcsRef":
-        deprecate_member(name, __name__, f"{__name__}.types.{name}")
-        return getattr(_types, name)
-
     if not name.startswith("_") and name not in {
         "run_copy",
         "run_recopy",

--- a/copier/__init__.py
+++ b/copier/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from . import _main
 from ._deprecation import deprecate_member_as_internal
-from ._types import VcsRef as VcsRef
+from ._types import Phase, VcsRef
 
 if TYPE_CHECKING:
     from ._main import *  # noqa: F403
@@ -32,5 +32,7 @@ def __getattr__(name: str) -> Any:
 __all__ = [
     "run_copy",  # noqa: F405
     "run_recopy",  # noqa: F405
-    "run_update",  # noqa: F405
+    "run_update",  # noqa: F405,
+    "Phase",
+    "VcsRef",
 ]

--- a/copier/types.py
+++ b/copier/types.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from copier import _types
-from copier._deprecation import deprecate_member_as_internal
+from copier._deprecation import (
+    deprecate_member_as_internal,
+    deprecate_module_as_internal,
+)
 
 if TYPE_CHECKING:
     from copier._types import *  # noqa: F403
@@ -13,7 +16,10 @@ if TYPE_CHECKING:
 __all__ = ["Phase", "VcsRef"]  # noqa: F405
 
 
+deprecate_module_as_internal(__name__)
+
+
 def __getattr__(name: str) -> Any:
-    if not name.startswith("_") and name not in {"Phase", "VcsRef"}:
+    if not name.startswith("_"):
         deprecate_member_as_internal(name, __name__)
     return getattr(_types, name)

--- a/copier/types.py
+++ b/copier/types.py
@@ -13,8 +13,6 @@ from copier._deprecation import (
 if TYPE_CHECKING:
     from copier._types import *  # noqa: F403
 
-__all__ = ["Phase", "VcsRef"]  # noqa: F405
-
 
 deprecate_module_as_internal(__name__)
 


### PR DESCRIPTION
I've added a re-export of the `Phase` enum from `copier/_types.py` in `copier/__init__.py` and reverted 47afec32cf9843a6d7dadb04b89e8d929ea99d8b and 0fda385cbbba64b675b4653a9076fe56941d86ed.

After thinking about our module layout more deeply, re-reading [Griffe's recommendation about public APIs](https://mkdocstrings.github.io/griffe/guide/users/recommendations/public-apis/), and going over @pawamoy's and my discussion at https://github.com/copier-org/copier/pull/2490#issuecomment-3859991822 (and subsequent comments) again, I think having several public modules adds unnecessary complexity for this comparatively small project. For example, if we kept `copier`, `copier.errors`, and `copier.types` as public modules, where should `Settings` be exported? These layout decisions seem to be rather arbitrary and opinionated without adding value to the project, I don't think that's good use of our time.

With this PR, I'm proposing to follow the [single top-level re-export location](https://mkdocstrings.github.io/griffe/guide/users/recommendations/public-apis/#single-location-top-level-good) approach recommended by Griffe and preferred by @pawamoy.