### PR TITLE
refactor: make `YieldExtension` self-contained

### DIFF
--- a/copier/_jinja_ext.py
+++ b/copier/_jinja_ext.py
@@ -3,76 +3,75 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
+from weakref import WeakKeyDictionary
 
-from jinja2 import nodes
+from jinja2 import Environment, nodes
 from jinja2.exceptions import UndefinedError
 from jinja2.ext import Extension
 from jinja2.parser import Parser
-from jinja2.sandbox import SandboxedEnvironment
 
 from copier.errors import MultipleYieldTagsError
 
 
-class YieldEnvironment(SandboxedEnvironment):
-    """Jinja2 environment with attributes from the YieldExtension.
+@dataclass
+class YieldContext:
+    yield_name: str | None = None
+    yield_iterable: Iterable[Any] | None = None
 
-    This is simple environment class that extends the SandboxedEnvironment
-    for use with the YieldExtension, mainly for avoiding type errors.
 
-    We use the SandboxedEnvironment because we want to minimize the risk of hidden
-    malware in the templates. Of course we still have the post-copy tasks to worry
-    about, but at least they are more visible to the final user.
-    """
+_yield_contexts: WeakKeyDictionary[Environment, YieldContext] = WeakKeyDictionary()
 
-    yield_name: str | None
-    yield_iterable: Iterable[Any] | None
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        super().__init__(*args, **kwargs)
-        self.extend(yield_name=None, yield_iterable=None)
+def get_yield_context(env: Environment) -> YieldContext:
+    """Get or create yield context for an environment."""
+    if env not in _yield_contexts:
+        _yield_contexts[env] = YieldContext()
+    return _yield_contexts[env]
 
 
 class YieldExtension(Extension):
     """Jinja2 extension for the `yield` tag.
 
-    If `yield` tag is used in a template, this extension sets following attribute to the
-    jinja environment:
+    If `yield` tag is used in a template, this extension stores the yield context
+    which can be accessed via `get_yield_context(env)`:
 
     - `yield_name`: The name of the variable that will be yielded.
     - `yield_iterable`: The variable that will be looped over.
 
-    Note that this extension just sets the attributes but renders templates as usual.
-    It is the caller's responsibility to use the `yield_context` attribute in the
-    template to generate the desired output.
+    Note that this extension just sets the context but renders templates as usual.
+    It is the caller's responsibility to use the yield context to generate the
+    desired output.
 
     !!! example
 
         ```pycon
-        >>> from copier.jinja_ext import YieldEnvironment, YieldExtension
-        >>> env = YieldEnvironment(extensions=[YieldExtension])
+        >>> from jinja2.sandbox import SandboxedEnvironment
+        >>> from copier._jinja_ext import YieldExtension, get_yield_context
+        >>> env = SandboxedEnvironment(extensions=[YieldExtension])
         >>> template = env.from_string(
         ...     "{% yield single_var from looped_var %}{{ single_var }}{% endyield %}"
         ... )
         >>> template.render({"looped_var": [1, 2, 3]})
         ''
-        >>> env.yield_name
+        >>> get_yield_context(env).yield_name
         'single_var'
-        >>> env.yield_iterable
+        >>> get_yield_context(env).yield_iterable
         [1, 2, 3]
         ```
     """
 
     tags = {"yield"}
 
-    environment: YieldEnvironment
-
     def preprocess(
-        self, source: str, _name: str | None, _filename: str | None = None
+        self, source: str, name: str | None, filename: str | None = None
     ) -> str:
-        """Preprocess hook to reset attributes before rendering."""
-        self.environment.yield_name = self.environment.yield_iterable = None
-
+        """Preprocess hook to reset context before rendering."""
+        _ = name, filename
+        ctx = get_yield_context(self.environment)
+        ctx.yield_name = None
+        ctx.yield_iterable = None
         return source
 
     def parse(self, parser: Parser) -> nodes.Node:
