### PR TITLE
fix(migrations): use configurable Jinja delimiters for default migration condition

### DIFF
--- a/copier/_template.py
+++ b/copier/_template.py
@@ -424,16 +424,19 @@ class Template:
                     )
             else:
                 # New configuration format
+                v_start = self.envops.get("variable_start_string", "{{")
+                v_end = self.envops.get("variable_end_string", "}}")
+                default_condition = f'{v_start} _stage == "after" {v_end}'
                 if isinstance(migration, (str, list)):
                     result.append(
                         Task(
                             cmd=migration,
                             extra_vars=extra_vars,
-                            condition='{{ _stage == "after" }}',
+                            condition=default_condition,
                         )
                     )
                 else:
-                    condition = migration.get("when", '{{ _stage == "after" }}')
+                    condition = migration.get("when", default_condition)
                     working_directory = Path(migration.get("working_directory", "."))
                     if "version" in migration:
                         current = parse(migration["version"])

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,4 +1,7 @@
+import json
+from collections.abc import Mapping, Sequence
 from pathlib import Path
+from typing import Any
 
 import pytest
 from plumbum import local
@@ -8,6 +11,7 @@ from copier._user_data import load_answersfile_data
 from copier.errors import UnsafeTemplateError, UserMessageError
 
 from .helpers import (
+    BRACKET_ENVOPS,
     COPIER_ANSWERS_FILE,
     PROJECT_TEMPLATE,
     build_file_tree,
@@ -30,6 +34,57 @@ def test_basic_migration(tmp_path_factory: pytest.TempPathFactory) -> None:
                     """\
                     _migrations:
                         - touch foo
+                    """
+                ),
+            }
+        )
+        git_save(tag="v1")
+    with local.cwd(dst):
+        run_copy(src_path=str(src))
+        git_save()
+
+    assert not (dst / "foo").exists()  # Migrations don't run on initial copy
+
+    with local.cwd(src):
+        git("tag", "v2")
+    with local.cwd(dst):
+        run_update(defaults=True, overwrite=True, unsafe=True)
+
+    assert (dst / "foo").is_file()
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "touch foo",
+        ["touch", "foo"],
+        {"command": "touch foo"},
+        {"command": ["touch", "foo"]},
+    ],
+)
+@pytest.mark.parametrize("envops", [{}, BRACKET_ENVOPS])
+def test_post_migration_by_default(
+    tmp_path_factory: pytest.TempPathFactory,
+    envops: Mapping[str, Any],
+    command: str | Sequence[str] | Mapping[str, Any],
+) -> None:
+    """Test a basic migration running on every version"""
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    v_start = envops.get("variable_start_string", "{{")
+    v_end = envops.get("variable_end_string", "}}")
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                f"{v_start} _copier_conf.answers_file {v_end}.jinja": (
+                    f"{v_start} _copier_answers|tojson {v_end}"
+                ),
+                "copier.yml": (
+                    f"""\
+                    _envops: {json.dumps(envops)}
+                    _migrations:
+                        - {json.dumps(command)}
                     """
                 ),
             }


### PR DESCRIPTION
I've fixed a bug related to rendering the default migration condition.

The default migration condition (`{{ _stage == "after" }}`) was built with hardcoded `{{` and `}}` as variable start/end strings. When a template configured alternative delimiters via `_envops` such as

```yaml
_envops:
  variable_start_string: "[["
  variable_end_string: "]]"
```

the default condition would contain the wrong delimiters and fail to render correctly.

The condition is now constructed using the delimiters resolved from the `_envops` settings in `copier.yml`, falling back to `{{` and `}}` when not overridden.