### PR TITLE
feat: add new settings API with minimal surface

### DIFF
--- a/copier/__init__.py
+++ b/copier/__init__.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from . import _main
 from ._deprecation import deprecate_member_as_internal
+from ._settings import Settings, load_settings
 from ._types import Phase, VcsRef
 
 if TYPE_CHECKING:
@@ -30,9 +31,11 @@ def __getattr__(name: str) -> Any:
 
 
 __all__ = [
+    "load_settings",
     "run_copy",  # noqa: F405
     "run_recopy",  # noqa: F405
     "run_update",  # noqa: F405,
     "Phase",
+    "Settings",
     "VcsRef",
 ]

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -41,6 +41,7 @@ from pydantic_core import to_jsonable_python
 from questionary import confirm, unsafe_prompt
 
 from ._jinja_ext import YieldEnvironment, YieldExtension
+from ._settings import Settings
 from ._subproject import Subproject
 from ._template import Task, Template
 from ._tools import (
@@ -77,7 +78,6 @@ from .errors import (
     UserMessageError,
     YieldTagInFileError,
 )
-from .settings import Settings
 
 _T = TypeVar("_T")
 _P = ParamSpec("_P")

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -41,7 +41,7 @@ from pydantic_core import to_jsonable_python
 from questionary import confirm, unsafe_prompt
 
 from ._jinja_ext import YieldEnvironment, YieldExtension
-from ._settings import Settings
+from ._settings import Settings, SettingsModel, is_trusted_repository
 from ._subproject import Subproject
 from ._template import Task, Template
 from ._tools import (
@@ -232,7 +232,7 @@ class Worker:
     answers_file: RelativePath | None = None
     vcs_ref: str | VcsRef | None = None
     data: AnyByStrDict = field(default_factory=dict)
-    settings: Settings = field(default_factory=Settings.from_file)
+    settings: SettingsModel = field(default_factory=SettingsModel.from_file)
     exclude: Sequence[str] = ()
     use_prereleases: bool = False
     skip_if_exists: Sequence[str] = ()
@@ -286,7 +286,7 @@ class Worker:
 
     def _check_unsafe(self, mode: Operation) -> None:
         """Check whether a template uses unsafe features."""
-        if self.unsafe or self.settings.is_trusted(self.template.url):
+        if self.unsafe or is_trusted_repository(self.settings.trust, self.template.url):
             return
         features: set[str] = set()
         if self.template.jinja_extensions:
@@ -1501,7 +1501,7 @@ def run_copy(
     *,
     answers_file: RelativePath | str | None = None,
     vcs_ref: str | VcsRef | None = None,
-    settings: Settings | None = None,
+    settings: Settings | SettingsModel | None = None,
     exclude: Sequence[str] = (),
     use_prereleases: bool = False,
     skip_if_exists: Sequence[str] = (),
@@ -1525,7 +1525,11 @@ def run_copy(
             else answers_file
         ),
         vcs_ref=vcs_ref,
-        settings=settings or Settings.from_file(),
+        settings=(
+            SettingsModel(defaults=settings.defaults, trust=settings.trust)
+            if isinstance(settings, Settings)
+            else (settings or SettingsModel.from_file())
+        ),
         exclude=exclude,
         use_prereleases=use_prereleases,
         skip_if_exists=skip_if_exists,
@@ -1548,7 +1552,7 @@ def run_recopy(
     *,
     answers_file: RelativePath | str | None = None,
     vcs_ref: str | VcsRef | None = None,
-    settings: Settings | None = None,
+    settings: Settings | SettingsModel | None = None,
     exclude: Sequence[str] = (),
     use_prereleases: bool = False,
     skip_if_exists: Sequence[str] = (),
@@ -1572,7 +1576,11 @@ def run_recopy(
             else answers_file
         ),
         vcs_ref=vcs_ref,
-        settings=settings or Settings.from_file(),
+        settings=(
+            SettingsModel(defaults=settings.defaults, trust=settings.trust)
+            if isinstance(settings, Settings)
+            else (settings or SettingsModel.from_file())
+        ),
         exclude=exclude,
         use_prereleases=use_prereleases,
         skip_if_exists=skip_if_exists,
@@ -1596,7 +1604,7 @@ def run_update(
     *,
     answers_file: RelativePath | str | None = None,
     vcs_ref: str | VcsRef | None = None,
-    settings: Settings | None = None,
+    settings: Settings | SettingsModel | None = None,
     exclude: Sequence[str] = (),
     use_prereleases: bool = False,
     skip_if_exists: Sequence[str] = (),
@@ -1622,7 +1630,11 @@ def run_update(
             else answers_file
         ),
         vcs_ref=vcs_ref,
-        settings=settings or Settings.from_file(),
+        settings=(
+            SettingsModel(defaults=settings.defaults, trust=settings.trust)
+            if isinstance(settings, Settings)
+            else (settings or SettingsModel.from_file())
+        ),
         exclude=exclude,
         use_prereleases=use_prereleases,
         skip_if_exists=skip_if_exists,

--- a/copier/_settings.py
+++ b/copier/_settings.py
@@ -1,0 +1,78 @@
+"""User settings models and helper functions."""
+
+from __future__ import annotations
+
+import os
+import warnings
+from os.path import expanduser
+from pathlib import Path
+from typing import Any
+
+import yaml
+from platformdirs import user_config_path
+from pydantic import BaseModel, Field
+
+from ._tools import OS
+from .errors import MissingSettingsWarning
+
+ENV_VAR = "COPIER_SETTINGS_PATH"
+
+
+class Settings(BaseModel):
+    """User settings model."""
+
+    defaults: dict[str, Any] = Field(
+        default_factory=dict, description="Default values for questions"
+    )
+    trust: set[str] = Field(
+        default_factory=set, description="List of trusted repositories or prefixes"
+    )
+
+    @staticmethod
+    def _default_settings_path() -> Path:
+        return user_config_path("copier", appauthor=False) / "settings.yml"
+
+    @classmethod
+    def from_file(cls, settings_path: Path | None = None) -> Settings:
+        """Load settings from a file."""
+        env_path = os.getenv(ENV_VAR)
+        if settings_path is None:
+            if env_path:
+                settings_path = Path(env_path)
+            else:
+                settings_path = cls._default_settings_path()
+
+                # NOTE: Remove after a sufficiently long deprecation period.
+                if OS == "windows":
+                    old_settings_path = user_config_path("copier") / "settings.yml"
+                    if old_settings_path.is_file():
+                        warnings.warn(
+                            f"Settings path {old_settings_path} is deprecated. "
+                            f"Please migrate to {settings_path}.",
+                            DeprecationWarning,
+                            stacklevel=2,
+                        )
+                        settings_path = old_settings_path
+        if settings_path.is_file():
+            data = yaml.safe_load(settings_path.read_bytes())
+            return cls.model_validate(data)
+        elif env_path:
+            warnings.warn(
+                f"Settings file not found at {env_path}", MissingSettingsWarning
+            )
+        return cls()
+
+    def is_trusted(self, repository: str) -> bool:
+        """Check if a repository is trusted."""
+        return any(
+            repository.startswith(self.normalize(trusted))
+            if trusted.endswith("/")
+            else repository == self.normalize(trusted)
+            for trusted in self.trust
+        )
+
+    def normalize(self, url: str) -> str:
+        """Normalize an URL using user settings."""
+        if url.startswith("~"):  # Only expand on str to avoid messing with URLs
+            url = expanduser(url)  # noqa: PTH111
+        return url

--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -26,7 +26,7 @@ from pygments.lexers.data import JsonLexer, YamlLexer
 from questionary.prompts.common import Choice
 
 from copier._jinja_ext import UnsetError
-from copier._settings import Settings
+from copier._settings import SettingsModel
 
 from ._tools import cast_to_bool, cast_to_str, force_str_end
 from ._types import (
@@ -207,7 +207,7 @@ class Question:
     answers: AnswersMap
     context: Mapping[str, Any]
     jinja_env: SandboxedEnvironment
-    settings: Settings = field(default_factory=Settings)
+    settings: SettingsModel = field(default_factory=SettingsModel)
     choices: Sequence[Any] | dict[Any, Any] | str = field(default_factory=list)
     multiselect: bool = False
     default: Any = MISSING

--- a/copier/_user_data.py
+++ b/copier/_user_data.py
@@ -26,7 +26,7 @@ from pygments.lexers.data import JsonLexer, YamlLexer
 from questionary.prompts.common import Choice
 
 from copier._jinja_ext import UnsetError
-from copier.settings import Settings
+from copier._settings import Settings
 
 from ._tools import cast_to_bool, cast_to_str, force_str_end
 from ._types import (

--- a/copier/errors.py
+++ b/copier/errors.py
@@ -236,3 +236,7 @@ class InteractiveSessionError(UserMessageError):
 
     def __init__(self, message: str) -> None:
         super().__init__(f"Interactive session required: {message}")
+
+
+class SettingsError(CopierError):
+    """Exception raised when the settings are invalid."""

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -1,82 +1,33 @@
-"""User settings models and helper functions."""
+"""Deprecated: module is intended for internal use only."""
 
 from __future__ import annotations
 
-import os
-import warnings
-from os.path import expanduser
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import yaml
-from platformdirs import user_config_path
-from pydantic import BaseModel, Field
+from copier import _settings
+from copier._deprecation import (
+    deprecate_member_as_internal,
+    deprecate_module_as_internal,
+)
 
-from ._tools import OS
-from .errors import MissingSettingsWarning
-
-__all__ = [
-    "Settings",
-]
-
-ENV_VAR = "COPIER_SETTINGS_PATH"
-
-
-class Settings(BaseModel):
-    """User settings model."""
-
-    defaults: dict[str, Any] = Field(
-        default_factory=dict, description="Default values for questions"
-    )
-    trust: set[str] = Field(
-        default_factory=set, description="List of trusted repositories or prefixes"
+if TYPE_CHECKING:
+    from copier._settings import (  # noqa: F401
+        _ENV_VAR as ENV_VAR,
+        SettingsModel as Settings,
     )
 
-    @staticmethod
-    def _default_settings_path() -> Path:
-        return user_config_path("copier", appauthor=False) / "settings.yml"
 
-    @classmethod
-    def from_file(cls, settings_path: Path | None = None) -> Settings:
-        """Load settings from a file."""
-        env_path = os.getenv(ENV_VAR)
-        if settings_path is None:
-            if env_path:
-                settings_path = Path(env_path)
-            else:
-                settings_path = cls._default_settings_path()
+deprecate_module_as_internal(__name__)
 
-                # NOTE: Remove after a sufficiently long deprecation period.
-                if OS == "windows":
-                    old_settings_path = user_config_path("copier") / "settings.yml"
-                    if old_settings_path.is_file():
-                        warnings.warn(
-                            f"Settings path {old_settings_path} is deprecated. "
-                            f"Please migrate to {settings_path}.",
-                            DeprecationWarning,
-                            stacklevel=2,
-                        )
-                        settings_path = old_settings_path
-        if settings_path.is_file():
-            data = yaml.safe_load(settings_path.read_bytes())
-            return cls.model_validate(data)
-        elif env_path:
-            warnings.warn(
-                f"Settings file not found at {env_path}", MissingSettingsWarning
-            )
-        return cls()
 
-    def is_trusted(self, repository: str) -> bool:
-        """Check if a repository is trusted."""
-        return any(
-            repository.startswith(self.normalize(trusted))
-            if trusted.endswith("/")
-            else repository == self.normalize(trusted)
-            for trusted in self.trust
-        )
+def __getattr__(name: str) -> Any:
+    # Explicitly handle deprecated members with re-mapped names for backwards
+    # compatibility.
+    if name == "Settings":
+        deprecate_member_as_internal(name, __name__)
+        return _settings.SettingsModel
+    if name == "ENV_VAR":
+        deprecate_member_as_internal(name, __name__)
+        return _settings._ENV_VAR
 
-    def normalize(self, url: str) -> str:
-        """Normalize an URL using user settings."""
-        if url.startswith("~"):  # Only expand on str to avoid messing with URLs
-            url = expanduser(url)  # noqa: PTH111
-        return url
+    raise AttributeError(f"module {__name__} has no attribute '{name}'")

--- a/copier/settings.py
+++ b/copier/settings.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from copier import _settings
 from copier._deprecation import (
+    deprecate_member,
     deprecate_member_as_internal,
     deprecate_module_as_internal,
 )
@@ -24,7 +25,7 @@ def __getattr__(name: str) -> Any:
     # Explicitly handle deprecated members with re-mapped names for backwards
     # compatibility.
     if name == "Settings":
-        deprecate_member_as_internal(name, __name__)
+        deprecate_member(name, __name__, f"from copier import {name}")
         return _settings.SettingsModel
     if name == "ENV_VAR":
         deprecate_member_as_internal(name, __name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def gitconfig(gitconfig: GitConfig) -> Iterator[GitConfig]:
 def config_path(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
     config_path = tmp_path / "config"
     monkeypatch.delenv("COPIER_SETTINGS_PATH", raising=False)
-    with patch("copier.settings.user_config_path", return_value=config_path):
+    with patch("copier._settings.user_config_path", return_value=config_path):
         yield config_path
 
 

--- a/tests/test_settings_deprecated.py
+++ b/tests/test_settings_deprecated.py
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from copier._settings import Settings
 from copier.errors import MissingSettingsWarning
-from copier.settings import Settings
 
 
 def test_default_settings() -> None:


### PR DESCRIPTION
I've deprecated the public `settings` module and its public symbols because it turned out that [the current settings API leaks internal-only methods and public methods from Pydantic's `BaseModel` class](https://github.com/copier-org/copier/pull/2497#issuecomment-3887255316), effectively adding part of Pydantic's public API to ours.

I've given the Pydantic situation deeper thought, this is my current conclusion: In a well-architected Python library, Pydantic should live strictly at the input boundary for parsing and validating untrusted data (e.g., config files) and never define the public domain model. Public APIs should expose plain Python types (e.g., primitive types, dataclasses, `dict`/`TypedDict`, etc.) that represent already-validated domain objects, while Pydantic models and validators remain private implementation details. Validation errors from Pydantic should be caught and mapped to custom exceptions, since exception types are also part of the public API contract. This keeps the public surface minimal and stable, prevents framework types and exceptions from leaking, and allows validation mechanisms to be replaced without breaking the library's API contract.

When thinking about Pydantic's place in a proper architecture, I also wondered about where validation rules should be implemented because Pydantic offers many runtime validation types and field/model validators for additional checks; this is my current conclusion (it might deserve a longer explanation for better clarity): The input boundary layer (Pydantic models) is responsible for validating and normalizing _how data is provided_, i.e., parsing raw input, enforcing structural constraints, handling mutually exclusive or deprecated fields, and converting untrusted representations into typed values. The domain layer is responsible for enforcing _invariants that must always hold for a valid domain object_, regardless of how it was constructed. In other words, the boundary ensures that data is well-formed and acceptable as input, while the domain guarantees that any constructed object is logically valid and cannot exist in an inconsistent state. From my perspective, this reasoning gives dataclasses an edge over typed dicts because domain invariants can be enforced via checks implemented in the `__post_init__` method while typed dicts are only dicts at runtime which cannot enforce invariants at construction time.

With these insights, I've created a new settings API:

- A dataclass `Settings` without any methods.
- A `load_settings` function.

These symbols are re-exported at the top-level location now.

I've tried hard to retain backward compatibility at all levels including raised exceptions. The new settings API, on the other hand, raises only a custom exception `SettingsError` instead of Pydantic or PyYAML exceptions. I've also retained the tests for the deprecated settings API in the renamed `tests/test_settings_deprecated.py` file to ensure continued functionality, and added modified/extended tests for the new settings API.

WDYT, @pawamoy?