### PR TITLE
fix(vcs): make Git version parsing robust to vendor-suffixed patch versions

### DIFF
--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -38,7 +38,7 @@ def get_git_version() -> Version:
     """Get the installed git version."""
     git = get_git()
 
-    return Version(re.findall(r"\d+\.\d+\.\d+", git("version"))[0])
+    return Version(re.findall(r"\d+\.\d+(?:\.\d+)?", git("version"))[0])
 
 
 GIT_PREFIX = ("git@", "git://", "git+", "https://github.com/", "https://gitlab.com/")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -2,6 +2,7 @@ import os
 import shutil
 from collections.abc import Callable, Iterator, Sequence
 from pathlib import Path
+from unittest import mock
 
 import pytest
 from packaging.version import Version
@@ -238,3 +239,21 @@ def test_select_latest_version_tag(
     assert (dst / filename).read_text() == "v1.0.1"
     answers = load_answersfile_data(dst)
     assert answers["_commit"] == "v1.0.1"
+
+
+@pytest.mark.parametrize(
+    ("git_version_output", "expected_version"),
+    [
+        ("git version 2.53.0\n", Version("2.53.0")),
+        ("git version 2.53.GIT\n", Version("2.53.0")),
+    ],
+)
+def test_get_git_version(git_version_output: str, expected_version: Version) -> None:
+    def _mock_git(*args: str) -> str:
+        assert args == ("version",)
+        return git_version_output
+
+    with mock.patch(
+        "copier._vcs.get_git", return_value=mock.MagicMock(side_effect=_mock_git)
+    ):
+        assert get_git_version() == expected_version


### PR DESCRIPTION
I've fixed a bug related to Git version parsing with vendor-suffixed patch versions. Git can report versions like 2.53.GIT, which caused `get_git_version()` to fail parsing the Git version.

I've updated the version extraction to normalize this output to a valid semantic version (for example, 2.53.0) and added tests covering both standard (2.53.0) and suffixed (2.53.GIT) Git version outputs.

Fixes #2537.