### PR TITLE
docs(api): remove deprecated `settings` and `types` modules from API reference

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -3,7 +3,3 @@
 ## ::: copier
 
 ### ::: copier.errors
-
-### ::: copier.settings
-
-### ::: copier.types


### PR DESCRIPTION
I've removed the deprecated `settings` and `types` modules from API reference.

Follow-up of #2069 and #2513 (f85a19f7d3090fad4439ca5e2d5f3a484a12861a).