### PR TITLE
fix: only warn about dirty template when checking out `HEAD`

### DIFF
--- a/copier/_template.py
+++ b/copier/_template.py
@@ -24,7 +24,7 @@ from pydantic.dataclasses import dataclass
 
 from ._tools import copier_version, handle_remove_readonly
 from ._types import AnyByStrDict, VCSTypes
-from ._vcs import checkout_latest_tag, clone, get_git, get_repo
+from ._vcs import clone, get_git, get_latest_tag, get_repo
 from .errors import (
     InvalidConfigFileError,
     MultipleConfigFilesError,
@@ -564,9 +564,12 @@ class Template:
         """
         result = Path(self.url)
         if self.vcs == "git":
-            result = Path(clone(self.url_expanded, self.ref))
-            if self.ref is None:
-                checkout_latest_tag(result, self.use_prereleases)
+            result = Path(
+                clone(
+                    self.url_expanded,
+                    self.ref or get_latest_tag(self.url_expanded, self.use_prereleases),
+                )
+            )
         if not result.is_dir():
             raise ValueError("Local template must be a directory.")
         with suppress(OSError):

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -126,37 +126,39 @@ def get_repo(url: str) -> str | None:
     return None
 
 
-def checkout_latest_tag(local_repo: StrOrPath, use_prereleases: OptBool = False) -> str:
-    """Checkout latest git tag and check it out, sorted by PEP 440.
+def get_latest_tag(url: str, use_prereleases: OptBool = False) -> str:
+    """Get latest git tag, sorted by PEP 440.
 
-    Parameters:
-        local_repo:
-            A git repository in the local filesystem.
+    Args:
+        url:
+            Git-parseable URL of the repo. As returned by
+            [get_repo][copier.vcs.get_repo].
         use_prereleases:
             If `False`, skip prerelease git tags.
+
+    Returns:
+        The latest git tag, or `HEAD` if no valid tags are found.
     """
     git = get_git()
-    with local.cwd(local_repo):
-        all_tags = filter(valid_version, git("tag").split())
-        if not use_prereleases:
-            all_tags = filter(
-                lambda tag: not version.parse(tag).is_prerelease, all_tags
-            )
-        sorted_tags = sorted(all_tags, key=version.parse, reverse=True)
-        try:
-            latest_tag = str(sorted_tags[0])
-        except IndexError:
-            print(
-                colors.warn | "No git tags found in template; using HEAD as ref",
-                file=sys.stderr,
-            )
-            latest_tag = "HEAD"
-        git("checkout", "--force", latest_tag)
-        git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
-        return latest_tag
+    all_tags = (
+        tag.split("\t", 1)[1].removeprefix("refs/tags/")
+        for tag in git("ls-remote", "--tags", "--refs", url).splitlines()
+    )
+    all_tags = (tag for tag in all_tags if valid_version(tag))
+    if not use_prereleases:
+        all_tags = (tag for tag in all_tags if not version.parse(tag).is_prerelease)
+    sorted_tags = sorted(all_tags, key=version.parse, reverse=True)
+    try:
+        return str(sorted_tags[0])
+    except IndexError:
+        print(
+            colors.warn | "No git tags found in template; using HEAD as ref",
+            file=sys.stderr,
+        )
+        return "HEAD"
 
 
-def clone(url: str, ref: str | None = None) -> str:
+def clone(url: str, ref: str = "HEAD") -> str:
     """Clone repo into some temporary destination.
 
     Includes dirty changes for local templates by copying into a temp
@@ -190,7 +192,7 @@ def clone(url: str, ref: str | None = None) -> str:
     _clone()
     # Include dirty changes if checking out a local HEAD
     url_abspath = Path(url).absolute()
-    if ref in {None, "HEAD"} and url_abspath.is_dir():
+    if ref == "HEAD" and url_abspath.is_dir():
         is_dirty = False
         with local.cwd(url):
             is_dirty = bool(git("status", "--porcelain").strip())
@@ -215,7 +217,7 @@ def clone(url: str, ref: str | None = None) -> str:
         ## The `git checkout -f <ref>` command doesn't works when repo is local, dirty
         ## and core.fsmonitor is enabled
         ## ref: https://github.com/copier-org/copier/issues/1887
-        git("-c", "core.fsmonitor=false", "checkout", "-f", ref or "HEAD")
+        git("-c", "core.fsmonitor=false", "checkout", "-f", ref)
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
 
     return location

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -38,6 +38,43 @@ def test_copy(tmp_path_factory: pytest.TempPathFactory) -> None:
         assert bool(git("status", "--porcelain").strip())
 
 
+def test_copy_with_tag(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "tracked": "",
+            src / "untracked": "",
+        }
+    )
+    with local.cwd(src):
+        git("init")
+        git("add", "tracked")
+        git("commit", "-m1")
+        git("tag", "v1")
+    copier.run_copy(str(src), dst, vcs_ref=None)
+    assert (dst / "tracked").exists()
+    assert not (dst / "untracked").exists()
+
+
+def test_copy_with_tag_and_ref_head(tmp_path_factory: pytest.TempPathFactory) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "tracked": "",
+            src / "untracked": "",
+        }
+    )
+    with local.cwd(src):
+        git("init")
+        git("add", "tracked")
+        git("commit", "-m1")
+        git("tag", "v1")
+    with pytest.warns(DirtyLocalWarning):
+        copier.run_copy(str(src), dst, vcs_ref="HEAD")
+    assert (dst / "tracked").exists()
+    assert (dst / "untracked").exists()
+
+
 def test_copy_dirty_head(tmp_path_factory: pytest.TempPathFactory) -> None:
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
     build_file_tree(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -12,7 +12,7 @@ from pytest_gitconfig.plugin import GitConfig
 from copier import run_copy, run_update
 from copier._main import Worker
 from copier._user_data import load_answersfile_data
-from copier._vcs import checkout_latest_tag, clone, get_git_version, get_repo
+from copier._vcs import clone, get_git_version, get_latest_tag, get_repo
 from copier.errors import DirtyLocalWarning, ShallowCloneWarning
 
 from .helpers import build_file_tree, git, git_save
@@ -210,8 +210,7 @@ def test_invalid_version(tmp_path: Path) -> None:
         sample.write_text("3")
         git("commit", "-am3")
         assert git("describe", "--tags").strip() != "v2"
-        checkout_latest_tag(tmp_path)
-        assert git("describe", "--tags").strip() == "v2"
+        assert get_latest_tag(str(tmp_path)) == "v2"
 
 
 @pytest.mark.parametrize("sorter", [iter, reversed])


### PR DESCRIPTION
I've fixed an error related to raising a warning when dirty changes are included for project generation.

Before, `DirtyLocalWarning` was raised even when the project was generated from a tagged release of a local template, because the dirty-changes check ran before the target revision was resolved. Now the warning is only emitted when the revision that actually includes dirty changes (`HEAD`) is used.

Related to https://github.com/copier-org/copier/discussions/2546#discussioncomment-16097724.