### PR TITLE
fix(vcs): fix Git tag lookup for relative local template paths

### DIFF
--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -7,6 +7,7 @@ import sys
 from contextlib import suppress
 from pathlib import Path
 from tempfile import TemporaryDirectory, mkdtemp
+from urllib.parse import urlparse
 from warnings import warn
 
 from packaging import version
@@ -143,6 +144,15 @@ def get_latest_tag(url: str, use_prereleases: OptBool = False) -> str:
     Returns:
         The latest git tag, or `HEAD` if no valid tags are found.
     """
+    # For local Git repos, `git ls-remote` requires an absolute path to work correctly,
+    # it behaves unexpectedly with some relative paths, especially with parent path
+    # traversal.
+    #
+    # See:
+    # - https://github.com/copier-org/copier/issues/2589
+    # - https://stackoverflow.com/q/59981939
+    if urlparse(url).scheme in {"", "file"}:
+        url = Path(url).resolve().as_posix()
     git = get_git()
     all_tags = (
         tag.split("\t", 1)[1].removeprefix("refs/tags/")

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -1426,3 +1426,22 @@ def test_warn_if_chmod_raises_permission_error(
 
     assert (dst / "test.txt").stat().st_mode == dst_file_mode
     assert (dst / "test.txt").read_text("utf-8") == "foo"
+
+
+@pytest.mark.parametrize("depth", [1, 2, 3])
+def test_copy_with_relative_path_to_local_git_template_through_multiple_parents(
+    tmp_path_factory: pytest.TempPathFactory, depth: int
+) -> None:
+    root = tmp_path_factory.mktemp("root")
+    (src := root / "src").mkdir()
+    (dst := root.joinpath(*["dst"] * depth)).mkdir(parents=True)
+
+    build_file_tree({src / "test.txt.jinja": "test"})
+    git_save(src, tag="v1")
+
+    git_save(root / "dst", allow_empty=True)
+    with local.cwd(dst):
+        run_copy("../" * depth + "src", dst)
+
+    assert (dst / "test.txt").is_file()
+    assert (dst / "test.txt").read_text() == "test"


### PR DESCRIPTION
Copier uses `git ls-remote` to look up available tags in a template repository. With relative paths containing parent traversal segments (e.g. `../../my-template`), `git ls-remote` can behave unexpectedly, working correctly in some cases but not others. Resolve local file paths to their absolute form before passing them to `git ls-remote` to ensure consistent behavior regardless of the working directory.

Fixes #2589.