@@ -100,27 +99,23 @@ class YieldExtension(Extension):
     ) -> str:
         """Support function for the yield tag.
 
-        Sets the `yield_name` and `yield_iterable` attributes in the environment then
+        Sets the `yield_name` and `yield_iterable` in the yield context then
         calls the provided caller function. If an UndefinedError is raised, it returns
         an empty string.
         """
-        if (
-            self.environment.yield_name is not None
-            or self.environment.yield_iterable is not None
-        ):
+        ctx = get_yield_context(self.environment)
+        if ctx.yield_name is not None or ctx.yield_iterable is not None:
             raise MultipleYieldTagsError(
                 "Attempted to parse the yield tag twice. Only one yield tag is allowed per path name.\n"
-                f'A yield tag with the name: "{self.environment.yield_name}" and iterable: "{self.environment.yield_iterable}" already exists.'
+                f'A yield tag with the name: "{ctx.yield_name}" and iterable: "{ctx.yield_iterable}" already exists.'
             )
 
-        self.environment.yield_name = yield_name
-        self.environment.yield_iterable = yield_iterable
+        ctx.yield_name = yield_name
+        ctx.yield_iterable = yield_iterable
 
         try:
             res = caller()
 
-        # expression like `dict.attr` will always raise UndefinedError
-        # so we catch it here and return an empty string
         except UndefinedError:
             res = ""
 

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -31,6 +31,7 @@ from typing import (
 from unicodedata import normalize
 
 from jinja2.loaders import FileSystemLoader
+from jinja2.sandbox import SandboxedEnvironment
 from packaging.version import Version
 from pathspec import PathSpec, __version__ as pathspec_version
 from plumbum import ProcessExecutionError, colors
@@ -40,7 +41,7 @@ from pydantic.dataclasses import dataclass
 from pydantic_core import to_jsonable_python
 from questionary import confirm, unsafe_prompt
 
-from ._jinja_ext import YieldEnvironment, YieldExtension
+from ._jinja_ext import YieldExtension, get_yield_context
 from ._settings import Settings, SettingsModel, is_trusted_repository
 from ._subproject import Subproject
 from ._template import Task, Template
@@ -651,7 +652,7 @@ class Worker:
         return tuple(chain(self.skip_if_exists, self.template.skip_if_exists))
 
     @cached_property
-    def jinja_env(self) -> YieldEnvironment:
+    def jinja_env(self) -> SandboxedEnvironment:
         """Return a pre-configured Jinja environment.
 
         Respects template settings.
@@ -664,7 +665,7 @@ class Worker:
         ]
         extensions = default_extensions + list(self.template.jinja_extensions)
         try:
-            env = YieldEnvironment(
+            env = SandboxedEnvironment(
                 loader=loader, extensions=extensions, **self.template.envops
             )
         except ModuleNotFoundError as error:
@@ -800,7 +801,7 @@ class Worker:
                 new_content = tpl.render(
                     **self._render_context(), **(extra_context or {})
                 ).encode()
-                if self.jinja_env.yield_name:
+                if get_yield_context(self.jinja_env).yield_name:
                     raise YieldTagInFileError(
                         f"File {src_relpath} contains a yield tag, but it is not allowed."
                     )
@@ -937,9 +938,10 @@ class Worker:
         # name and iterable
         rendered_part = self._render_string(part, extra_context=extra_context)
 
-        yield_name = self.jinja_env.yield_name
+        ctx = get_yield_context(self.jinja_env)
+        yield_name = ctx.yield_name
         if yield_name:
-            for value in self.jinja_env.yield_iterable or ():
+            for value in ctx.yield_iterable or ():
                 new_context = {**extra_context, yield_name: value}
                 rendered_part = self._render_string(part, extra_context=new_context)
                 rendered_part = self._adjust_rendered_part(rendered_part)


### PR DESCRIPTION
I've refactored the Jinja code related to the extension providing the `{% yield %}` tag for looping over lists to generate files and directories.

The `YieldEnvironment` class created tight coupling between the environment and extension, requiring a dedicated subclass to use the yield tag feature. This violated Jinja2's extension design where extensions should be composable and work with any environment.

Now, the yield context is stored externally using a dataclass with weak references to the environment. This eliminates the need for a custom environment class and improves type safety.