### PR TITLE
chore(devcontainer): remove uv's virtual env path override

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,3 @@ COPY --chown=${DEVBOX_USER}:${DEVBOX_USER} devbox.lock devbox.lock
 
 # Install the Devbox environment
 RUN devbox install && nix-store --gc
-
-# Configure the project's virtual env path to be outside the mounted workspace
-# to avoid conflicts with the host env.
-ENV UV_PROJECT_ENVIRONMENT=/code/.venv


### PR DESCRIPTION
I've removed uv's virtual env path override environment variable from the dev container's `Dockerfile`. This path and the path specified via `python.defaultInterpreterPath` weren't aligned, and setting `python.defaultInterpreterPath` to `/code/.venv` causes some problems for VS Code to discover the virtual env there – I'm not exactly sure why.