### PR TITLE
chore: use `rumdl` as Markdown formatter and linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,18 @@ repos:
         language: system
         types: [toml]
         require_serial: true
+
+      - id: rumdl
+        name: rumdl
+        entry: uv run rumdl check --fix
+        language: system
+        types: [markdown]
+        require_serial: true
+        exclude: |
+          (?x)(
+            # Those files have wrong syntax and would fail
+            ^tests/demo_invalid/copier\.yml$|
+            ^tests/demo_transclude_invalid(_multi)?/demo/copier\.yml$|
+            # HACK https://github.com/prettier/prettier/issues/9430
+            ^tests/demo
+          )

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# Markdown is formatted by `rumdl`
+*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,563 +8,563 @@ the changelog itself conforms to [Keep A Changelog](https://keepachangelog.com/)
 
 ### Feat
 
--   **cli**: add `--answers-file` flag to `check-update` command
+- **cli**: add `--answers-file` flag to `check-update` command
 
 ### Fix
 
--   only warn about dirty template when checking out `HEAD`
--   **cli**: show only supported flags in `check-update` command help output
+- only warn about dirty template when checking out `HEAD`
+- **cli**: show only supported flags in `check-update` command help output
 
 ## v9.13.1 (2026-03-09)
 
 ### Fix
 
--   **vcs**: make Git version parsing robust to vendor-suffixed patch versions
+- **vcs**: make Git version parsing robust to vendor-suffixed patch versions
 
 ## v9.13.0 (2026-03-05)
 
 ### Feat
 
--   add CLI subcommand `check-update` to check for new template version (#2463)
+- add CLI subcommand `check-update` to check for new template version (#2463)
 
 ### Refactor
 
--   **cli**: call public `run_*` functions instead of internal `Worker.run_*` methods
+- **cli**: call public `run_*` functions instead of internal `Worker.run_*` methods
 
 ## v9.12.0 (2026-02-21)
 
 ### Feat
 
--   add new settings API with minimal surface
--   re-export `Phase` enum at package level
+- add new settings API with minimal surface
+- re-export `Phase` enum at package level
 
 ### Fix
 
--   **updating**: apply skip-if-exists patterns as gitignore-style at subproject root in
+- **updating**: apply skip-if-exists patterns as gitignore-style at subproject root in
     update algorithm
--   **updating**: anchor removed file paths to project root in update algorithm
--   **updating**: normalize user-deleted paths before skip-if-exists pattern matching
+- **updating**: anchor removed file paths to project root in update algorithm
+- **updating**: normalize user-deleted paths before skip-if-exists pattern matching
     during updates
 
 ### Refactor
 
--   **typing**: use builtin types in public API signatures
--   deprecate public `settings` module and its symbols
--   replace `**kwargs` with explicit parameters in `run_{copy,recopy,update}` functions
+- **typing**: use builtin types in public API signatures
+- deprecate public `settings` module and its symbols
+- replace `**kwargs` with explicit parameters in `run_{copy,recopy,update}` functions
 
 ## v9.11.3 (2026-01-23)
 
 ### Fix
 
--   **updating**: include non-question answers when generating fresh copy of new
+- **updating**: include non-question answers when generating fresh copy of new
     template
--   **updating**: ignore Git hooks on internal checkout before 3-way merging file with
+- **updating**: ignore Git hooks on internal checkout before 3-way merging file with
     conflicts (#2432)
--   avoid pattern deprecation warning for `pathspec` v1.0.0+
+- avoid pattern deprecation warning for `pathspec` v1.0.0+
 
 ## v9.11.2 (2026-01-20)
 
 ### Fix
 
--   **updating**: restore support for preserved symlinks pointing outside subproject
+- **updating**: restore support for preserved symlinks pointing outside subproject
     (#2427)
 
 ### Security
 
--   disallow symlink-based includes outside template root
--   disallow symlink-following write operations outside destination directory (#2427)
+- disallow symlink-based includes outside template root
+- disallow symlink-following write operations outside destination directory (#2427)
 
 ## v9.11.1 (2026-01-10)
 
 ### Fix
 
--   **updating**: avoid circular reference when rendering JSON-serialized `_copier_conf`
+- **updating**: avoid circular reference when rendering JSON-serialized `_copier_conf`
     variable
 
 ## v9.11.0 (2025-11-20)
 
 ### Feat
 
--   **updating**: allow updating a dirty Git repository when the subproject directory is
+- **updating**: allow updating a dirty Git repository when the subproject directory is
     clean (#2369)
--   add support for custom question icons (#2381)
--   add support for conditionally unsetting a question's default value
+- add support for custom question icons (#2381)
+- add support for conditionally unsetting a question's default value
 
 ### Fix
 
--   raise warning instead of error when `chmod` is not allowed
--   fix using default answers from settings for required questions (#2374)
+- raise warning instead of error when `chmod` is not allowed
+- fix using default answers from settings for required questions (#2374)
 
 ### Refactor
 
--   drop support for Python 3.9
+- drop support for Python 3.9
 
 ## v9.10.3 (2025-10-17)
 
 ### Fix
 
--   **updating**: render templated skip-if-exists patterns before applying patch with
+- **updating**: render templated skip-if-exists patterns before applying patch with
     excluded paths
--   **updating**: exclude only Git-ignored files when applying patch
--   **updating**: ignore paths added to the `_exclude` list in new template version when
+- **updating**: exclude only Git-ignored files when applying patch
+- **updating**: ignore paths added to the `_exclude` list in new template version when
     updating
 
 ## v9.10.2 (2025-09-09)
 
 ### Fix
 
--   **deps**: remove prompt-toolkit version cap
+- **deps**: remove prompt-toolkit version cap
 
 ## v9.10.1 (2025-08-28)
 
 ### Fix
 
--   **deps**: cap prompt-toolkit to <3.0.52
+- **deps**: cap prompt-toolkit to <3.0.52
 
 ## v9.10.0 (2025-08-26)
 
 ### Feat
 
--   add support for nested multi-document includes in `copier.yml` (#2251)
+- add support for nested multi-document includes in `copier.yml` (#2251)
 
 ### Fix
 
--   disable default answer validator for secret questions
+- disable default answer validator for secret questions
 
 ## v9.9.1 (2025-08-18)
 
 ### Security
 
--   disallow render paths outside destination directory
--   cast Jinja context path variables to `pathlib.PurePath`
+- disallow render paths outside destination directory
+- cast Jinja context path variables to `pathlib.PurePath`
 
 ## v9.9.0 (2025-08-01)
 
 ### Feat
 
--   add support for prompting filesystem paths (#2210)
+- add support for prompting filesystem paths (#2210)
 
 ### Fix
 
--   **updating**: disable secret question validator when replaying old copy
--   **vcs**: fix cloning local dirty template repo when `core.fsmonitor=true` (#2151)
+- **updating**: disable secret question validator when replaying old copy
+- **vcs**: fix cloning local dirty template repo when `core.fsmonitor=true` (#2151)
 
 ## v9.8.0 (2025-07-07)
 
 ### Feat
 
--   add support for providing serialized answers to multiselect choice questions
--   **updating**: add VCS ref sentinel `:current:` for referring to the current template
+- add support for providing serialized answers to multiselect choice questions
+- **updating**: add VCS ref sentinel `:current:` for referring to the current template
     ref
 
 ### Fix
 
--   avoid infinite recursion when accessing `_copier_conf.answers_file` via Jinja
+- avoid infinite recursion when accessing `_copier_conf.answers_file` via Jinja
     context hook
--   validate default answers
--   correct git stage order on merge conflicts
+- validate default answers
+- correct git stage order on merge conflicts
 
 ## v9.7.1 (2025-04-23)
 
 ### Refactor
 
--   import from module `_tools` instead of `tools`
+- import from module `_tools` instead of `tools`
 
 ## v9.7.0 (2025-04-22)
 
 ### Feat
 
--   raise new `TaskError` exception on task errors
--   raise `InteractiveSessionError` when prompting in non-interactive environment
+- raise new `TaskError` exception on task errors
+- raise `InteractiveSessionError` when prompting in non-interactive environment
 
 ### Fix
 
--   **settings**: use `<CONFIG_ROOT>/copier` as settings directory on Windows (#2071)
--   **updating**: ignore last answer of `when: false` questions
--   restore access to full rendering context in prompt phase
+- **settings**: use `<CONFIG_ROOT>/copier` as settings directory on Windows (#2071)
+- **updating**: ignore last answer of `when: false` questions
+- restore access to full rendering context in prompt phase
 
 ### Refactor
 
--   re-expose API with deprecation warnings on non-public API imports
--   rename internal modules with a `_` prefix
+- re-expose API with deprecation warnings on non-public API imports
+- rename internal modules with a `_` prefix
 
 ## v9.6.0 (2025-03-09)
 
 ### Feat
 
--   Add `_copier_operation` variable (#1733)
--   **context**: expose a `_copier_phase` context variable
+- Add `_copier_operation` variable (#1733)
+- **context**: expose a `_copier_phase` context variable
 
 ### Fix
 
--   explicitly specify file encoding for windows (#2007)
--   auto-detect encoding when reading external data file
--   **settings**: auto-detect encoding when reading settings file
--   **cli**: auto-detect encoding when reading unicode-encoded file specified with
+- explicitly specify file encoding for windows (#2007)
+- auto-detect encoding when reading external data file
+- **settings**: auto-detect encoding when reading settings file
+- **cli**: auto-detect encoding when reading unicode-encoded file specified with
     `--data-file`
--   expose only answers in question rendering context
--   ignore `$file` if `$file.tmpl` exists when subdirectory is used
--   decode external data file content explicitly as UTF-8
--   decode answers file content explicitly as UTF-8
+- expose only answers in question rendering context
+- ignore `$file` if `$file.tmpl` exists when subdirectory is used
+- decode external data file content explicitly as UTF-8
+- decode answers file content explicitly as UTF-8
 
 ### Refactor
 
--   use common answers file loader
+- use common answers file loader
 
 ## v9.5.0 (2025-02-17)
 
 ### Feat
 
--   **external_data**: load data from other YAML files
--   **settings**: allow to define some trusted repositories or prefixes
--   **settings**: add user settings support with `defaults` values (fix #235)
--   add dynamic file structures in loop using yield-tag (#1855)
--   add support for dynamic choices
+- **external_data**: load data from other YAML files
+- **settings**: allow to define some trusted repositories or prefixes
+- **settings**: add user settings support with `defaults` values (fix #235)
+- add dynamic file structures in loop using yield-tag (#1855)
+- add support for dynamic choices
 
 ### Fix
 
--   correctly record missing stages in index for merge conflicts (#1907)
--   allow importing from a file that has a conditional name
--   **updating**: don't crash when file is removed from template's `.gitignore` file
+- correctly record missing stages in index for merge conflicts (#1907)
+- allow importing from a file that has a conditional name
+- **updating**: don't crash when file is removed from template's `.gitignore` file
     (#1886)
--   **deps**: update dependency packaging to v24.2
--   re-render answers file path when producing render context
--   restore compatibility with Git prior to v2.31 (#1838)
--   **updating**: don't validate computed values
--   Don't mark files without conflict markers as unmerged (#1813)
+- **deps**: update dependency packaging to v24.2
+- re-render answers file path when producing render context
+- restore compatibility with Git prior to v2.31 (#1838)
+- **updating**: don't validate computed values
+- Don't mark files without conflict markers as unmerged (#1813)
 
 ## v9.4.1 (2024-10-18)
 
 ### Fix
 
--   restore support for `preserve_symlinks: false` for directories (#1820)
+- restore support for `preserve_symlinks: false` for directories (#1820)
 
 ## v9.4.0 (2024-10-15)
 
 ### Fix
 
--   **exclude**: support negative exclude matching child of excluded parent
--   parse new answer when `--skip-answered` is used
--   validate answers to secret questions
--   **updating**: do not recreate deleted paths on update (#1719)
--   support Git config without user identity
+- **exclude**: support negative exclude matching child of excluded parent
+- parse new answer when `--skip-answered` is used
+- validate answers to secret questions
+- **updating**: do not recreate deleted paths on update (#1719)
+- support Git config without user identity
 
 ### Refactor
 
--   set default value for `keep_trailing_newline` more idiomatically
--   drop support for Python 3.8
+- set default value for `keep_trailing_newline` more idiomatically
+- drop support for Python 3.8
 
 ### Perf
 
--   **updating**: avoid creating subproject copy
+- **updating**: avoid creating subproject copy
 
 ## v9.3.1 (2024-07-03)
 
 ### Fix
 
--   pass `--skip-tasks` flag to worker (#1688)
+- pass `--skip-tasks` flag to worker (#1688)
 
 ## v9.3.0 (2024-07-01)
 
 ### Feat
 
--   add simpler migrations configuration syntax (#1510)
+- add simpler migrations configuration syntax (#1510)
 
 ### Fix
 
--   **tasks**: do not consider unsafe if they are being skipped
--   add context information to answer validation error message (#1609)
--   do not overwrite identical files (#1576)
--   **updating**: unset invalid last answers
--   render `default` list items for multi-select choice questions
--   **updating**: yield merge conflict when both template and project add same file
+- **tasks**: do not consider unsafe if they are being skipped
+- add context information to answer validation error message (#1609)
+- do not overwrite identical files (#1576)
+- **updating**: unset invalid last answers
+- render `default` list items for multi-select choice questions
+- **updating**: yield merge conflict when both template and project add same file
 
 ## v9.2.0 (2024-04-04)
 
 ### Feat
 
--   **tasks**: add support for skipping tasks (#1561)
--   add support for validating multi-select choice answers
+- **tasks**: add support for skipping tasks (#1561)
+- add support for validating multi-select choice answers
 
 ### Fix
 
--   ignore empty YAML documents in `copier.yml`
--   preserve choices order in answers to multi-select choice questions
--   **exclude**: apply exclude matcher to rendered path
+- ignore empty YAML documents in `copier.yml`
+- preserve choices order in answers to multi-select choice questions
+- **exclude**: apply exclude matcher to rendered path
 
 ### Refactor
 
--   drop `pyyaml-include` dependency and reimplement relevant features
+- drop `pyyaml-include` dependency and reimplement relevant features
 
 ### Perf
 
--   apply `PERF` lint rules fixes (#1556)
+- apply `PERF` lint rules fixes (#1556)
 
 ## v9.1.1 (2024-01-16)
 
 ### Fix
 
--   don't fail in systems with windows 1252 encoding (probably)
--   skip excluded paths before rendering
+- don't fail in systems with windows 1252 encoding (probably)
+- skip excluded paths before rendering
 
 ## v9.1.0 (2023-11-27)
 
 ### Feat
 
--   Conflicts on updates now appear as git merge conflicts, also on VSCode
--   **choices**: support questionary checkbox for multiple choices using
+- Conflicts on updates now appear as git merge conflicts, also on VSCode
+- **choices**: support questionary checkbox for multiple choices using
     `multiselect: true`.
 
 ### Fix
 
--   mark package as typed
--   Normalize paths obtained from Git commands output
--   don't crash when update replaces file with symlink (or vice versa) (#1409)
--   keep git-ignored files on update (#1373)
--   address deprecation warning in `shutil.rmtree(onerror=...)` (#1401)
+- mark package as typed
+- Normalize paths obtained from Git commands output
+- don't crash when update replaces file with symlink (or vice versa) (#1409)
+- keep git-ignored files on update (#1373)
+- address deprecation warning in `shutil.rmtree(onerror=...)` (#1401)
 
 ## v9.0.1 (2023-10-30)
 
 ### Fix
 
--   don't produce output when imported with `$FORCE_COLOR=1` env
+- don't produce output when imported with `$FORCE_COLOR=1` env
 
 ## v9.0.0 (2023-10-22)
 
 ### BREAKING CHANGE
 
--   Changes the return code for unsafe template error from 2 to 4 to avoid return code
+- Changes the return code for unsafe template error from 2 to 4 to avoid return code
     collision with Plumbum's `SwitchError` type errors which use return code 2.
 
 ### Feat
 
--   allow overriding data file with CLI arguments (#1332)
--   **cli**: read answers from yaml file (#1325)
+- allow overriding data file with CLI arguments (#1332)
+- **cli**: read answers from yaml file (#1325)
 
 ### Fix
 
--   **vcs**: prevent local clone from being stuck by gpg prompts (#1360)
--   **pydantic**: compatible with 2.4+, solving `FieldValidationInfo` warning (#1342)
--   fix answer validation for `type: str` questions
--   version guess from tags that don't start with `v`, but are still PEP440 compliant
+- **vcs**: prevent local clone from being stuck by gpg prompts (#1360)
+- **pydantic**: compatible with 2.4+, solving `FieldValidationInfo` warning (#1342)
+- fix answer validation for `type: str` questions
+- version guess from tags that don't start with `v`, but are still PEP440 compliant
     (#1048)
--   **cli**: use return code 4 for unsafe template error
--   **nix**: detect build version appropriately
+- **cli**: use return code 4 for unsafe template error
+- **nix**: detect build version appropriately
 
 ## v8.3.0 (2023-09-05)
 
 ### Feat
 
--   add `-A` as an alias for `--skip-answered`, and support it in `recopy` too
--   add `--skip-answered` flag to avoid repeating recorded answers
+- add `-A` as an alias for `--skip-answered`, and support it in `recopy` too
+- add `--skip-answered` flag to avoid repeating recorded answers
 
 ### Fix
 
--   **recopy**: never clone old template (even less if it's just for cleanup)
+- **recopy**: never clone old template (even less if it's just for cleanup)
 
 ## v8.2.0 (2023-08-28)
 
 ### Feat
 
--   release on FlakeHub.com too
--   add support for pre-update and post-update messages (#1288)
--   add support for pre-copy and post-copy messages
+- release on FlakeHub.com too
+- add support for pre-update and post-update messages (#1288)
+- add support for pre-copy and post-copy messages
 
 ### Fix
 
--   do not immediately fail if git is not available
--   provide more clarification in unsafe error message (#1280)
--   clean up tmp dir
--   don't lie about updated files
--   require default value for secret question
--   fix answer validation against conditional choices with duplicate values
+- do not immediately fail if git is not available
+- provide more clarification in unsafe error message (#1280)
+- clean up tmp dir
+- don't lie about updated files
+- require default value for secret question
+- fix answer validation against conditional choices with duplicate values
 
 ### Refactor
 
--   drop support for Python 3.7 (#1252)
+- drop support for Python 3.7 (#1252)
 
 ## v8.1.0 (2023-07-10)
 
 ### Feat
 
--   add support for computed values via skipped questions (#1220)
--   add `--trust` as a less scary alternative to `--UNSAFE` (#1179)
--   add OS identifier to render context
+- add support for computed values via skipped questions (#1220)
+- add `--trust` as a less scary alternative to `--UNSAFE` (#1179)
+- add OS identifier to render context
 
 ### Fix
 
--   **pydantic**: add upper dependency bound to fix unlocked installations
+- **pydantic**: add upper dependency bound to fix unlocked installations
 
 ### Refactor
 
--   request answers imperatively instead of implicitly via impure property
+- request answers imperatively instead of implicitly via impure property
 
 ## v8.0.0 (2023-06-04)
 
 ### BREAKING CHANGE
 
--   Updates will overwrite existing files always. If you need to select only some files,
+- Updates will overwrite existing files always. If you need to select only some files,
     just use `git mergetool` or `git difftool` after updating.
--   Flag `--overwrite/-w` disappeared from `copier update`. It is now implicit.
--   To update via API, `overwrite=True` is now required.
--   The default update conflict mode is now `inline` instead of `rej`.
--   By default, updates now consider 3 lines of context instead of just 1.
--   All CLI calls to Copier must now include the subcommand as the 1st argument. For
+- Flag `--overwrite/-w` disappeared from `copier update`. It is now implicit.
+- To update via API, `overwrite=True` is now required.
+- The default update conflict mode is now `inline` instead of `rej`.
+- By default, updates now consider 3 lines of context instead of just 1.
+- All CLI calls to Copier must now include the subcommand as the 1st argument. For
     example, `copier` must become now `copier update`; also `copier ./tpl ./dst` must
     become `copier copy ./tpl ./dst`.
--   All flags must go after the subcommand now. For example,
+- All flags must go after the subcommand now. For example,
     `copier -r HEAD update ./dst` must now become `copier update -r HEAD ./dst` or
     `copier update ./dst -r HEAD`.
--   Automatic mode removed. Since now subcommands are required, the automatic mode is
+- Automatic mode removed. Since now subcommands are required, the automatic mode is
     removed.
--   Deprecated `copier.copy` function is removed. Use `copier.run_copy`,
+- Deprecated `copier.copy` function is removed. Use `copier.run_copy`,
     `copier.run_update` or `copier.run_recopy` explicitly as needed.
--   default values must be of the same type than the question.
+- default values must be of the same type than the question.
 
 ### Feat
 
--   disable unsafe features by default and add `--UNSAFE` switch (#1171)
--   basic nixpkgs overlay
--   add `recopy` command and function
--   support conditional choices (#1010)
--   validate default values (#1075)
+- disable unsafe features by default and add `--UNSAFE` switch (#1171)
+- basic nixpkgs overlay
+- add `recopy` command and function
+- support conditional choices (#1010)
+- validate default values (#1075)
 
 ### Fix
 
--   explain better why an answer casting fails
--   **cli**: display subcommand args meaning
--   preserver recursive symlinks
--   work around Pydantic bug when parsing choices
--   skip validating question and generating its default value when its skip condition is
+- explain better why an answer casting fails
+- **cli**: display subcommand args meaning
+- preserver recursive symlinks
+- work around Pydantic bug when parsing choices
+- skip validating question and generating its default value when its skip condition is
     met
 
 ### Refactor
 
--   overwrite always on updates
--   **update**: default to inline markers and 3 lines of context
--   remove unused local overrides to answers
+- overwrite always on updates
+- **update**: default to inline markers and 3 lines of context
+- remove unused local overrides to answers
 
 ## v7.2.0 (2023-04-19)
 
 ### Feat
 
--   customizable update accuracy
+- customizable update accuracy
 
 ### Fix
 
--   fix using a branch name as VCS ref
--   answer validation for question with complex choices (#1110)
+- fix using a branch name as VCS ref
+- answer validation for question with complex choices (#1110)
 
 ## v7.1.0 (2023-04-07)
 
 ### Feat
 
--   include git in flake app
--   support preserving symlinks when copying templates (#938)
--   allow imports in inline templates (#986)
--   properly support update in repo subdirectory (#1069)
--   allow templating `_answers_file` setting (#1027)
--   let answers file exist in a subdirectory
--   validate answers given via CLI/API
--   exclude nothing by default when using subdirectory
--   add native OS directory separator variable in `_copier_conf.sep` to allow generating
+- include git in flake app
+- support preserving symlinks when copying templates (#938)
+- allow imports in inline templates (#986)
+- properly support update in repo subdirectory (#1069)
+- allow templating `_answers_file` setting (#1027)
+- let answers file exist in a subdirectory
+- validate answers given via CLI/API
+- exclude nothing by default when using subdirectory
+- add native OS directory separator variable in `_copier_conf.sep` to allow generating
     dynamic directory structures
--   nix support
+- nix support
 
 ### Fix
 
--   include dirty local changes when copying HEAD
--   require answer for questions without default value (#958)
--   **cleanup**: don't clean up local template in parent folder
--   delete conditionally created file when answer changes (#982)
--   properly support diffs over updates with new interactive answers
--   ignore Git hooks during project update (#1066)
--   properly support diffs over updates with new answers
--   skip tasks in pretend mode (#970)
--   parse CLI data using question's answer parser
--   don't set YAML `!include` constructor globally (#947)
--   **cli**: use `--conflict` flag only in `copier update` subcommand
--   ignore template repo tags that aren't valid PEP 440 versions
--   --skip option was ignored (#966)
--   Remove useless is_dir check
--   don't attempt to render a file if its name is empty
--   warn users against using shallow clones as template source
+- include dirty local changes when copying HEAD
+- require answer for questions without default value (#958)
+- **cleanup**: don't clean up local template in parent folder
+- delete conditionally created file when answer changes (#982)
+- properly support diffs over updates with new interactive answers
+- ignore Git hooks during project update (#1066)
+- properly support diffs over updates with new answers
+- skip tasks in pretend mode (#970)
+- parse CLI data using question's answer parser
+- don't set YAML `!include` constructor globally (#947)
+- **cli**: use `--conflict` flag only in `copier update` subcommand
+- ignore template repo tags that aren't valid PEP 440 versions
+- --skip option was ignored (#966)
+- Remove useless is_dir check
+- don't attempt to render a file if its name is empty
+- warn users against using shallow clones as template source
 
 ### Refactor
 
--   **tests**: remove unknown timeout marker
--   deduplicate code
--   remove unused method argument
--   simplify casting boolean question settings
--   remove useless code related to not asking a question
--   **typing**: use `Mapping` instead of `ChainMap` type
--   move unrelated code out of try-except block
--   **inline**: smarter inline conflict markers algorithm
+- **tests**: remove unknown timeout marker
+- deduplicate code
+- remove unused method argument
+- simplify casting boolean question settings
+- remove useless code related to not asking a question
+- **typing**: use `Mapping` instead of `ChainMap` type
+- move unrelated code out of try-except block
+- **inline**: smarter inline conflict markers algorithm
 
 ## v7.1.0a0 (2022-12-29)
 
 ### Feat
 
--   experimental inline conflict markers when updating
--   merge copier settings from multiple documents
+- experimental inline conflict markers when updating
+- merge copier settings from multiple documents
 
 ### Fix
 
--   remove dependency on iteration_utilities
+- remove dependency on iteration_utilities
 
 ## v7.0.1 (2022-10-14)
 
 ### Fix
 
--   remove deprecated code scheduled for removal in Copier v7 (#843)
+- remove deprecated code scheduled for removal in Copier v7 (#843)
 
 ## v7.0.0 (2022-10-12)
 
 ### Feat
 
--   expand tilde in template source path (#835)
+- expand tilde in template source path (#835)
 
 ### Fix
 
--   delete temporary clones after execution automatically (#802)
--   **typing**: remove invalid migration task stage "task"
+- delete temporary clones after execution automatically (#802)
+- **typing**: remove invalid migration task stage "task"
 
 ### Refactor
 
--   **typing**: use abstract container types where possible (#832)
--   use `dict` constructor as default factory
--   **typing**: remove unused types
--   remove unreachable code (#826)
--   model a task to execute using a dataclass
--   reduce module imports
+- **typing**: use abstract container types where possible (#832)
+- use `dict` constructor as default factory
+- **typing**: remove unused types
+- remove unreachable code (#826)
+- model a task to execute using a dataclass
+- reduce module imports
 
 ## v6.2.0 (2022-09-18)
 
 ### Feat
 
--   add validator field to Question (#719)
--   support passing github or gitlab urls without the .git suffix (#677)
+- add validator field to Question (#719)
+- support passing github or gitlab urls without the .git suffix (#677)
 
 ### Fix
 
--   compatibility with pydantic 1.10
--   git bundle support breaks with relative paths
--   prevent name collision for question var name "value"
+- compatibility with pydantic 1.10
+- git bundle support breaks with relative paths
+- prevent name collision for question var name "value"
 
 ### Refactor
 
--   add "flake8-simplify" plugin and simplify code
+- add "flake8-simplify" plugin and simplify code
 
 ## v6.1.0 (2022-06-13)
 
 ### Feat
 
--   support getting template commit hash with `{{ _copier_conf.vcs_ref_hash }}`
--   simplify the format of the question prompt (#689)
+- support getting template commit hash with `{{ _copier_conf.vcs_ref_hash }}`
+- simplify the format of the question prompt (#689)
 
 ### Fix
 
--   ignore non-PEP-440-compliant tags (#676)
+- ignore non-PEP-440-compliant tags (#676)
 
 ## [6.0.0] - 2022-05-15
 
@@ -573,144 +573,144 @@ Summary:
 
 ### Added
 
--   Allow using additional Jinja 2 extensions.
--   Major version mismatch warning. If your Copier version is too new, you'll be warned.
--   Specific exceptions, which will help on error detection for API usages.
--   Multiline questions.
--   Conditional questions.
--   Placeholders.
--   Interactive TUI for questionaries. Prompts are way cooler now. 😎
--   Python 3.9 support.
--   Python 3.10 support.
--   Support empty templates suffix, telling Copier to render every file.
--   Added `--defaults` flag to use default answers to questions, which might be null if
+- Allow using additional Jinja 2 extensions.
+- Major version mismatch warning. If your Copier version is too new, you'll be warned.
+- Specific exceptions, which will help on error detection for API usages.
+- Multiline questions.
+- Conditional questions.
+- Placeholders.
+- Interactive TUI for questionaries. Prompts are way cooler now. 😎
+- Python 3.9 support.
+- Python 3.10 support.
+- Support empty templates suffix, telling Copier to render every file.
+- Added `--defaults` flag to use default answers to questions, which might be null if
     not specified.
--   Added `--overwrite` flag to overwrite files that already exist, without asking.
--   In migration scripts, we have the new environment variables `$VERSION_PEP440_FROM`,
+- Added `--overwrite` flag to overwrite files that already exist, without asking.
+- In migration scripts, we have the new environment variables `$VERSION_PEP440_FROM`,
     `$VERSION_PEP440_CURRENT` and `$VERSION_PEP440_TO`, which will always get a valid
     PEP440 version identifier, without the `v` prefix, allowing your migration scripts
     to have a valid standard where to base their logic.
--   Raise a CopierAnswersInterrupt instead of a bare KeyboardInterrupt to provide
+- Raise a CopierAnswersInterrupt instead of a bare KeyboardInterrupt to provide
     callers with additional context - such as the partially completed AnswersMap.
--   Support for `user_defaults`, which take precedence over template defaults.
--   Copy dirty changes from a Git-tracked template to the project by default, to make
+- Support for `user_defaults`, which take precedence over template defaults.
+- Copy dirty changes from a Git-tracked template to the project by default, to make
     testing easier.
--   Advertise clearly which version is being copied or updated in the CLI.
--   Add jinja variable `_copier_python` to provide Python `sys.executable`.
+- Advertise clearly which version is being copied or updated in the CLI.
+- Add jinja variable `_copier_python` to provide Python `sys.executable`.
 
 ### Changed
 
--   Fully refactored core.
--   Running `copier copy` on a preexisting project now recopies the project instead of
+- Fully refactored core.
+- Running `copier copy` on a preexisting project now recopies the project instead of
     updating it. That means that it respects old answers, but ignores history diff.
--   We use Jinja 2 defaults now. `{{ }}` instead of `[[ ]]` and similar.
--   We keep trailing newlines by default for Jinja 2 templates.
--   Copier will never ask for overwriting the answers file.
--   Multi-typed choices follow the same type-casting logic as any other question, so
+- We use Jinja 2 defaults now. `{{ }}` instead of `[[ ]]` and similar.
+- We keep trailing newlines by default for Jinja 2 templates.
+- Copier will never ask for overwriting the answers file.
+- Multi-typed choices follow the same type-casting logic as any other question, so
     it's easier to reason about them. However, if you were using this feature, you might
     be surprised about its side effects if you don't specify the type explicitly. Just
     add `type: yaml` to make it behave _mostly_ as before. Or just don't use that, it's
     complicated anyway (warn added to docs).
--   Changed `--force` to be the same as `--defaults --overwrite`.
--   Copied files will reflect permissions on the same files in the template.
--   Copier now uses `git clone --filter=blob:none` when cloning, to be faster.
--   Removing files from templates will remove them too from the subprojects when they
+- Changed `--force` to be the same as `--defaults --overwrite`.
+- Copied files will reflect permissions on the same files in the template.
+- Copier now uses `git clone --filter=blob:none` when cloning, to be faster.
+- Removing files from templates will remove them too from the subprojects when they
     get updated.
 
 ### Deprecated
 
--   Deprecated `now` and `make_secret` functions. If your template used those, Copier
+- Deprecated `now` and `make_secret` functions. If your template used those, Copier
     will emit warnings leading you on how to upgrade it.
--   Templates marked with `_min_copier_version` below 6 will still default to use
+- Templates marked with `_min_copier_version` below 6 will still default to use
     bracket-based Jinja defaults, but that will disappear soon. If you want your
     template to work on Copier 5 and 6, make sure to declare `_envops` explicitly in
     your `copier.yaml`.
--   `copier.copy()` is confusing, now that actually copying and updating are 2
+- `copier.copy()` is confusing, now that actually copying and updating are 2
     completely different actions (before, you were actually always updating if
     possible). Its direct equivalent is now `copier.run_auto()`, and `copier.copy()`
     will disappear in the future.
 
 ### Removed
 
--   Minimal supported Python version is now 3.7 (dropped Python 3.6 support).
--   Removed the `json` method on `_copier_conf`. Where you would previously use
+- Minimal supported Python version is now 3.7 (dropped Python 3.6 support).
+- Removed the `json` method on `_copier_conf`. Where you would previously use
     `_copier_conf.json()` in your templates, please now use `_copier_conf|to_json`
     instead.
--   `--subdirectory` flag, which was confusing... and probably useless.
--   Lots of dead code.
+- `--subdirectory` flag, which was confusing... and probably useless.
+- Lots of dead code.
 
 ### Fixed
 
--   A directory that gets an empty name works as expected: not copied (nor its
+- A directory that gets an empty name works as expected: not copied (nor its
     contents).
--   When comparing versions to update, PEP 440 is always used now. This way, we avoid
+- When comparing versions to update, PEP 440 is always used now. This way, we avoid
     fake ordering when Git commit descriptions happen to be ordered in a non-predictable
     way.
--   Answers file will only remember answers to questions specified in the questionary.
+- Answers file will only remember answers to questions specified in the questionary.
 
 ## [5.1.0] - 2020-08-17
 
 [All changes here](https://github.com/copier-org/copier/milestone/14?closed=1). Summary:
 
--   Forbid downgrades.
--   Print all logs to STDERR.
+- Forbid downgrades.
+- Print all logs to STDERR.
 
 ## [5.0.0] - 2020-08-13
 
 [All changes here](https://github.com/copier-org/copier/milestone/2?closed=1). Summary:
 
--   Add `--prerelease` flag, which will be `False` by default. This is a behavioral
+- Add `--prerelease` flag, which will be `False` by default. This is a behavioral
     change and that's basically why I'm doing a new major release. All other changes are
     minor here.
--   Better docs.
+- Better docs.
 
 ## [4.1.0] - 2020-08-10
 
 [All changes here](https://github.com/copier-org/copier/milestone/12?closed=1). Summary:
 
--   Make Copier work fine with Git 2.28.
--   We have [docs](https://copier.readthedocs.io/)!
--   Polish docs a little bit.
--   We now run tests on macOS and Windows!
+- Make Copier work fine with Git 2.28.
+- We have [docs](https://copier.readthedocs.io/)!
+- Polish docs a little bit.
+- We now run tests on macOS and Windows!
 
 ## [4.0.2] - 2020-07-21
 
 [All changes here](https://github.com/copier-org/copier/milestone/11?closed=1). Summary:
 
--   Fix wrong templated default answers classification, which produced some questions
+- Fix wrong templated default answers classification, which produced some questions
     being ignored.
 
 ## [4.0.1] - 2020-06-23
 
 [All changes here](https://github.com/copier-org/copier/milestone/10?closed=1). Summary:
 
--   Fix wrong prompt regression when updating.
--   Remove redundant `dst` fixture in tests.
+- Fix wrong prompt regression when updating.
+- Remove redundant `dst` fixture in tests.
 
 ## [4.0.0] - 2020-06
 
 [All changes here](https://github.com/copier-org/copier/milestone/9?closed=1). Summary:
 
--   Remove semver to avoid having 2 different versioning systems. We stick to PEP 440
+- Remove semver to avoid having 2 different versioning systems. We stick to PEP 440
     now.
--   Remember where an answer comes from.
--   Do not re-ask to the user if already answer via `--data`.
--   Support pre-migration scripts that modify the answers file.
+- Remember where an answer comes from.
+- Do not re-ask to the user if already answer via `--data`.
+- Support pre-migration scripts that modify the answers file.
 
 ## [3.2.0] - 2020-06
 
 [All changes here](https://github.com/copier-org/copier/milestone/8?closed=1). Summary:
 
--   Templates can now use a subdirectory instead of always the template root.
+- Templates can now use a subdirectory instead of always the template root.
 
 ## [3.1.0] - 2020-05
 
 [All changes here](https://github.com/pykong/copier/milestone/7?closed=1). Summary:
 
--   Assert minimum Copier version.
--   Prettier prompts.
--   Prompt self-templating.
--   Better README.
+- Assert minimum Copier version.
+- Prettier prompts.
+- Prompt self-templating.
+- Better README.
 
 ## [3.0.0] - 2020-03
 
@@ -719,85 +719,85 @@ received a lot of love and hardening.
 
 ### Features
 
--   Minimal supported Python version is now 3.6.
--   Dropped support for deprecated `voodoo.json`.
--   Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
--   Dropped support for `include` option.
--   Added support for extending content of config files via content of other files via
+- Minimal supported Python version is now 3.6.
+- Dropped support for deprecated `voodoo.json`.
+- Introduced gitignore-style patterns for `exclude` und `skip-if-exists`.
+- Dropped support for `include` option.
+- Added support for extending content of config files via content of other files via
     `pyaml-include`.
--   Customizable template extension.
--   Ability to remember last answers.
--   Ability to choose where to remember them.
--   Template upgrades support, (based on the previous points) with migration tasks
+- Customizable template extension.
+- Ability to remember last answers.
+- Ability to choose where to remember them.
+- Template upgrades support, (based on the previous points) with migration tasks
     specification.
--   Extended questions format, supporting help, format, choices and secrets.
--   More beautiful prompts.
--   New CLI experience.
+- Extended questions format, supporting help, format, choices and secrets.
+- More beautiful prompts.
+- New CLI experience.
 
 ### Other
 
--   Moved to `poetry` for package management.
--   Type annotated entire code base.
--   Increased test coverage.
--   Ditched `ruamel.yaml` for `PyYaml`.
--   Ditched Travis CI for GitHub Actions.
--   Added `pre-commit` for enforced linting.
--   Added `prettier`, `black` and `isort` for code formatting.
--   Added `pytest` for running tests.
--   Use `plumbum` as CLI and subprocess engine.
+- Moved to `poetry` for package management.
+- Type annotated entire code base.
+- Increased test coverage.
+- Ditched `ruamel.yaml` for `PyYaml`.
+- Ditched Travis CI for GitHub Actions.
+- Added `pre-commit` for enforced linting.
+- Added `prettier`, `black` and `isort` for code formatting.
+- Added `pytest` for running tests.
+- Use `plumbum` as CLI and subprocess engine.
 
 ### [2.5.0] - 2019-06-16
 
--   Expanduser on all paths (so "~/foo/bar" is expanded to
+- Expanduser on all paths (so "~/foo/bar" is expanded to
     "<YOUR_HOME_FOLDER>/foo/bar").
--   Improve the output when running tasks.
--   Remove the destination folder if the copy process or one of the tasks fail.
--   Add a `cleanup_on_error` flag to optionally disable the cleanup feature.
--   Add the `skip_if_exists` option to skip files, without asking, if they already
+- Improve the output when running tasks.
+- Remove the destination folder if the copy process or one of the tasks fail.
+- Add a `cleanup_on_error` flag to optionally disable the cleanup feature.
+- Add the `skip_if_exists` option to skip files, without asking, if they already
     exists in the destination folder.
 
 ## [2.4.2] - 2019-06-09
 
--   Fix MAJOR bug that was preventing the `_exclude`, `_include` and `_tasks` keys from
+- Fix MAJOR bug that was preventing the `_exclude`, `_include` and `_tasks` keys from
     `copier.yml` (or alternatives) to be used at all. It also interpreted `_tasks` as a
     user-provided variable.
 
 ### [2.4.0] - 2019-06-08
 
--   Empty folders are now copied. The folders are also displayed in the console output
+- Empty folders are now copied. The folders are also displayed in the console output
     instead of just the files.
--   `prompt_bool` can now have an undefined default (and answer is mandatory in that
+- `prompt_bool` can now have an undefined default (and answer is mandatory in that
     case).
--   Reactivates the `copier.yml` and `copier.yaml` as configuration files.
--   The new `extra_paths` argument specifies additional paths to find templates to
+- Reactivates the `copier.yml` and `copier.yaml` as configuration files.
+- The new `extra_paths` argument specifies additional paths to find templates to
     inherit from.
 
 ### [2.3.0] - 2019-04-17
 
--   Back to using a setup.py instead of a pyproject.toml.
--   The recommended configuration file is now `copier.toml`.
+- Back to using a setup.py instead of a pyproject.toml.
+- The recommended configuration file is now `copier.toml`.
 
 ### [2.2.3] - 2019-04-13
 
--   The `copier` command-line script now accepts "help" and "version" as commands.
+- The `copier` command-line script now accepts "help" and "version" as commands.
 
 ### [2.1.0] - 2019-02-08
 
--   Task runner 🎉.
--   Use `_exclude`, `_include`, and `_tasks` keys in `copier.yml` as the default values
+- Task runner 🎉.
+- Use `_exclude`, `_include`, and `_tasks` keys in `copier.yml` as the default values
     for the `.copy()` arguments `exclude`, `include`, and `tasks`.
 
 ### [2.0.0] - 2019-02-07
 
--   Rebranded from `Voodoo` to `Copier`!
--   Dropped support for Python 2.x, the minimal version is now Python 3.5.
--   Cleanup and 100% test coverage.
--   The recommended configuration file is now `copier.yaml`, but a `copier.json` can be
+- Rebranded from `Voodoo` to `Copier`!
+- Dropped support for Python 2.x, the minimal version is now Python 3.5.
+- Cleanup and 100% test coverage.
+- The recommended configuration file is now `copier.yaml`, but a `copier.json` can be
     used as well. The old `voodoo.json` is also supported _for now_ but is deprecated
     and will be removed in version 2.2.
--   Python package format updated to the latest standard (no `setup.py` 😵).
--   Renamed the `render_skeleton()` function to `copy()`. The function signature remains
+- Python package format updated to the latest standard (no `setup.py` 😵).
+- Renamed the `render_skeleton()` function to `copy()`. The function signature remains
     almost the same, the only changes are:
-    -   `filter_this` parameter is now called `exclude`.
-    -   `ignore_this` parameter is now called just `ignore`.
--   Dropped the idea of storing the templates in a hidden `$HOME` folder.
+    - `filter_this` parameter is now called `exclude`.
+    - `ignore_this` parameter is now called just `ignore`.
+- Dropped the idea of storing the templates in a hidden `$HOME` folder.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,9 +9,9 @@ Report bugs at <https://github.com/copier-org/copier/issues>.
 
 If you are reporting a bug, please include:
 
--   Your operating system name and version.
--   Any details about your local setup that might be helpful in troubleshooting.
--   Detailed steps to reproduce the bug.
+- Your operating system name and version.
+- Any details about your local setup that might be helpful in troubleshooting.
+- Detailed steps to reproduce the bug.
 
 ## Fix Bugs
 
@@ -35,9 +35,9 @@ The best way to send feedback is to file an issue at
 
 If you are proposing a feature:
 
--   Explain in detail how it would work.
--   Keep the scope as narrow as possible, to make it easier to implement.
--   Remember that this is a volunteer-driven project, and that contributions are
+- Explain in detail how it would work.
+- Keep the scope as narrow as possible, to make it easier to implement.
+- Remember that this is a volunteer-driven project, and that contributions are
     welcome. :)
 
 ## Discuss
@@ -50,7 +50,7 @@ Feel free to discuss with our community through
 The recommended way is:
 
 1. Click on
-   [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/copier-org/copier)
+    [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/copier-org/copier)
 1. Wait until the terminal that pops up is ready.
 1. Accept the direnv pop-ups that appear.
 
@@ -63,9 +63,9 @@ For local or more complex setups, continue reading.
 We use some tools as part of our development workflow which you'll need to install into
 your host environment:
 
--   [Devbox](https://www.jetify.com/docs/devbox/) to provide a reproducible development
+- [Devbox](https://www.jetify.com/docs/devbox/) to provide a reproducible development
     environment.
--   [Direnv](https://direnv.net/) to load that environment automatically in your shell.
+- [Direnv](https://direnv.net/) to load that environment automatically in your shell.
 
 ### Without Devbox/Nix
 
@@ -88,19 +88,20 @@ will kindly auto-format code for you and push it back to your branch.
 
 [uv]: https://docs.astral.sh/uv/
 
-## Get Started!
+## Get Started
 
 Ready to contribute? Here's how to set up the project for local development.
 
-1.  Fork the Copier repo on GitHub.
-1.  Clone your fork locally:
+1. Fork the Copier repo on GitHub.
+
+1. Clone your fork locally:
 
     ```shell
     git clone git@github.com:my-user/copier.git
     cd copier
     ```
 
-1.  Use Direnv (or Devbox directly) to set up a development environment:
+1. Use Direnv (or Devbox directly) to set up a development environment:
 
     ```shell
     # Let direnv do its magic ...
@@ -114,7 +115,7 @@ Ready to contribute? Here's how to set up the project for local development.
     development dependencies, including [uv][], and it will use it to create a
     virtualenv and install Copier with all its development dependencies too.
 
-1.  Create a branch for local development:
+1. Create a branch for local development:
 
     ```shell
     git checkout -b name-of-your-bugfix-or-feature
@@ -122,7 +123,7 @@ Ready to contribute? Here's how to set up the project for local development.
 
     Now you can make your changes locally.
 
-1.  When you're done making changes, check that your changes pass all tests:
+1. When you're done making changes, check that your changes pass all tests:
 
     ```shell
     uv run poe test
@@ -151,7 +152,7 @@ Ready to contribute? Here's how to set up the project for local development.
         }
         ```
 
-1.  Optionally, use pyclean to remove Python bytecode and build artifacts, e.g.
+1. Optionally, use pyclean to remove Python bytecode and build artifacts, e.g.
 
     ```shell
     uvx pyclean . --debris --verbose
@@ -163,7 +164,7 @@ Ready to contribute? Here's how to set up the project for local development.
     pipx run pyclean . --debris --verbose
     ```
 
-1.  Commit your changes and push your branch to GitHub:
+1. Commit your changes and push your branch to GitHub:
 
     ```shell
     git add .
@@ -171,15 +172,15 @@ Ready to contribute? Here's how to set up the project for local development.
     git push origin name-of-your-bugfix-or-feature
     ```
 
-1.  Submit a pull request through the GitHub website.
+1. Submit a pull request through the GitHub website.
 
 ## Pull Request Guidelines
 
 Before you submit a pull request, check that it meets these guidelines:
 
-1.  The pull request has code, it should include tests.
-1.  Check that all checks pass on GitHub CI.
-1.  If something significant changed, modify docs.
+1. The pull request has code, it should include tests.
+1. Check that all checks pass on GitHub CI.
+1. If something significant changed, modify docs.
 
 ### Commit message guidelines
 
@@ -187,7 +188,7 @@ Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) st
 
 We use [Commitizen](https://commitizen-tools.github.io/commitizen/) to handle Copier
 releases. This tool generates the appropriate tag based on that standard. It also writes
-our [changelog](changelog.md). Changes that are included there are of type `fix`, `feat`
+our [changelog](CHANGELOG.md). Changes that are included there are of type `fix`, `feat`
 and `refactor`; also `BREAKING CHANGE:` trailers will appear. If your change is not
 meaningful in the changelog, then please don't use one of those categories.
 
@@ -237,7 +238,7 @@ Now the tag is released, but GitHub won't display it in the releases page. For t
 1. [Draft a new release](https://github.com/copier-org/copier/releases/new).
 1. Choose the tag you just pushed.
 1. Set the tag also as release title.
-1. Copy the just added changelog entry from [CHANGELOG](changelog.md) and paste it as a
+1. Copy the just added changelog entry from [CHANGELOG](CHANGELOG.md) and paste it as a
    description.
 1. Enable "Set as the latest release".
 1. Optionally, enable "Create a discussion for this release".

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 [![PyPI](https://img.shields.io/pypi/v/copier?logo=pypi&logoColor=%23959DA5)](https://pypi.org/project/copier/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Documentation Status](https://img.shields.io/readthedocs/copier/latest?logo=readthedocs)](https://copier.readthedocs.io/en/latest)
-[![](https://img.shields.io/badge/Gurubase-Ask%20Copier%20Guru-006BFF)](https://gurubase.io/g/copier)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Copier%20Guru-006BFF)](https://gurubase.io/g/copier)
 
 A library and CLI app for rendering project templates.
 
--   Works with **local** paths and **Git URLs**.
--   Your project can include any file and Copier can dynamically replace values in any
+- Works with **local** paths and **Git URLs**.
+- Your project can include any file and Copier can dynamically replace values in any
     kind of text file.
--   It generates a beautiful output and takes care of not overwriting existing files
+- It generates a beautiful output and takes care of not overwriting existing files
     unless instructed to do so.
 
 ![Sample output](https://github.com/copier-org/copier/raw/master/img/copier-output.png)
@@ -79,13 +79,13 @@ Content of the `{{_copier_conf.answers_file}}.jinja` file:
 
 To generate a project from the template:
 
--   On the command-line:
+- On the command-line:
 
     ```shell
     copier copy path/to/project/template path/to/destination
     ```
 
--   Or in Python code, programmatically:
+- Or in Python code, programmatically:
 
     ```python
     from copier import run_copy
@@ -115,13 +115,13 @@ Copier is composed of these main concepts:
 
 Copier targets these main human audiences:
 
-1.  **Template creators**. Programmers that repeat code too much and prefer a tool to do
+1. **Template creators**. Programmers that repeat code too much and prefer a tool to do
     it for them.
 
     **_Tip:_** Copier doesn't replace the DRY principle... but sometimes you simply
     can't be DRY and you need a DRYing machine...
 
-1.  **Template consumers**. Programmers that want to start a new project quickly, or
+1. **Template consumers**. Programmers that want to start a new project quickly, or
     that want to evolve it comfortably.
 
 Non-humans should be happy also by using Copier's CLI or API, as long as their
@@ -164,34 +164,32 @@ If you're using Copier, consider adding the Copier badge to your project's `READ
 
 ...or, as HTML:
 
-<!-- prettier-ignore-start -->
 ```html
 <a href="https://github.com/copier-org/copier"><img src="https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-orange.json" alt="Copier" style="max-width:100%;"/></a>
 ```
-<!-- prettier-ignore-end -->
 
 ### Copier badge variations
 
 1. Badge Grayscale Border
-   [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-border.json)](https://github.com/copier-org/copier)
+    [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-border.json)](https://github.com/copier-org/copier)
 
 1. Badge Grayscale Inverted Border
-   [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border.json)](https://github.com/copier-org/copier)
+    [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border.json)](https://github.com/copier-org/copier)
 
 1. Badge Grayscale Inverted Border Orange
-   [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-orange.json)](https://github.com/copier-org/copier)
+    [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-orange.json)](https://github.com/copier-org/copier)
 
 1. Badge Grayscale Inverted Border Red
-   [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-red.json)](https://github.com/copier-org/copier)
+    [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-red.json)](https://github.com/copier-org/copier)
 
 1. Badge Grayscale Inverted Border Teal
-   [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-teal.json)](https://github.com/copier-org/copier)
+    [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-teal.json)](https://github.com/copier-org/copier)
 
 1. Badge Grayscale Inverted Border Purple
-   [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-purple.json)](https://github.com/copier-org/copier)
+    [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-grayscale-inverted-border-purple.json)](https://github.com/copier-org/copier)
 
 1. Badge Black
-   [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-black.json)](https://github.com/copier-org/copier)
+    [![Copier](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/copier-org/copier/master/img/badge/badge-black.json)](https://github.com/copier-org/copier)
 
 ## Credits
 
@@ -213,6 +211,8 @@ codebase.
 
 And thanks to all financial supporters and folks that give us a shiny star! ⭐
 
+<!-- rumdl-capture -->
+<!-- rumdl-disable MD033 -->
 <a href="https://star-history.com/#copier-org/copier&Date">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=copier-org/copier&type=Date&theme=dark" />
@@ -220,3 +220,4 @@ And thanks to all financial supporters and folks that give us a shiny star! ⭐
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=copier-org/copier&type=Date" />
   </picture>
 </a>
+<!-- rumdl-restore -->

--- a/docs/comparisons.md
+++ b/docs/comparisons.md
@@ -25,12 +25,12 @@ docs! We don't want to be biased, but it's easy that we tend to be:
 | Requires handwriting JSON                | No                               | Yes                             | Yes           |
 | Requires installing templates separately | No                               | No                              | Yes           |
 | Requires programming                     | No                               | No                              | Yes, JS       |
-| Requires templates to have a suffix      | Yes by default, configurable[^3] | No, not configurable            | You choose    |
+| Requires templates to have a suffix      | Yes by default, configurable[^2] | No, not configurable            | You choose    |
 | Task hooks                               | Yes                              | Yes                             | Yes           |
-| Context hooks                            | Yes[^5]                          | Yes                             | ?             |
+| Context hooks                            | Yes[^3]                          | Yes                             | ?             |
 | Template in a subfolder                  | Not required, but you choose     | Yes, required                   | Yes, required |
-| Template package format                  | Git repo[^2], Git bundle, folder | Git or Mercurial repo, Zip file | NPM package   |
-| Template updates                         | **Yes**[^4]                      | No[^6]                          | No            |
+| Template package format                  | Git repo[^4], Git bundle, folder | Git or Mercurial repo, Zip file | NPM package   |
+| Template updates                         | **Yes**[^5]                      | No[^6]                          | No            |
 | Templating engine                        | [Jinja][]                        | [Jinja][]                       | [EJS][]       |
 
 [jinja]: https://jinja.palletsprojects.com/
@@ -39,21 +39,21 @@ docs! We don't want to be biased, but it's easy that we tend to be:
 [^1]: The file itself can [include other YAML files][include-other-yaml-files].
 
 [^2]:
-    Git repo is recommended to be able to use advanced features such as template tagging
-    and smart updates.
-
-[^3]:
     A suffix is required by default. Defaults to `.jinja`, but can be configured to use
     a different suffix, or to use none.
 
+[^3]: Context hooks are provided through the [`ContextHook` extension][context-hook].
+
 [^4]:
+    Git repo is recommended to be able to use advanced features such as template tagging
+    and smart updates.
+
+[^5]:
     Only for Git templates, because Copier uses Git tags to obtain available versions
     and extract smart diffs between them.
-
-[^5]: Context hooks are provided through the [`ContextHook` extension][context-hook].
 
 [^6]: Updates are possible through [Cruft][cruft].
 
 [context-hook]:
-    https://github.com/copier-org/copier-templates-extensions#context-hook-extension
+    <https://github.com/copier-org/copier-templates-extensions#context-hook-extension>
 [cruft]: https://github.com/cruft/cruft

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -13,22 +13,22 @@ It is important that you understand how Copier works. It has 2 kinds of configur
 Copier reads **settings** from these sources, in this order of priority:
 
 1. Command line or API arguments.
-1. [The `copier.yml` file][the-copieryml-file]. Settings here always start with an
+1. [The `copier.yml` file](#the-copieryml-file). Settings here always start with an
    underscore (e.g. `_min_copier_version`).
 
 !!! info
 
     Some settings are _only_ available as CLI arguments, and some others _only_ as
     template configurations. Some behave differently depending on where they are
-    defined. [Check the docs for each specific setting][available-settings].
+    defined. [Check the docs for each specific setting](#available-settings).
 
 Copier obtains **answers** from these sources, in this order of priority:
 
 1. Command line or API arguments.
 1. Asking the user. Notice that Copier will not ask any questions answered in the
    previous source.
-1. [Answer from last execution][the-copier-answersyml-file].
-1. Default values defined in [the `copier.yml` file][the-copieryml-file].
+1. [Answer from last execution](#the-copier-answersyml-file).
+1. Default values defined in [the `copier.yml` file](#the-copieryml-file).
 
 ## The `copier.yml` file
 
@@ -36,8 +36,8 @@ The `copier.yml` (or `copier.yaml`) file is found in the root of the template, a
 the main entrypoint for managing your template configuration. It will be read and used
 for two purposes:
 
--   [Prompting the user for information][questions].
--   [Applying template settings][available-settings] (excluding files, setting arguments
+- [Prompting the user for information](#questions).
+- [Applying template settings](#available-settings) (excluding files, setting arguments
     defaults, etc.).
 
 ### Questions
@@ -57,6 +57,8 @@ they become available to the project template.
 
     Will result in a questionnaire similar to:
 
+    <!-- rumdl-capture -->
+    <!-- rumdl-disable MD033 -->
     <pre style="font-weight: bold">
     🎤 name_of_the_project
       <span style="color:orange">My awesome project</span>
@@ -64,6 +66,7 @@ they become available to the project template.
       <span style="color:orange">1234</span>
     🎤 your_email
     </pre>
+    <!-- rumdl-restore -->
 
 #### Advanced prompt formatting
 
@@ -72,10 +75,12 @@ to ask users for data. To use it, the value must be a dict.
 
 Supported keys:
 
--   **type**: User input must match this type. Options are: `bool`, `float`, `int`,
+- **type**: User input must match this type. Options are: `bool`, `float`, `int`,
     `json`, `path`, `str`, `yaml` (default).
--   **help**: Additional text to help the user know what's this question for.
--   **choices**: To restrict possible values.
+
+- **help**: Additional text to help the user know what's this question for.
+
+- **choices**: To restrict possible values.
 
     !!! tip
 
@@ -185,9 +190,10 @@ Supported keys:
                 Some array: "[str, keeps, this, as, a, str]"
         ```
 
--   **multiselect**: When set to `true`, allows multiple choices. The answer will be a
+- **multiselect**: When set to `true`, allows multiple choices. The answer will be a
     `list[T]` instead of a `T` where `T` is of type `type`.
--   **default**: Leave empty to force the user to answer. Provide a default to save them
+
+- **default**: Leave empty to force the user to answer. Provide a default to save them
     from typing it if it's quite common. When using `choices`, the default must be the
     choice _value_, not its _key_, and it must match its _type_. If values are quite
     long, you can use
@@ -242,10 +248,11 @@ Supported keys:
             validator: "{% if '://' not in database_url %}Invalid{% endif %}"
         ```
 
--   **secret**: When `true`, it hides the prompt displaying asterisks (`*****`) and
-    doesn't save the answer in [the answers file][the-copier-answersyml-file]. When
+- **secret**: When `true`, it hides the prompt displaying asterisks (`*****`) and
+    doesn't save the answer in [the answers file](#the-copier-answersyml-file). When
     `true`, a default value is required.
--   **placeholder**: To provide a visual example for what would be a good value. It is
+
+- **placeholder**: To provide a visual example for what would be a good value. It is
     only shown while the answer is empty, so maybe it doesn't make much sense to provide
     both `default` and `placeholder`. It must be a string.
 
@@ -254,7 +261,7 @@ Supported keys:
         Multiline placeholders are not supported currently, due to
         [this upstream bug](https://github.com/prompt-toolkit/python-prompt-toolkit/issues/1267).
 
--   **qmark**: Custom emoji or mark to display before the question. If not specified,
+- **qmark**: Custom emoji or mark to display before the question. If not specified,
     defaults to 🎤 for regular questions and 🕵️ for secret questions. This is useful for
     customizing the visual appearance of your prompts.
 
@@ -267,20 +274,20 @@ Supported keys:
             help: Do you love Copier?
         ```
 
--   **multiline**: When set to `true`, it allows multiline input. This is especially
+- **multiline**: When set to `true`, it allows multiline input. This is especially
     useful when `type` is `json` or `yaml`.
 
--   **validator**: Jinja template with which to validate the user input. This template
+- **validator**: Jinja template with which to validate the user input. This template
     will be rendered with the combined answers as variables; it should render _nothing_
     if the value is valid, and an error message to show to the user otherwise.
 
--   **when**: Condition that, if `false`, skips the question.
+- **when**: Condition that, if `false`, skips the question.
 
     If it is a boolean, it is used directly. Setting it to `false` is useful for
     creating a computed value.
 
     If it is a string, it is converted to boolean using a parser similar to YAML, but
-    only for boolean values. The string can be [templated][prompt-templating].
+    only for boolean values. The string can be [templated](#prompt-templating).
 
     If a question is skipped, its answer is not recorded, but its default value is
     available in the render context.
@@ -489,10 +496,10 @@ larger `copier.yml` and enables you to reuse common partial sections from your
 templates. When multiple documents are used, care has to be taken with questions and
 settings that are defined in more than one document:
 
--   A question with the same name overwrites definitions from an earlier document.
--   Settings given in multiple documents for `exclude`, `skip_if_exists`,
+- A question with the same name overwrites definitions from an earlier document.
+- Settings given in multiple documents for `exclude`, `skip_if_exists`,
     `jinja_extensions` and `secret_questions` are concatenated.
--   Other settings (such as `tasks` or `migrations`) overwrite previous definitions for
+- Other settings (such as `tasks` or `migrations`) overwrite previous definitions for
     these settings.
 
 !!! hint
@@ -560,12 +567,12 @@ your_template
 
 !!! important
 
-    Note that the chosen [template suffix][templates_suffix]
+    Note that the chosen [template suffix](#templates_suffix)
     **must** appear outside of the Jinja condition,
     otherwise the whole file won't be considered a template and will
     be copied as such in generated projects.
 
-You can even use the answers of questions with [choices][advanced-prompt-formatting]:
+You can even use the answers of questions with [choices](#advanced-prompt-formatting):
 
 ```yaml title="copier.yml"
 ci:
@@ -588,7 +595,8 @@ your_template
 
 !!! important
 
-    Contrary to files, directories **must not** end with the [template suffix][templates_suffix].
+    Contrary to files, directories **must not** end with the
+    [template suffix](#templates_suffix).
 
 !!! warning
 
@@ -732,14 +740,14 @@ your_template
         ...
 ```
 
-Then, make sure to [exclude][exclude] this folder
+Then, make sure to [exclude](#exclude) this folder
 
 ```yaml title="copier.yml"
 _exclude:
     - includes
 ```
 
-or use a [subdirectory][subdirectory], e.g.:
+or use a [subdirectory](#subdirectory), e.g.:
 
 ```yaml title="copier.yml"
 _subdirectory: template
@@ -761,16 +769,16 @@ reason, Copier provides a function
 ## Available settings
 
 Template settings alter how the template is rendered. [They come from several
-sources][configuration-sources].
+sources](#configuration-sources).
 
 Remember that **the key must be prefixed with an underscore if you use it in [the
-`copier.yml` file][the-copieryml-file]**.
+`copier.yml` file](#the-copieryml-file)**.
 
 ### `answers_file`
 
--   Format: `str`
--   CLI flags: `-a`, `--answers-file`
--   Default value: `.copier-answers.yml`
+- Format: `str`
+- CLI flags: `-a`, `--answers-file`
+- Default value: `.copier-answers.yml`
 
 Path to a file where answers will be recorded by default. The path must be relative to
 the project root.
@@ -780,7 +788,7 @@ the project root.
     Remember to add that file to your Git template if you want to support
     [updates](updating.md).
 
-Don't forget to read [the docs about the answers file][the-copier-answersyml-file].
+Don't forget to read [the docs about the answers file](#the-copier-answersyml-file).
 
 !!! example
 
@@ -790,13 +798,13 @@ Don't forget to read [the docs about the answers file][the-copier-answersyml-fil
 
 ### `cleanup_on_error`
 
--   Format: `bool`
--   CLI flags: `-C`, `--no-cleanup` (used to disable this setting; only available in
+- Format: `bool`
+- CLI flags: `-C`, `--no-cleanup` (used to disable this setting; only available in
     `copier copy` subcommand)
--   Default value: `True`
+- Default value: `True`
 
 When Copier creates the destination path, if there's any failure when rendering the
-template (either in the rendering process or when running the [tasks][tasks]), Copier
+template (either in the rendering process or when running the [tasks](#tasks)), Copier
 will delete that folder.
 
 Copier will never delete the folder if it didn't create it. For this reason, when
@@ -808,9 +816,9 @@ running `copier update`, this setting has no effect.
 
 ### `conflict`
 
--   Format: `Literal["rej", "inline"]`
--   CLI flags: `-o`, `--conflict` (only available in `copier update` subcommand)
--   Default value: `inline`
+- Format: `Literal["rej", "inline"]`
+- CLI flags: `-o`, `--conflict` (only available in `copier update` subcommand)
+- Default value: `inline`
 
 When updating a project, sometimes Copier doesn't know what to do with a diff code hunk.
 This option controls the output format if this happens. Using `rej`, creates `*.rej`
@@ -823,9 +831,9 @@ code hunk in the file itself, similar to the behavior of `git merge`.
 
 ### `context_lines`
 
--   Format: `Int`
--   CLI flags: `-c`, `--context-lines` (only available in `copier update` subcommand)
--   Default value: `1`
+- Format: `Int`
+- CLI flags: `-c`, `--context-lines` (only available in `copier update` subcommand)
+- Default value: `1`
 
 During a project update, Copier needs to compare the template evolution with the
 subproject evolution. This way, it can detect what changed, where and how to merge those
@@ -845,9 +853,9 @@ code chunks.
 
 ### `data`
 
--   Format: `dict|List[str=str]`
--   CLI flags: `-d`, `--data`
--   Default value: N/A
+- Format: `dict|List[str=str]`
+- CLI flags: `-d`, `--data`
+- Default value: N/A
 
 Give answers to questions through CLI/API.
 
@@ -882,12 +890,12 @@ questions with default answers.
 
 ### `data_file`
 
--   Format: `str`
--   CLI flags: `--data-file`
--   Default value: N/A
+- Format: `str`
+- CLI flags: `--data-file`
+- Default value: N/A
 
-As an alternative to [`-d, --data`][data] you can also pass the path to a YAML file that
-contains your data.
+As an alternative to [`-d, --data`](#data) you can also pass the path to a YAML file
+that contains your data.
 
 !!! info
 
@@ -915,8 +923,8 @@ contains your data.
     copier copy -d 'user_name=Manuel Calavera' -d 'age=7' -d 'height=1.83' template destination
     ```
 
-    If you'd like to override some of the answers in the file, `--data` flags always take
-    precedence:
+    If you'd like to override some of the answers in the file, `--data` flags always
+    take precedence:
 
     ```shell
     copier copy -d 'user_name=Bilbo Baggins' --data-file input.yml template destination
@@ -924,25 +932,27 @@ contains your data.
 
 !!! info
 
-    Command line arguments passed via `--data` always take precedence over the data file.
+    Command line arguments passed via `--data` always take precedence over the data
+    file.
 
 ### `external_data`
 
--   Format: `dict[str, str]`
--   CLI flags: N/A
--   Default value: `{}`
+- Format: `dict[str, str]`
+- CLI flags: N/A
+- Default value: `{}`
 
 This allows using preexisting data inside the rendering context. The format is a dict of
 strings, where:
 
--   The dict key will be the namespace of the data under [`_external_data`][].
--   The dict value is the relative path (from the subproject destination) where the YAML
+- The dict key will be the namespace of the data under
+    [`_external_data`](#external_data).
+- The dict value is the relative path (from the subproject destination) where the YAML
     data file should be found.
 
 !!! example "Template composition"
 
     If your template is
-    [a complement of another template][applying-multiple-templates-to-the-same-subproject],
+    [a complement of another template](#applying-multiple-templates-to-the-same-subproject),
     you can access the other template's answers with a pattern similar to this:
 
     ```yaml title="copier.yml"
@@ -970,7 +980,7 @@ strings, where:
 
 !!! example "Loading secrets"
 
-    If your template has [secret questions][secret_questions], you can load the secrets
+    If your template has [secret questions](#secret_questions), you can load the secrets
     and use them, e.g., as default answers with a pattern similar to this:
 
     ```yaml
@@ -997,9 +1007,9 @@ strings, where:
 
 ### `envops`
 
--   Format: `dict`
--   CLI flags: N/A
--   Default value: `{"keep_trailing_newline": true}`
+- Format: `dict`
+- CLI flags: N/A
+- Default value: `{"keep_trailing_newline": true}`
 
 Configurations for the Jinja environment. Copier uses the Jinja defaults whenever
 possible. The only exception at the moment is that
@@ -1031,19 +1041,19 @@ to know available options.
 
     By specifying this, your template will be compatible with both Copier 5 and 6.
 
-    Copier 6 will apply these older defaults if your [min_copier_version][] is lower
-    than 6.
+    Copier 6 will apply these older defaults if your
+    [min_copier_version](#min_copier_version) is lower than 6.
 
-    Copier 7+ no longer uses the old defaults independent of [min_copier_version][].
+    Copier 7+ no longer uses the old defaults independent of
+    [min_copier_version](#min_copier_version).
 
 ### `exclude`
 
--   Format: `List[str]`
--   CLI flags: `-x`, `--exclude`
--   Default value:
-    `["copier.yaml", "copier.yml", "~*", "*.py[co]", "__pycache__", ".git", ".DS_Store", ".svn"]`
+- Format: `List[str]`
+- CLI flags: `-x`, `--exclude`
+- Default value: `["copier.yaml", "copier.yml", "~*", "*.py[co]", "__pycache__", ".git", ".DS_Store", ".svn"]` <!-- rumdl-disable-line MD013 -->
 
-[Patterns][patterns-syntax] for files/folders that must not be copied.
+[Patterns](#patterns-syntax) for files/folders that must not be copied.
 
 The CLI option can be passed several times to add several patterns.
 
@@ -1059,8 +1069,8 @@ Each pattern can be templated using Jinja.
         - "{% if _copier_operation == 'update' -%}src/*_example.py{% endif %}"
     ```
 
-    The difference with [skip_if_exists][] is that it will never be rendered during
-    an update, no matter if it exists or not.
+    The difference with [skip_if_exists](#skip_if_exists) is that it will never be
+    rendered during an update, no matter if it exists or not.
 
 !!! info
 
@@ -1079,7 +1089,7 @@ Each pattern can be templated using Jinja.
 
 !!! info
 
-    When the [`subdirectory`][subdirectory] parameter is defined and its value is the
+    When the [`subdirectory`](#subdirectory) parameter is defined and its value is the
     path of an actual subdirectory (i.e. not `""` or `"."` or `"./"`), then the default
     value of the `exclude` parameter is `[]`.
 
@@ -1090,7 +1100,6 @@ Each pattern can be templated using Jinja.
 
     Instead, CLI/API definitions **will extend** those from `copier.yml`.
 
-
     !!! example "Example CLI usage to copy only a single file from the template"
 
         ```shell
@@ -1099,14 +1108,14 @@ Each pattern can be templated using Jinja.
 
 ### `force`
 
--   Format: `bool`
--   CLI flags: `-f`, `--force` (N/A in `copier update`)
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `-f`, `--force` (N/A in `copier update`)
+- Default value: `False`
 
 Overwrite files that already exist, without asking.
 
 Also don't ask questions to the user; just use default values [obtained from other
-sources][configuration-sources].
+sources](#configuration-sources).
 
 !!! info
 
@@ -1114,16 +1123,16 @@ sources][configuration-sources].
 
 ### `defaults`
 
--   Format: `bool`
--   CLI flags: `--defaults`
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `--defaults`
+- Default value: `False`
 
 Use default answers to questions.
 
 !!! attention
 
     Any question that does not have a default value must be answered
-    [via CLI/API][data]. Otherwise, an error is raised.
+    [via CLI/API](#data). Otherwise, an error is raised.
 
 !!! info
 
@@ -1131,13 +1140,13 @@ Use default answers to questions.
 
 ### `overwrite`
 
--   Format: `bool`
--   CLI flags: `--overwrite` (N/A in `copier update` because it's implicit)
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `--overwrite` (N/A in `copier update` because it's implicit)
+- Default value: `False`
 
 Overwrite files that already exist, without asking.
 
-[obtained from other sources][configuration-sources].
+[obtained from other sources](#configuration-sources).
 
 !!! info
 
@@ -1147,16 +1156,16 @@ Overwrite files that already exist, without asking.
 
 ### `jinja_extensions`
 
--   Format: `List[str]`
--   CLI flags: N/A
--   Default value: `[]`
+- Format: `List[str]`
+- CLI flags: N/A
+- Default value: `[]`
 
 Additional Jinja2 extensions to load in the Jinja2 environment. Extensions can add
 filters, global variables and functions, or tags to the environment.
 
 The following extensions are _always_ loaded:
 
--   [`jinja2_ansible_filters.AnsibleCoreFiltersExtension`](https://gitlab.com/dreamer-labs/libraries/jinja2-ansible-filters/):
+- [`jinja2_ansible_filters.AnsibleCoreFiltersExtension`](https://gitlab.com/dreamer-labs/libraries/jinja2-ansible-filters/):
     this extension adds most of the
     [Ansible filters](https://docs.ansible.com/ansible/2.3/playbooks_filters.html) to
     the environment.
@@ -1171,10 +1180,10 @@ on them, so they are always installed when Copier is installed.
 
 !!! info "Note to template writers"
 
-    You must inform your users that they need to install the extensions alongside Copier,
-    i.e. in the same virtualenv where Copier is installed.
-    For example, if your template uses `jinja2_time.TimeExtension`,
-    your users must install the `jinja2-time` Python package.
+    You must inform your users that they need to install the extensions alongside
+    Copier, i.e. in the same virtualenv where Copier is installed. For example, if your
+    template uses `jinja2_time.TimeExtension`, your users must install the `jinja2-time`
+    Python package.
 
     ```shell
     # with pip, in the same virtualenv where Copier is installed
@@ -1201,7 +1210,8 @@ on them, so they are always installed when Copier is installed.
 
     -   [Native Jinja2 extensions](https://jinja.palletsprojects.com/en/3.1.x/extensions/):
         -   [expression statement](https://jinja.palletsprojects.com/en/3.1.x/templates/#expression-statement),
-            which can be used to alter the Jinja context (answers, filters, etc.) or execute other operations, without outputting anything.
+            which can be used to alter the Jinja context (answers, filters, etc.) or
+            execute other operations, without outputting anything.
         -   [loop controls](https://jinja.palletsprojects.com/en/3.1.x/extensions/#loop-controls), which adds the `break` and `continue`
             keywords for Jinja loops.
         -   [debug extension](https://jinja.palletsprojects.com/en/3.1.x/extensions/#debug-extension), which can dump the current context
@@ -1210,12 +1220,13 @@ on them, so they are always installed when Copier is installed.
     -   From [cookiecutter](https://cookiecutter.readthedocs.io/en/1.7.2/):
 
         -   [`cookiecutter.extensions.JsonifyExtension`](https://cookiecutter.readthedocs.io/en/latest/advanced/template_extensions.html#jsonify-extension):
-            provides a `jsonify` filter, to format a dictionary as JSON. Note that Copier
-            natively provides a `to_nice_json` filter that can achieve the same thing.
+            provides a `jsonify` filter, to format a dictionary as JSON. Note that
+            Copier natively provides a `to_nice_json` filter that can achieve the same
+            thing.
         -   [`cookiecutter.extensions.RandomStringExtension`](https://cookiecutter.readthedocs.io/en/latest/advanced/template_extensions.html#random-string-extension):
             provides a `random_ascii_string(length, punctuation=False)` global function.
-            Note that Copier natively provides the `ans_random` and `hash` filters that can
-            be used to achieve the same thing:
+            Note that Copier natively provides the `ans_random` and `hash` filters that
+            can be used to achieve the same thing:
 
             !!! example
 
@@ -1231,7 +1242,7 @@ on them, so they are always installed when Copier is installed.
         enhances the extension loading mechanism to allow templates writers to put their
         extensions directly in their templates. It also allows to modify the rendering context
         (the Jinja variables that you can use in your templates) before
-        rendering templates, see [using a context hook][how-can-i-alter-the-context-before-rendering-the-project].
+        rendering templates, see [using a context hook](faq.md#how-can-i-alter-the-context-before-rendering-the-project).
     -   [`jinja_markdown.MarkdownExtension`](https://github.com/jpsca/jinja-markdown):
         provides a `markdown` tag that will render Markdown to HTML using
         [PyMdown extensions](https://facelessuser.github.io/pymdown-extensions/).
@@ -1250,18 +1261,18 @@ on them, so they are always installed when Copier is installed.
 
 ### `message_after_copy`
 
--   Format: `str`
--   CLI flags: N/A
--   Default value: `""`
+- Format: `str`
+- CLI flags: N/A
+- Default value: `""`
 
 A message to be printed after [generating](generating.md) or
-[regenerating][regenerating-a-project] a project _successfully_.
+[regenerating](generating.md#regenerating-a-project) a project _successfully_.
 
 If the message contains Jinja code, it will be rendered with the same context as the
-rest of the template. A [Jinja include][importing-jinja-templates-and-macros] expression
-may be used to import a message from a file.
+rest of the template. A [Jinja include](#importing-jinja-templates-and-macros)
+expression may be used to import a message from a file.
 
-The message is suppressed when Copier is run in [quiet mode][quiet].
+The message is suppressed when Copier is run in [quiet mode](#quiet).
 
 !!! example
 
@@ -1284,11 +1295,11 @@ The message is suppressed when Copier is run in [quiet mode][quiet].
 
 ### `message_after_update`
 
--   Format: `str`
--   CLI flags: N/A
--   Default value: `""`
+- Format: `str`
+- CLI flags: N/A
+- Default value: `""`
 
-Like [`message_after_copy`][message_after_copy] but printed after
+Like [`message_after_copy`](#message_after_copy) but printed after
 [_updating_](updating.md) a project.
 
 !!! example
@@ -1306,12 +1317,13 @@ Like [`message_after_copy`][message_after_copy] but printed after
 
 ### `message_before_copy`
 
--   Format: `str`
--   CLI flags: N/A
--   Default value: `""`
+- Format: `str`
+- CLI flags: N/A
+- Default value: `""`
 
-Like [`message_after_copy`][message_after_copy] but printed _before_
-[generating](generating.md) or [regenerating][regenerating-a-project] a project.
+Like [`message_after_copy`](#message_after_copy) but printed _before_
+[generating](generating.md) or [regenerating](generating.md#regenerating-a-project) a
+project.
 
 !!! example
 
@@ -1329,11 +1341,11 @@ Like [`message_after_copy`][message_after_copy] but printed _before_
 
 ### `message_before_update`
 
--   Format: `str`
--   CLI flags: N/A
--   Default value: `""`
+- Format: `str`
+- CLI flags: N/A
+- Default value: `""`
 
-Like [`message_before_copy`][message_after_copy] but printed before
+Like [`message_before_copy`](#message_after_copy) but printed before
 [_updating_](updating.md) a project.
 
 !!! example
@@ -1352,19 +1364,19 @@ Like [`message_before_copy`][message_after_copy] but printed before
 
 ### `migrations`
 
--   Format: `List[str|List[str]|dict]`
--   CLI flags: N/A
--   Default value: `[]`
+- Format: `List[str|List[str]|dict]`
+- CLI flags: N/A
+- Default value: `[]`
 
-Migrations are like [tasks][tasks], but each item can have additional keys:
+Migrations are like [tasks](#tasks), but each item can have additional keys:
 
--   **command**: The migration command to run
--   **version** (optional): Indicates the version that the template update has to go
-    through to trigger this migration. It is evaluated using [PEP 440][]. If no version is
+- **command**: The migration command to run
+- **version** (optional): Indicates the version that the template update has to go
+    through to trigger this migration. It is evaluated using [PEP 440]. If no version is
     specified the migration will run on every update.
--   **when** (optional): Specifies a condition that needs to hold for the task to run.
+- **when** (optional): Specifies a condition that needs to hold for the task to run.
     By default, a migration will run in the after upgrade stage.
--   **working_directory** (optional): Specifies the directory in which the command will
+- **working_directory** (optional): Specifies the directory in which the command will
     be run. Defaults to the destination directory.
 
 If a `str` or `List[str]` is given as a migrator it will be treated as `command` with
@@ -1375,7 +1387,7 @@ migration for a higher version before running a migration for a lower version if
 higher one is declared before and the update passes through both).
 
 When `version` is given they will only run when _new version >= declared version > old
-version_. Your template will only be marked as [unsafe][unsafe] if this condition is
+version_. Your template will only be marked as [unsafe](#unsafe) if this condition is
 true. Migrations will also only run when updating (not when copying for the 1st time).
 
 If the migrations definition contains Jinja code, it will be rendered with the same
@@ -1385,21 +1397,22 @@ There are a number of additional variables available for templating of migration
 variables are also passed to the migration process as environment variables. Migration
 processes will receive these variables:
 
--   `_stage`/`$STAGE`: Either `before` or `after`.
--   `_version_from`/`$VERSION_FROM`: [Git commit description][git describe] of the
+- `_stage`/`$STAGE`: Either `before` or `after`.
+- `_version_from`/`$VERSION_FROM`: [Git commit description][git describe] of the
     template as it was before updating.
--   `_version_to`/`$VERSION_TO`: [Git commit description][git describe] of the template
+- `_version_to`/`$VERSION_TO`: [Git commit description][git describe] of the template
     as it will be after updating.
--   `_version_current`/`$VERSION_CURRENT`: The `version` detector as you indicated it
+- `_version_current`/`$VERSION_CURRENT`: The `version` detector as you indicated it
     when describing migration tasks (only when `version` is given).
--   `_version_pep440_from`/`$VERSION_PEP440_FROM`,
+- `_version_pep440_from`/`$VERSION_PEP440_FROM`,
     `_version_pep440_to`/`$VERSION_PEP440_TO`,
     `_version_pep440_current`/`$VERSION_PEP440_CURRENT`: Same as the above, but
-    normalized into a standard [PEP 440][] version. In Jinja templates these are represented
-    as [packaging.version.Version](https://packaging.pypa.io/en/stable/version.html#packaging.version.Version)
-    objects and allow access to their attributes. As environment variables they are represented
-    as strings. If you use variables to perform migrations, you probably will prefer to use
-    these variables.
+    normalized into a standard [PEP 440] version. In Jinja templates these are
+    represented as
+    [packaging.version.Version](https://packaging.pypa.io/en/stable/version.html#packaging.version.Version)
+    objects and allow access to their attributes. As environment variables they are
+    represented as strings. If you use variables to perform migrations, you probably
+    will prefer to use these variables.
 
 [git describe]: https://git-scm.com/docs/git-describe
 [pep 440]: https://www.python.org/dev/peps/pep-0440/
@@ -1421,26 +1434,26 @@ format is still available, but will raise a warning when used.
 
 Each item in the list is a `dict` with the following keys:
 
--   **version**: Indicates the version that the template update has to go through to
-    trigger this migration. It is evaluated using [PEP 440][].
--   **before** (optional): Commands to execute before performing the update. The answers
+- **version**: Indicates the version that the template update has to go through to
+    trigger this migration. It is evaluated using [PEP 440].
+- **before** (optional): Commands to execute before performing the update. The answers
     file is reloaded after running migrations in this stage, to let you migrate answer
     values.
--   **after** (optional): Commands to execute after performing the update.
+- **after** (optional): Commands to execute after performing the update.
 
 The migration variables mentioned above are available as environment variables, but
 can't be used in jinja templates.
 
 ### `min_copier_version`
 
--   Format: `str`
--   CLI flags: N/A
--   Default value: N/A
+- Format: `str`
+- CLI flags: N/A
+- Default value: N/A
 
 Specifies the minimum required version of Copier to generate a project from this
-template. The version must be follow the [PEP 440][] syntax. Upon generating or updating
-a project, if the installed version of Copier is less than the required one, the generation
-will be aborted and an error will be shown to the user.
+template. The version must be follow the [PEP 440] syntax. Upon generating or updating a
+project, if the installed version of Copier is less than the required one, the
+generation will be aborted and an error will be shown to the user.
 
 !!! info
 
@@ -1457,9 +1470,9 @@ will be aborted and an error will be shown to the user.
 
 ### `pretend`
 
--   Format: `bool`
--   CLI flags: `-n`, `--pretend`
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `-n`, `--pretend`
+- Default value: `False`
 
 Run but do not make any changes.
 
@@ -1469,9 +1482,9 @@ Run but do not make any changes.
 
 ### `preserve_symlinks`
 
--   Format: `bool`
--   CLI flags: N/A
--   Default value: `False`
+- Format: `bool`
+- CLI flags: N/A
+- Default value: `False`
 
 Keep symlinks as symlinks. If this is set to `False` symlinks will be replaced with the
 file they point to.
@@ -1481,9 +1494,9 @@ the target path of the symlink will be rendered as a jinja template.
 
 ### `quiet`
 
--   Format: `bool`
--   CLI flags: `-q`, `--quiet`
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `-q`, `--quiet`
+- Default value: `False`
 
 Suppress status output.
 
@@ -1493,13 +1506,13 @@ Suppress status output.
 
 ### `secret_questions`
 
--   Format: `List[str]`
--   CLI flags: N/A
--   Default value: `[]`
+- Format: `List[str]`
+- CLI flags: N/A
+- Default value: `[]`
 
 Question variables to mark as secret questions. This is especially useful when questions
-are provided in the [simplified prompt format][questions]. It's equivalent to
-configuring `secret: true` in the [advanced prompt format][advanced-prompt-formatting].
+are provided in the [simplified prompt format](#questions). It's equivalent to
+configuring `secret: true` in the [advanced prompt format](#advanced-prompt-formatting).
 
 !!! example
 
@@ -1513,9 +1526,9 @@ configuring `secret: true` in the [advanced prompt format][advanced-prompt-forma
 
 ### `skip_answered`
 
--   Format: `bool`
--   CLI flags: `-A`, `--skip-answered` (only available in `copier update` subcommand)
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `-A`, `--skip-answered` (only available in `copier update` subcommand)
+- Default value: `False`
 
 When updating a project, skip asking questions that have already been answered and keep
 the recorded answer.
@@ -1526,11 +1539,11 @@ the recorded answer.
 
 ### `skip_if_exists`
 
--   Format: `List[str]`
--   CLI flags: `-s`, `--skip`
--   Default value: `[]`
+- Format: `List[str]`
+- CLI flags: `-s`, `--skip`
+- Default value: `[]`
 
-[Patterns][patterns-syntax] for files/folders that must be skipped only if they already
+[Patterns](#patterns-syntax) for files/folders that must be skipped only if they already
 exist, but always be present. If they do not exist in a project during an `update`
 operation, they will be recreated.
 
@@ -1552,25 +1565,25 @@ Each pattern can be templated using Jinja.
 
 ### `skip_tasks`
 
--   Format: `bool`
--   CLI Flags: `-T`, `--skip-tasks`
--   Default value: `False`
+- Format: `bool`
+- CLI Flags: `-T`, `--skip-tasks`
+- Default value: `False`
 
-Skip template [tasks][tasks] execution, if set to `True`.
+Skip template [tasks](#tasks) execution, if set to `True`.
 
 !!! note
 
-    It only skips [tasks][tasks], not [migration tasks][migrations].
+    It only skips [tasks](#tasks), not [migration tasks](#migrations).
 
 !!! question "Does it imply `--trust`?"
 
-    This flag does not imply [`--trust`][unsafe], and will do nothing if not used with.
+    This flag does not imply [`--trust`](#unsafe), and will do nothing if not used with.
 
 ### `subdirectory`
 
--   Format: `str`
--   CLI flags: N/A
--   Default value: N/A
+- Format: `str`
+- CLI flags: N/A
+- Default value: N/A
 
 Subdirectory to use as the template root when generating a project. If not specified,
 the root of the template is used.
@@ -1593,18 +1606,17 @@ This allows you to keep separate the template metadata and the template code.
     The Copier recommendation is: **1 template = 1 Git repository**.
 
     Why? Unlike almost all other templating engines, Copier supports
-    [smart project updates](updating.md). For that, Copier needs to know in which version it
-    was copied last time, and to which version you are evolving. Copier gets that
-    information from Git tags. Git tags are shared across the whole Git repository. Using a
-    repository to host multiple templates would lead to many corner case situations that we
-    don't want to support.
+    [smart project updates](updating.md). For that, Copier needs to know in which
+    version it was copied last time, and to which version you are evolving. Copier gets
+    that information from Git tags. Git tags are shared across the whole Git repository.
+    Using a repository to host multiple templates would lead to many corner case
+    situations that we don't want to support.
 
     So, in Copier, the subdirectory option is just there to let template owners separate
     templates metadata from template source code. This way, for example, you can have
     different dotfiles for you template and for the projects it generates.
 
     !!! example "Example project with different `.gitignore` files"
-
 
         ```tree result="shell" title="Project layout"
         my_copier_template
@@ -1626,9 +1638,9 @@ This allows you to keep separate the template metadata and the template code.
 
     !!! example
 
-        With this questions file and this directory structure, the user will be prompted which
-        Python engine to use, and the project will be generated using the subdirectory whose
-        name matches the answer from the user:
+        With this questions file and this directory structure, the user will be prompted
+        which Python engine to use, and the project will be generated using the
+        subdirectory whose name matches the answer from the user:
 
         ```yaml title="copier.yaml"
         _subdirectory: "{{ python_engine }}"
@@ -1651,13 +1663,13 @@ This allows you to keep separate the template metadata and the template code.
         ```
 
         1.  The configuration from the previous example snippet.
-        1.  See [the answers file docs][the-copier-answersyml-file] to understand.
+        1.  See [the answers file docs](#the-copier-answersyml-file) to understand.
 
 ### `tasks`
 
--   Format: `List[str|List[str]|dict]`
--   CLI flags: N/A
--   Default value: `[]`
+- Format: `List[str|List[str]|dict]`
+- CLI flags: N/A
+- Default value: `[]`
 
 Commands to execute after generating or updating a project from your template.
 
@@ -1666,9 +1678,9 @@ runs in its own subprocess.
 
 If a `dict` is given it can contain the following items:
 
--   **command**: The task command to run.
--   **when** (optional): Specifies a condition that needs to hold for the task to run.
--   **working_directory** (optional): Specifies the directory in which the command will
+- **command**: The task command to run.
+- **when** (optional): Specifies a condition that needs to hold for the task to run.
+- **working_directory** (optional): Specifies the directory in which the command will
     be run. Defaults to the destination directory.
 
 If a `str` or `List[str]` is given as a task it will be treated as `command` with all
@@ -1705,9 +1717,9 @@ Refer to the example provided below for more information.
 
 ### `templates_suffix`
 
--   Format: `str`
--   CLI flags: N/A
--   Default value: `.jinja`
+- Format: `str`
+- CLI flags: N/A
+- Default value: `.jinja`
 
 Suffix that instructs which files are to be processed by Jinja as templates.
 
@@ -1718,7 +1730,7 @@ Suffix that instructs which files are to be processed by Jinja as templates.
     ```
 
 An empty suffix is also valid, and will instruct Copier to copy and render _every file_,
-except those that are [excluded by default][exclude]. If an error happens while trying
+except those that are [excluded by default](#exclude). If an error happens while trying
 to read a file as a template, it will fallback to a simple copy (it will typically
 happen for binary files like images). At the contrary, if such an error happens and the
 templates suffix is _not_ empty, Copier will abort and print an error message.
@@ -1746,22 +1758,23 @@ without suffix will be ignored.
     Copier 5 and older had a different default value: `.tmpl`. If you wish to keep it,
     add it to your `copier.yml` to keep it future-proof.
 
-    Copier 6 will apply that old default if your [min_copier_version][] is lower
-    than 6.
+    Copier 6 will apply that old default if your
+    [min_copier_version](#min_copier_version) is lower than 6.
 
-    Copier 7+ no longer uses the old default independent of [min_copier_version][].
+    Copier 7+ no longer uses the old default independent of
+    [min_copier_version](#min_copier_version).
 
 ### `unsafe`
 
--   Format: `bool`
--   CLI flags: `--UNSAFE`, `--trust`
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `--UNSAFE`, `--trust`
+- Default value: `False`
 
 Copier templates can use dangerous features that allow arbitrary code execution:
 
--   [Jinja extensions][jinja_extensions]
--   [Migrations][migrations]
--   [Tasks][tasks]
+- [Jinja extensions](#jinja_extensions)
+- [Migrations](#migrations)
+- [tasks](#tasks)
 
 Therefore, these features are disabled by default and Copier will raise an error (and
 exit from the CLI with code `4`) when they are found in a template. In this case, please
@@ -1779,13 +1792,14 @@ switch `--UNSAFE` or `--trust`.
 
 !!! tip
 
-    See the [`trust` setting][trusted-locations] to mark some repositories as always trusted.
+    See the [`trust` setting](./settings.md#trusted-locations) to mark some repositories
+    as always trusted.
 
 ### `use_prereleases`
 
--   Format: `bool`
--   CLI flags: `g`, `--prereleases`
--   Default value: `False`
+- Format: `bool`
+- CLI flags: `g`, `--prereleases`
+- Default value: `False`
 
 Imagine that the template supports updates and contains these 2 Git tags: `v1.0.0` and
 `v2.0.0a1`. Copier will copy by default `v1.0.0` unless you add `--prereleases`.
@@ -1806,9 +1820,9 @@ the `v2.0.0a1` tag unless this flag is enabled.
 
 ### `vcs_ref`
 
--   Format: `str | VcsRef`
--   CLI flags: `-r`, `--vcs-ref`
--   Default value: N/A (use latest release)
+- Format: `str | VcsRef`
+- CLI flags: `-r`, `--vcs-ref`
+- Default value: N/A (use latest release)
 
 When copying or updating from a Git-versioned template, indicate which template version
 to copy.
@@ -1826,7 +1840,7 @@ _commit: v1.0.0
 The special value `VcsRef.CURRENT` is set to indicate that the template version should
 be identical to the version already present. It is set when using `--vcs-ref=:current:`
 in the CLI. By default, Copier will copy from the last release found in template Git
-tags, sorted as [PEP 440][].
+tags, sorted as [PEP 440].
 
 ## Patterns syntax
 
@@ -1851,18 +1865,18 @@ _exclude:
 
 If the destination path exists and a `.copier-answers.yml` file is present there, it
 will be used to load the last user's answers to the questions made in [the `copier.yml`
-file][the-copieryml-file].
+file](#the-copieryml-file).
 
 This makes projects easier to update because when the user is asked, the default answers
 will be the last ones they used.
 
 The file **must be called exactly `#!jinja {{ _copier_conf.answers_file }}.jinja`** (or
-ended with [your chosen suffix][templates_suffix]) in your template's root folder) to
+ended with [your chosen suffix](#templates_suffix)) in your template's root folder) to
 allow [applying multiple templates to the same
-subproject][applying-multiple-templates-to-the-same-subproject].
+subproject](#applying-multiple-templates-to-the-same-subproject).
 
 The default name will be `.copier-answers.yml`, but [you can define a different default
-path for this file][answers_file].
+path for this file](#answers_file).
 
 The file must have this content:
 
@@ -1874,11 +1888,11 @@ The file must have this content:
 !!! important
 
     Did you notice that `NEVER EDIT MANUALLY` part?
-    [It is important][never-change-the-answers-file-manually].
+    [It is important](updating.md#never-change-the-answers-file-manually).
 
 The builtin `_copier_answers` variable includes all data needed to smooth future updates
 of this project. This includes (but is not limited to) all JSON-serializable values
-declared as user questions in [the `copier.yml` file][the-copieryml-file].
+declared as user questions in [the `copier.yml` file](#the-copieryml-file).
 
 As you can see, you also have the power to customize what will be logged here. Keys that
 start with an underscore (`_`) are specific to Copier. Other keys should match questions
@@ -1886,8 +1900,8 @@ in `copier.yml`.
 
 The path to the answers file must be expressed relative to the project root, because:
 
--   Its value must be available at render time.
--   It is used to update projects, and for that a project must be git-tracked. So, the
+- Its value must be available at render time.
+- It is used to update projects, and for that a project must be git-tracked. So, the
     file must be in the repo anyway.
 
 ### Applying multiple templates to the same subproject
@@ -1904,16 +1918,16 @@ Imagine this scenario:
 
 All 3 templates are completely independent:
 
--   Anybody can generate a project for the specific framework, no matter if they want to
+- Anybody can generate a project for the specific framework, no matter if they want to
     use pre-commit or not.
--   You want to share the same pre-commit configurations, no matter if the subproject is
+- You want to share the same pre-commit configurations, no matter if the subproject is
     for one or another framework.
--   You want to have a centralized CI configuration for all your company projects, no
+- You want to have a centralized CI configuration for all your company projects, no
     matter their pre-commit configuration or the framework they rely on.
 
 Well, don't worry. Copier has you covered. You just need to use a different answers file
 for each one. All of them contain a `#!jinja {{ _copier_conf.answers_file }}.jinja` file
-[as specified above][the-copier-answersyml-file]. Then you apply all the templates to
+[as specified above](#the-copier-answersyml-file). Then you apply all the templates to
 the same project:
 
 ```shell

--- a/docs/creating.md
+++ b/docs/creating.md
@@ -3,9 +3,9 @@
 A template is a directory: usually the root folder of a Git repository.
 
 The content of the files inside the project template is copied to the destination
-without changes, **unless they end with `.jinja`** (or [your chosen
-suffix][templates_suffix]). In that case, the templating engine will be used to render
-them.
+without changes, **unless they end with `.jinja`** (or
+[your chosen suffix](configuring.md#templates_suffix)). In that case, the templating
+engine will be used to render them.
 
 Jinja2 templating is used. Learn more about it by reading
 [Jinja2 documentation](https://jinja.palletsprojects.com/).
@@ -86,11 +86,11 @@ The following variables are always available in Jinja templates:
 ### `_copier_answers`
 
 `_copier_answers` includes the current answers dict, but slightly modified to make it
-suitable to [autoupdate your project safely][the-copier-answersyml-file]:
+suitable to [autoupdate your project safely](configuring.md#the-copier-answersyml-file):
 
--   It doesn't contain secret answers.
--   It doesn't contain any data that is not easy to render to JSON or YAML.
--   It contains special keys like `_commit` and `_src_path`, indicating how the last
+- It doesn't contain secret answers.
+- It doesn't contain any data that is not easy to render to JSON or YAML.
+- It contains special keys like `_commit` and `_src_path`, indicating how the last
     template update was done.
 
 ### `_copier_conf`
@@ -104,31 +104,31 @@ suitable to [autoupdate your project safely][the-copier-answersyml-file]:
 
 Attributes:
 
-| Name               | Type                                                          | Description                                                                                                                                                                                                                                                |
-| ------------------ | ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `answers_file`     | `PurePath`                                                    | The path for [the answers file][the-copier-answersyml-file] relative to `dst_path`.<br>See the [`answers_file`][] setting for related information.                                                                                                         |
-| `cleanup_on_error` | `bool`                                                        | When `True`, delete `dst_path` if there's an error.<br>See the [`cleanup_on_error`][] setting for related information.                                                                                                                                     |
-| `conflict`         | `Literal["inline", "rej"]`                                    | The output format of a diff code hunk when [updating][updating-a-project] a file yields conflicts.<br>See the [`conflict`][] setting for related information.                                                                                              |
-| `context_lines`    | `PositiveInt`                                                 | Lines of context to consider when solving conflicts in updates.<br>See the [`context_lines`][] setting for related information.                                                                                                                            |
-| `data`             | `dict[str, Any]`                                              | Answers to the questionnaire, defined in the template, provided via CLI (`-d,--data`) or API (`data`).<br>See the [`data`][] setting for related information.<br>⚠️ May contain secret answers.                                                            |
-| `defaults`         | `bool`                                                        | When `True`, use default answers to questions.<br>See the [`defaults`][] setting for related information.                                                                                                                                                  |
-| `dst_path`         | `PurePath`                                                    | Destination path where to render the subproject.<br>⚠️ When [updating a project][updating-a-project], it may be a temporary directory, as Copier's update algorithm generates fresh copies using the old and new template versions in temporary locations. |
-| `exclude`          | `Sequence[str]`                                               | Specified additional [file exclusion patterns][patterns-syntax].<br>See the [`exclude`][] setting for related information.                                                                                                                                 |
-| `os`               | <code>Literal["linux", "macos", "windows"] &vert; None</code> | The detected operating system, `None` if it could not be detected.                                                                                                                                                                                         |
-| `overwrite`        | `bool`                                                        | When `True`, overwrite files that already exist, without asking.<br>See the [`overwrite`][] setting for related information.                                                                                                                               |
-| `pretend`          | `bool`                                                        | When `True`, produce no real rendering.<br>See the [`pretend`][] setting for related information.                                                                                                                                                          |
-| `quiet`            | `bool`                                                        | When `True`, disable all output.<br>See the [`quiet`][] setting for related information.                                                                                                                                                                   |
-| `sep`              | `str`                                                         | The operating system-specific directory separator.                                                                                                                                                                                                         |
-| `settings`         | [`copier.settings.Settings`][]                                | General user settings.<br>See the [`settings`][] page for related information.                                                                                                                                                                             |
-| `skip_answered`    | `bool`                                                        | When `True`, skip questions that have already been answered.<br>See the [`skip_answered`][] setting for related information.                                                                                                                               |
-| `skip_if_exists`   | `Sequence[str]`                                               | Specified additional [file skip patterns][patterns-syntax].<br>See the [`skip_if_exists`][] setting for related information.                                                                                                                               |
-| `skip_tasks`       | `bool`                                                        | When `True`, skip [template tasks execution][tasks].<br>See the [`skip_tasks`][] setting for related information.                                                                                                                                          |
-| `src_path`         | `PurePath`                                                    | The absolute path to the (cloned/downloaded) template on disk.                                                                                                                                                                                             |
-| `unsafe`           | `bool`                                                        | When `True`, allow usage of unsafe templates.<br>See the [`unsafe`][] setting for related information.                                                                                                                                                     |
-| `use_prereleases`  | `bool`                                                        | When `True`, `vcs_ref`/`vcs_ref_hash` may refer to a prerelease version of the template.<br>See the [`use_prereleases`][] setting for related information.                                                                                                 |
-| `user_defaults`    | `dict[str, Any]`                                              | Specified user defaults that may override a template's defaults during question prompts.                                                                                                                                                                   |
-| `vcs_ref`          | <code>str &vert; None</code>                                  | The VCS tag/commit of the template, `None` if the template is not VCS-tracked.<br>See the [`vcs_ref`][] setting for related information.                                                                                                                   |
-| `vcs_ref_hash`     | <code>str &vert; None</code>                                  | The VCS commit hash of the template, `None` if the template is not VCS-tracked.                                                                                                                                                                            |
+| Name               | Type                                                          | Description                                                                                                                                                                                                                                         |
+| ------------------ | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `answers_file`     | `PurePath`                                                    | The path for [the answers file](configuring.md#the-copier-answersyml-file) relative to `dst_path`.<br>See the [`answers_file`](configuring.md#answers_file) setting for related information.                                                        |
+| `cleanup_on_error` | `bool`                                                        | When `True`, delete `dst_path` if there's an error.<br>See the [`cleanup_on_error`](configuring.md#cleanup_on_error) setting for related information.                                                                                               |
+| `conflict`         | `Literal["inline", "rej"]`                                    | The output format of a diff code hunk when [updating][updating-a-project] a file yields conflicts.<br>See the [`conflict`](configuring.md#conflict) setting for related information.                                                                |
+| `context_lines`    | `PositiveInt`                                                 | Lines of context to consider when solving conflicts in updates.<br>See the [`context_lines`](configuring.md#context_lines) setting for related information.                                                                                         |
+| `data`             | `dict[str, Any]`                                              | Answers to the questionnaire, defined in the template, provided via CLI (`-d,--data`) or API (`data`).<br>See the [`data`](configuring.md#data) setting for related information.<br>⚠️ May contain secret answers.                                  |
+| `defaults`         | `bool`                                                        | When `True`, use default answers to questions.<br>See the [`defaults`](configuring.md#defaults) setting for related information.                                                                                                                    |
+| `dst_path`         | `PurePath`                                                    | Destination path where to render the subproject.<br>⚠️ When [updating a project](updating.md), it may be a temporary directory, as Copier's update algorithm generates fresh copies using the old and new template versions in temporary locations. |
+| `exclude`          | `Sequence[str]`                                               | Specified additional [file exclusion patterns](configuring.md#patterns-syntax).<br>See the [`exclude`](configuring.md#exclude) setting for related information.                                                                                     |
+| `os`               | <code>Literal["linux", "macos", "windows"] &vert; None</code> | The detected operating system, `None` if it could not be detected.                                                                                                                                                                                  |
+| `overwrite`        | `bool`                                                        | When `True`, overwrite files that already exist, without asking.<br>See the [`overwrite`](configuring.md#overwrite) setting for related information.                                                                                                |
+| `pretend`          | `bool`                                                        | When `True`, produce no real rendering.<br>See the [`pretend`](configuring.md#pretend) setting for related information.                                                                                                                             |
+| `quiet`            | `bool`                                                        | When `True`, disable all output.<br>See the [`quiet`](configuring.md#quiet) setting for related information.                                                                                                                                        |
+| `sep`              | `str`                                                         | The operating system-specific directory separator.                                                                                                                                                                                                  |
+| `settings`         | `copier.settings.Settings`                                    | General user settings.<br>See the [`settings`](settings.md) page for related information.                                                                                                                                                           |
+| `skip_answered`    | `bool`                                                        | When `True`, skip questions that have already been answered.<br>See the [`skip_answered`](configuring.md#skip_answered) setting for related information.                                                                                            |
+| `skip_if_exists`   | `Sequence[str]`                                               | Specified additional [file skip patterns][patterns-syntax].<br>See the [`skip_if_exists`](configuring.md#skip_if_exists) setting for related information.                                                                                           |
+| `skip_tasks`       | `bool`                                                        | When `True`, skip [template tasks execution][tasks].<br>See the [`skip_tasks`](configuring.md#skip_tasks) setting for related information.                                                                                                          |
+| `src_path`         | `PurePath`                                                    | The absolute path to the (cloned/downloaded) template on disk.                                                                                                                                                                                      |
+| `unsafe`           | `bool`                                                        | When `True`, allow usage of unsafe templates.<br>See the [`unsafe`](configuring.md#unsafe) setting for related information.                                                                                                                         |
+| `use_prereleases`  | `bool`                                                        | When `True`, `vcs_ref`/`vcs_ref_hash` may refer to a prerelease version of the template.<br>See the [`use_prereleases`](configuring.md#use_prereleases) setting for related information.                                                            |
+| `user_defaults`    | `dict[str, Any]`                                              | Specified user defaults that may override a template's defaults during question prompts.                                                                                                                                                            |
+| `vcs_ref`          | <code>str &vert; None</code>                                  | The VCS tag/commit of the template, `None` if the template is not VCS-tracked.<br>See the [`vcs_ref`](configuring.md#vcs_ref) setting for related information.                                                                                      |
+| `vcs_ref_hash`     | <code>str &vert; None</code>                                  | The VCS commit hash of the template, `None` if the template is not VCS-tracked.                                                                                                                                                                     |
 
 ### `_copier_python`
 
@@ -136,14 +136,14 @@ The absolute path of the Python interpreter running Copier.
 
 ### `_external_data`
 
-A dict of the data contained in [external_data][].
+A dict of the data contained in [external_data](configuring.md#external_data).
 
 When rendering the template, that data will be exposed in the special `_external_data`
 variable:
 
--   Keys will be the same as in [external_data][].
--   Values will be the files contents parsed as YAML. JSON is also compatible.
--   Parsing is done lazily on first use.
+- Keys will be the same as in [external_data](configuring.md#external_data).
+- Values will be the files contents parsed as YAML. JSON is also compatible.
+- Parsing is done lazily on first use.
 
 ### `_folder_name`
 
@@ -173,7 +173,7 @@ Availability: [`exclude`](configuring.md#exclude), [`tasks`](configuring.md#task
 
 Some rendering contexts provide variables unique to them:
 
--   [`migrations`](configuring.md#migrations)
+- [`migrations`](configuring.md#migrations)
 
 ## Loop over lists to generate files and directories
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -3,8 +3,8 @@
 ## Can Copier be applied over a preexisting project?
 
 Yes, of course. Copier understands this use case out of the box. That's actually what
-powers features such as [updating](updating.md) or the ability of [applying multiple
-templates to the same subproject][applying-multiple-templates-to-the-same-subproject].
+powers features such as [updating](updating.md) or the ability of
+[applying multiple templates to the same subproject](configuring.md#applying-multiple-templates-to-the-same-subproject).
 
 !!! example
 
@@ -54,8 +54,8 @@ Combine `default` and `when: false`.
         when: false # This makes sure it isn't asked nor stored
     ```
 
-See [advanced prompt formatting docs][advanced-prompt-formatting]. If you need more
-power, see [below][how-can-i-alter-the-context-before-rendering-the-project].
+See [advanced prompt formatting docs](configuring.md#advanced-prompt-formatting). If you
+need more power, see [below](#how-can-i-alter-the-context-before-rendering-the-project).
 
 ## How to "lock" a computed value?
 
@@ -63,7 +63,7 @@ When you want to ensure that a computed value is set or locked during project
 initialization, for example if you want to store a dynamically computed `copyright_year`
 but ensure that it doesn't change upon later Copier template updates, you can combine
 the `default` and `when: false` configuration while also explicitly dumping the value to
-YAML with the [answers file][the-copier-answersyml-file].
+YAML with the [answers file](configuring.md#the-copier-answersyml-file).
 
 !!! example
 
@@ -84,14 +84,14 @@ YAML with the [answers file][the-copier-answersyml-file].
 **Use the [`ContextHook` extension][context-hook].** It lets you modify the context used
 to render templates, so that you can add, change or remove variables. Since it is a
 Python extension, you have the full power of Python at your fingertips, at the cost of
-having to mark the template as [unsafe][].
+having to mark the template as [unsafe](configuring.md#unsafe).
 
 [context-hook]:
-    https://github.com/copier-org/copier-templates-extensions#context-hook-extension
+    <https://github.com/copier-org/copier-templates-extensions#context-hook-extension>
 
 In order for Copier to be able to load and use the extension when generating a project,
 it must be installed alongside Copier itself. More details in the [`jinja_extensions`
-docs][jinja_extensions].
+docs](configuring.md#jinja_extensions).
 
 You can then configure your Jinja extensions in Copier's configuration file:
 
@@ -178,9 +178,9 @@ repository.
 
 ## While developing, why doesn't the template include dirty changes?
 
-Copier follows [a specific algorithm][templates-versions] to choose what reference to
-use from the template. It also [includes dirty changes in the `HEAD` ref while
-developing locally][copying-dirty-changes].
+Copier follows [a specific algorithm](generating.md#templates-versions) to choose what
+reference to use from the template. It also
+[includes dirty changes in the `HEAD` ref while developing locally](generating.md#copying-dirty-changes).
 
 However, did you make sure you are selecting the `HEAD` ref for copying?
 
@@ -198,7 +198,7 @@ v2.0.0
 Now, if you copy that template into a folder like this:
 
 ```shell
-$ copier copy ./src ./dst
+copier copy ./src ./dst
 ```
 
 ... you'll notice there's no `new-file.txt`. Why?
@@ -209,7 +209,7 @@ Well, Copier indeed included that into the `HEAD` ref. However, it still selecte
 However, if you do this:
 
 ```shell
-$ copier copy -r HEAD ./src ./dst
+copier copy -r HEAD ./src ./dst
 ```
 
 ... then you'll notice `new-file.txt` does exist. You passed a specific ref to copy, so
@@ -218,7 +218,8 @@ Copier skips its autodetection and just goes for the `HEAD` you already chose.
 ## How to pass credentials to Git?
 
 If you do something like this, and the template supports updates, you'll notice that the
-credentials will end up stored in [the answers file][the-copier-answersyml-file]:
+credentials will end up stored in
+[the answers file](configuring.md#the-copier-answersyml-file):
 
 ```shell
 copier copy https://myuser:example.com/repo.git .
@@ -228,8 +229,8 @@ To avoid that, the simplest fix is to clone using SSH with cryptographic key
 authentication. If you cannot do that, then check out these links for strategies on
 passing HTTPS credentials to Git:
 
--   https://github.com/copier-org/copier/issues/466#issuecomment-2338160284
--   https://stackoverflow.com/q/35942754
--   https://git-scm.com/docs/gitcredentials
--   https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage#_credential_caching
--   https://github.com/topics/git-credential-helper
+- <https://github.com/copier-org/copier/issues/466#issuecomment-2338160284>
+- <https://stackoverflow.com/q/35942754>
+- <https://git-scm.com/docs/gitcredentials>
+- <https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage#_credential_caching>
+- <https://github.com/topics/git-credential-helper>

--- a/docs/generating.md
+++ b/docs/generating.md
@@ -24,8 +24,8 @@ read-only).
 
 The "template" parameter can be a local path, an URL, or a shortcut URL:
 
--   GitHub: `gh:namespace/project`
--   GitLab: `gl:namespace/project`
+- GitHub: `gh:namespace/project`
+- GitLab: `gl:namespace/project`
 
 If Copier doesn't detect your remote URL as a Git repository, make sure it starts with
 one of `git+https://`, `git+ssh://`, `git@` or `git://`, or it ends with `.git`.
@@ -52,8 +52,8 @@ modifications made, Copier will use this modified working copy of the template t
 development of new template features.
 
 If you would like to override the version of template being installed, the
-[`--vcs-ref`][vcs_ref] argument can be used to specify a branch, tag or other reference
-to use.
+[`--vcs-ref`](configuring.md#vcs_ref) argument can be used to specify a branch, tag or
+other reference to use.
 
 For example to use the latest master branch from a public repository:
 
@@ -75,6 +75,6 @@ will just reapply the template on it, keeping answers but ignoring previous hist
 
 !!! warning
 
-    This is not [the recommended approach for updating a project][updating-a-project],
+    This is not [the recommended approach for updating a project](updating.md),
     where you usually want Copier to respect the project evolution wherever it doesn't
     conflict with the template evolution.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -3,16 +3,18 @@
 Copier settings are stored in `<CONFIG_ROOT>/settings.yml` where `<CONFIG_ROOT>` is the
 standard configuration directory for your platform:
 
--   `$XDG_CONFIG_HOME/copier` (`~/.config/copier ` in most cases) on Linux as defined by
+- `$XDG_CONFIG_HOME/copier` (`~/.config/copier` in most cases) on Linux as defined by
     [XDG Base Directory Specifications](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
--   `~/Library/Application Support/copier` on macOS as defined by
+- `~/Library/Application Support/copier` on macOS as defined by
     [Apple File System Basics](https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/FileSystemProgrammingGuide/FileSystemOverview/FileSystemOverview.html)
--   `%USERPROFILE%\AppData\Local\copier` on Windows as defined in
+- `%USERPROFILE%\AppData\Local\copier` on Windows as defined in
     [Known folders](https://docs.microsoft.com/en-us/windows/win32/shell/known-folders)
 
 !!! note
 
-    Windows only: `%USERPROFILE%\AppData\Local\copier\copier` was the standard configuration directory until v9.6.0. This standard configuration directory is deprecated and will be removed in a future version.
+    Windows only: `%USERPROFILE%\AppData\Local\copier\copier` was the standard
+    configuration directory until v9.6.0. This standard configuration directory is
+    deprecated and will be removed in a future version.
 
 This location can be overridden by setting the `COPIER_SETTINGS_PATH` environment
 variable.
@@ -56,5 +58,5 @@ trust:
 
 !!! warning "Security considerations"
 
-    Locations ending with `/` will be matched as prefixes, trusting all templates starting with that path.
-    Locations not ending with `/` will be matched exactly.
+    Locations ending with `/` will be matched as prefixes, trusting all templates
+    starting with that path. Locations not ending with `/` will be matched exactly.

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -20,7 +20,7 @@ The best way to update a project from its template is when all of these conditio
 true:
 
 1. The destination folder includes [a valid `.copier-answers.yml`
-   file][the-copier-answersyml-file].
+   file](configuring.md#the-copier-answersyml-file).
 1. The template is versioned with Git (with tags).
 1. The destination folder is versioned with Git.
 
@@ -41,9 +41,9 @@ answers you provided when copied last time. However, sometimes it's impossible f
 Copier to know what to do with a diff code hunk. In those cases, copier handles the
 conflict in one of two ways, controlled with the `--conflict` option:
 
--   `--conflict rej`: Creates a separate `.rej` file for each file with conflicts. These
+- `--conflict rej`: Creates a separate `.rej` file for each file with conflicts. These
     files contain the unresolved diffs.
--   `--conflict inline` (default): Updates the file with conflict markers. This is quite
+- `--conflict inline` (default): Updates the file with conflict markers. This is quite
     similar to the conflict markers created when a `git merge` command encounters a
     conflict. For more information, see the "Checking Out Conflicts" section of the
     [`git` documentation](https://git-scm.com/book/en/v2/Git-Tools-Advanced-Merging).
@@ -129,7 +129,7 @@ to go through the whole questionnaire again:
 copier update --defaults --data updated_question="my new answer"
 ```
 
-You can achieve the same using a [data file][data_file]:
+You can achieve the same using a [data file](configuring.md#data_file):
 
 ```shell
 echo "updated_question: my new answer" > /tmp/data-file.yaml
@@ -191,12 +191,12 @@ class compare,update,apply blackborder;
 
 As you can see here, `copier` does several things:
 
--   It regenerates a fresh project from the current template version.
--   Then, it compares both version to get the diff from "fresh project" to "current
+- It regenerates a fresh project from the current template version.
+- Then, it compares both version to get the diff from "fresh project" to "current
     project".
--   Now, it applies pre-migrations to your project, and updates the current project with
+- Now, it applies pre-migrations to your project, and updates the current project with
     the latest template changes (asking for confirmation).
--   Finally, it re-applies the previously obtained diff and then runs the
+- Finally, it re-applies the previously obtained diff and then runs the
     post-migrations.
 
 ### Handling of deleted paths
@@ -214,19 +214,20 @@ Their presence is always ensured, even during an `update` operation.
 Usually Copier will replay the last project generation without problems. However,
 sometimes that process can break. Examples:
 
--   When the last update was relying on some external resources that are no longer
+- When the last update was relying on some external resources that are no longer
     available.
--   When the old and new versions of the template depend on different incompatible
+- When the old and new versions of the template depend on different incompatible
     versions of the same Jinja extension, but Copier can only use one.
--   When the old version of the template was built for an older version of Copier.
+- When the old version of the template was built for an older version of Copier.
 
 Generally, you should keep your templates as pure and simple as possible to avoid those
 situations. But it can still happen.
 
-To overcome this, use [the `copier recopy` command][regenerating-a-project], which will
-discard all the smart update algorithm [explained above][how-the-update-works]. It will
-behave just like if you were applying the template for the first time, but it will keep
-your answers from the last update.
+To overcome this, use
+[the `copier recopy` command](generating.md#regenerating-a-project), which will discard
+all the smart update algorithm [explained above](#how-the-update-works). It will behave
+just like if you were applying the template for the first time, but it will keep your
+answers from the last update.
 
 Of course, the experience will be less satisfactory. The new template will override any
 changes found in your local project. But you can use a Git diff tool to overcome that.
@@ -239,9 +240,9 @@ the introduced changes to your code base, specifically when you have unpleasant
 conflicts, it's not 100% obvious how to get back to the previously clean copy of your
 branch. The following strategies won't work:
 
--   `git checkout <branch>` – _error: you need to resolve your current index first_
--   `git checkout .` – _error: path '&lt;filename&gt;' is unmerged_
--   `git merge --abort` – _fatal: There is no merge to abort (MERGE_HEAD missing)_
+- `git checkout <branch>` – _error: you need to resolve your current index first_
+- `git checkout .` – _error: path '&lt;filename&gt;' is unmerged_
+- `git merge --abort` – _fatal: There is no merge to abort (MERGE_HEAD missing)_
 
 Here is what you can do using Git in the terminal to throw away all changes:
 
@@ -288,7 +289,7 @@ To facilitate automated checking for updates, `copier check-update` provides two
 options:
 
 1. JSON output via the flag `--output-format json`
-2. Exit code output via the flag `--quiet`
+1. Exit code output via the flag `--quiet`
 
 Sample output is provided for different scenarios:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,3 +103,6 @@ plugins:
         "reference/types.md": "reference/api.md"
         "reference/user_data.md": "reference/api.md"
         "reference/vcs.md": "reference/api.md"
+
+hooks:
+  - mkdocs_hooks.py

--- a/mkdocs_hooks.py
+++ b/mkdocs_hooks.py
@@ -1,0 +1,22 @@
+"""MkDocs plugin hooks."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mkdocs.config.defaults import MkDocsConfig
+    from mkdocs.structure.files import Files
+    from mkdocs.structure.pages import Page
+
+
+def on_page_markdown(
+    markdown: str,
+    page: Page,  # noqa: ARG001
+    config: MkDocsConfig,  # noqa: ARG001
+    files: Files,  # noqa: ARG001
+) -> str | None:
+    """Modify markdown content before it's converted to HTML."""
+    # Rewrite links from `CHANGELOG.md` to `changelog.md` to match the filename of the
+    # MkDocs page.
+    return markdown.replace("CHANGELOG.md)", "changelog.md)")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
   "pytest-gitconfig==0.9.0",
   "pytest-xdist==3.8.0",
   "ruff==0.15.6",
+  "rumdl==0.1.57",
   "taplo==0.9.3",
   "types-backports==0.1.3",
   "types-colorama==0.4.15.20250801",
@@ -162,6 +163,10 @@ warn_return_any = false
 module = ["tests.test_cli", "tests.test_prompt"]
 disable_error_code = ["no-untyped-def"]
 
+[[tool.mypy.overrides]]
+module = "mkdocs_hooks"
+disable_error_code = ["import-not-found"]
+
 [tool.pytest.ini_options]
 addopts = "-n auto -ra"
 markers = ["impure: needs network or is not 100% reproducible"]
@@ -193,6 +198,23 @@ skip = '.git*,*.svg,*.lock,*.css,pyproject.toml,.mypy_cache,.venv'
 check-hidden = true
 ignore-regex = '\bla vie\b'
 ignore-words-list = 'ans'
+
+[tool.rumdl]
+flavor = "mkdocs"
+line_length = 88
+
+[tool.rumdl.MD013]
+reflow = true
+code-blocks = false
+
+[tool.rumdl.MD029]
+style = "one"
+
+[tool.rumdl.MD033]
+allowed-elements = ["br", "code"]
+
+[tool.rumdl.MD060]
+enabled = true
 
 [tool.hatch.version]
 source = "vcs"

--- a/uv.lock
+++ b/uv.lock
@@ -252,6 +252,7 @@ dev = [
     { name = "pytest-gitconfig" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "rumdl" },
     { name = "taplo" },
     { name = "types-backports" },
     { name = "types-colorama" },
@@ -298,6 +299,7 @@ dev = [
     { name = "pytest-gitconfig", specifier = "==0.9.0" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
     { name = "ruff", specifier = "==0.15.6" },
+    { name = "rumdl", specifier = "==0.1.57" },
     { name = "taplo", specifier = "==0.9.3" },
     { name = "types-backports", specifier = "==0.1.3" },
     { name = "types-colorama", specifier = "==0.4.15.20250801" },
@@ -1540,6 +1542,21 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
     { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+]
+
+[[package]]
+name = "rumdl"
+version = "0.1.57"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/b5/fe99af4edea2cda4a198617974f2b964f6c9aba46eaeeed13025f9ebbc06/rumdl-0.1.57.tar.gz", hash = "sha256:96ac54ca70b39e6422dbc05612f0c5f02cbd4665f58a237cf1eeb7f5c7cabd33", size = 2304599, upload-time = "2026-03-20T13:12:47.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b8/d76b296ae3c3a25d70d05da66186d4aa42e0403d422fc071b100ac95c092/rumdl-0.1.57-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e1f614b7f57a09aaecd3886b79d9b08b4eab1c76ed83bcd65b0be37c745e7b02", size = 5298985, upload-time = "2026-03-20T13:12:40.33Z" },
+    { url = "https://files.pythonhosted.org/packages/38/02/c85c7948baa36dbb589338fc5b6ed5af2feecf5b58bbc1160a9f7aac5f53/rumdl-0.1.57-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d5ccc334ee125ceeaf9f33ea72fb32454e5b9cf0cb51746fa99071aa4c7738d4", size = 4916156, upload-time = "2026-03-20T13:12:35.736Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f7/716312288576763d2a863bea16370990d6d2978c50733cebad2583da6df7/rumdl-0.1.57-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:d62037d04e3906fa0b3a77db3b5128588a5a42799db1ceef500f7bf214db3c58", size = 5129988, upload-time = "2026-03-20T13:12:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/90/df42ad1ac5cc31674bba7d8f9b511f26d812633bbb976e0594a82f932a89/rumdl-0.1.57-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f1da6bc5bd2aac713fd9d164b0fac7a17c651d3756ca82054eddc3c333078011", size = 5523695, upload-time = "2026-03-20T13:12:44.236Z" },
+    { url = "https://files.pythonhosted.org/packages/00/d8/77bf20da9a7aa44b85a24d701cb895e3643282f6e40b9712273c1226bbb9/rumdl-0.1.57-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:a22921a062bf33b9cddbc3e838c92db4e708af755ff69764aad4697873e35ead", size = 5133292, upload-time = "2026-03-20T13:12:38.633Z" },
+    { url = "https://files.pythonhosted.org/packages/07/08/5934a7026ffd876e575650e65c057fcba5df3eca1c3f7efdf50d333100fc/rumdl-0.1.57-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9e05e10f3d72e0eb85ed3c27ed59727a04fe187959914d91c01277107e9bbe55", size = 5521413, upload-time = "2026-03-20T13:12:45.584Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/11/a714138908ab84c4f953484674fa37045af12ed781d24348f156740fdc08/rumdl-0.1.57-py3-none-win_amd64.whl", hash = "sha256:c85dc7d153b3f77ea5be3128fa74e29f3f2c5b582c4744126ed7b9af4de20778", size = 5587232, upload-time = "2026-03-20T13:12:41.779Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
I've introduced [rumdl](https://rumdl.dev/) as our new Markdown formatter and linter and fixed raised errors accordingly. At the same time, I've configured Prettier to ignore Markdown files.

rumdl brings built-in Python/MkDocs-flavored Markdown support which is a major improvement over Prettier. Also, we've been stuck with an old Prettier version, as more recent versions break formatting compliance with the Python/MkDocs flavor. After delegating Markdown formatting to rumdl, we should finally be able to update to a recent Prettier version.