### PR TITLE
fix(extensions): ensure trusted/safe templates extensions are seen during update or copy with `--vcs-ref`

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -657,8 +657,14 @@ class Worker:
 
         Respects template settings.
         """
-        paths = [str(self.template.local_abspath)]
-        loader = FileSystemLoader(paths)
+        template_path = str(self.template.local_abspath)
+        loader = FileSystemLoader([template_path])
+        # Add template directory to sys.path so that template-local Python packages
+        # are importable as or by Jinja extensions and their transitive imports.
+        if template_path not in sys.path and (
+            self.unsafe or is_trusted_repository(self.settings.trust, self.template.url)
+        ):
+            sys.path.insert(0, template_path)
         default_extensions = [
             "jinja2_ansible_filters.AnsibleCoreFiltersExtension",
             YieldExtension,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,3 +119,9 @@ def settings_path(config_path: Path) -> Path:
     config_path.mkdir()
     settings_path = config_path / "settings.yml"
     return settings_path
+
+
+@pytest.fixture(autouse=True)
+def sys_path_cleanup(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Ensure that `sys.path` is restored after each test
+    monkeypatch.setattr("sys.path", [*sys.path])

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,5 +1,4 @@
 import json
-import sys
 from pathlib import Path
 from uuid import uuid4
 
@@ -12,7 +11,7 @@ from .helpers import build_file_tree, git_save
 
 
 def test_no_path_variables(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+    tmp_path_factory: pytest.TempPathFactory,
 ) -> None:
     """Test that there are no context variables of type `pathlib.Path`."""
     src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
@@ -60,7 +59,6 @@ def test_no_path_variables(
             src / "test.txt.jinja": "{{ __assert() | default('', true) }}",
         }
     )
-    monkeypatch.setattr("sys.path", [str(src), *sys.path])
     copier.run_copy(str(src), dst, unsafe=True)
     assert (dst / "test.txt").read_text("utf-8") == ""
 

--- a/tests/test_jinja2_extensions.py
+++ b/tests/test_jinja2_extensions.py
@@ -5,10 +5,11 @@ from typing import Any
 import pytest
 from jinja2 import Environment
 from jinja2.ext import Extension
+from plumbum import local
 
 import copier
 
-from .helpers import PROJECT_TEMPLATE, build_file_tree
+from .helpers import PROJECT_TEMPLATE, build_file_tree, git_save
 
 
 class FilterExtension(Extension):
@@ -34,6 +35,39 @@ class GlobalsExtension(Extension):
 
         environment.globals.update(super_func=super_func)
         environment.globals.update(super_var="super var!")
+
+
+@pytest.fixture
+def template_with_extension(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    src = tmp_path_factory.mktemp("src")
+    build_file_tree(
+        {
+            src / "extensions" / "__init__.py": "",
+            src / "extensions" / "data.py": """\
+                DATA_VALUE = "hello from data module"
+                """,
+            src / "extensions" / "filters.py": """\
+                from jinja2 import Environment
+                from jinja2.ext import Extension
+
+                from extensions import data
+
+
+                class DataFilter(Extension):
+                    def __init__(self, environment: Environment) -> None:
+                        super().__init__(environment)
+                        environment.filters["data_value"] = lambda _: data.DATA_VALUE
+                """,
+            src / "copier.yml": """\
+                _jinja_extensions:
+                    - extensions.filters.DataFilter
+                """,
+            src
+            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+            src / "result.txt.jinja": "{{ '' | data_value }}",
+        }
+    )
+    return src
 
 
 def test_default_jinja2_extensions(tmp_path: Path) -> None:
@@ -64,3 +98,44 @@ def test_to_json_filter_with_conf(tmp_path_factory: pytest.TempPathFactory) -> N
     assert conf_file.exists()
     # must not raise an error
     assert json.loads(conf_file.read_text())
+
+
+def test_extension_from_copy_with_vcs_ref(
+    template_with_extension: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    dst = tmp_path_factory.mktemp("dst")
+    with local.cwd(template_with_extension):
+        git_save(tag="1.0.0")
+    copier.run_copy(str(template_with_extension), dst, unsafe=True, vcs_ref="HEAD")
+    result = dst / "result.txt"
+    assert result.exists()
+    assert result.read_text() == "hello from data module"
+
+
+def test_extension_on_update(
+    template_with_extension: Path, tmp_path_factory: pytest.TempPathFactory
+) -> None:
+    dst = tmp_path_factory.mktemp("dst")
+    with local.cwd(template_with_extension):
+        git_save(tag="1.0.0")
+    # Initial copy
+    copier.run_copy(
+        str(template_with_extension),
+        dst,
+        unsafe=True,
+        vcs_ref="1.0.0",
+        defaults=True,
+        overwrite=True,
+    )
+    assert (dst / "result.txt").read_text() == "hello from data module"
+    with local.cwd(dst):
+        git_save()
+    # Add a new file in v2 (extension stays the same)
+    build_file_tree({template_with_extension / "v2.txt": "new in v2"})
+    with local.cwd(template_with_extension):
+        git_save(tag="2.0.0")
+    # Run update — extension should work because template is trusted
+    copier.run_update(dst, unsafe=True, defaults=True, overwrite=True)
+    # Extension still works during update rendering
+    assert (dst / "result.txt").read_text() == "hello from data module"
+    assert (dst / "v2.txt").read_text() == "new in v2"


### PR DESCRIPTION
Hello 👋🏼 

This PR fix a regression on template extensions.
When a template provides some extensions, they are not on `sys.path` anymore when:
- using `copy` with `--vcs-ref`
- using `update`

It fails with the following error (for a `extensions` package in the template directory)

```shell
Copier could not load some Jinja extensions:
No module named 'extensions'
Make sure to install these extensions alongside copier itself.
```

I can't say precisely in what version it broke, but it was working on Copier 9.3, 9.4 (I think it worked in 9.10) and not anymore since `9.12`.

This PR fix this by explicitely adding the template path to `sys.path` when the template is trusted.