### PR TITLE
chore(config): remove Prettier version cap package rule from Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,12 +22,6 @@
       "rangeStrategy": "pin"
     },
     {
-      "description": "Don't update Prettier to v3.4.0+ because it breaks some Markdown syntax extensions (https://github.com/prettier/prettier/issues/16929)",
-      "matchDatasources": ["devbox"],
-      "matchPackageNames": ["nodePackages.prettier"],
-      "allowedVersions": "<3.4.0"
-    },
-    {
       "matchCategories": ["python"],
       "addLabels": ["python"]
     },


### PR DESCRIPTION
Due to #2561, we can now update Prettier to a recent version. Thus, I've removed the Renovate package rule that capped Prettier's version to the last release before breaking compatibility with Python/MkDocs-flavored Markdown.