### PR TITLE
build(deps): replace `nodePackages.prettier` by `prettier` and update to v3.6.2

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -4,7 +4,7 @@
     "difftastic@0.67.0",
     "editorconfig-checker@3.6.1",
     "git@2.53.0",
-    "nodePackages.prettier@3.5.3",
+    "prettier@3.6.2",
     "uv@0.10.10"
   ],
   "env": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -173,51 +173,51 @@
       "last_modified": "2026-02-23T15:40:43Z",
       "resolved": "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97?lastModified=1771861243&narHash=sha256-mz05b1VyLWoTkNg8iJr3yXFJF7HDlwIUKI3ln39RacY%3D"
     },
-    "nodePackages.prettier@3.5.3": {
-      "last_modified": "2025-05-21T18:43:04Z",
-      "resolved": "github:NixOS/nixpkgs/8c441601c43232976179eac52dde704c8bdf81ed#nodePackages.prettier",
+    "prettier@3.6.2": {
+      "last_modified": "2026-03-06T04:25:18Z",
+      "resolved": "github:NixOS/nixpkgs/e38213b91d3786389a446dfce4ff5a8aaf6012f2#prettier",
       "source": "devbox-search",
-      "version": "3.5.3",
+      "version": "3.6.2",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/yspchsd3ww1ddz2r5783kw8y9j0vr3r8-prettier-3.5.3",
+              "path": "/nix/store/727v1xvix6h5z349k6yslpa1nk1hxgds-prettier-3.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/yspchsd3ww1ddz2r5783kw8y9j0vr3r8-prettier-3.5.3"
+          "store_path": "/nix/store/727v1xvix6h5z349k6yslpa1nk1hxgds-prettier-3.6.2"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/ya3imag4wkxj3g5fws96rzyzv36m74w8-prettier-3.5.3",
+              "path": "/nix/store/srrwdkd9307kqd6g3qzcn96affxf59vc-prettier-3.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/ya3imag4wkxj3g5fws96rzyzv36m74w8-prettier-3.5.3"
+          "store_path": "/nix/store/srrwdkd9307kqd6g3qzcn96affxf59vc-prettier-3.6.2"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/f9q2y20qa56hjzxnia0q664m0rkwwqvm-prettier-3.5.3",
+              "path": "/nix/store/p7fkyhr9hgn1y23fg1s9r64pbrjg3nlm-prettier-3.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/f9q2y20qa56hjzxnia0q664m0rkwwqvm-prettier-3.5.3"
+          "store_path": "/nix/store/p7fkyhr9hgn1y23fg1s9r64pbrjg3nlm-prettier-3.6.2"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/wry9vlk19pk7izrknb980icc8gihzllx-prettier-3.5.3",
+              "path": "/nix/store/8skdr5xqspbgwfvhj9hq91jnk6ir13kg-prettier-3.6.2",
               "default": true
             }
           ],
-          "store_path": "/nix/store/wry9vlk19pk7izrknb980icc8gihzllx-prettier-3.5.3"
+          "store_path": "/nix/store/8skdr5xqspbgwfvhj9hq91jnk6ir13kg-prettier-3.6.2"
         }
       }
     },


### PR DESCRIPTION
I've replaced the Devbox/Nix package `nodePackages.prettier`, which seems discontinued, by `prettier` and updated to the latest version v3.6.2.