### PR TITLE
feat(updating): propagate exec bit on new template files when core.fileMode=false

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -895,7 +895,49 @@ class Worker:
                         f"{stat.filemode(dst_mode)} to {stat.filemode(src_mode)}",
                         stacklevel=2,
                     )
+            self._register_in_git_index(dst_relpath)
             self._sync_git_index_executable_bit(dst_relpath, src_mode)
+
+    def _register_in_git_index(self, dst_relpath: Path) -> None:
+        """Register a freshly-rendered file in the destination's git index.
+
+        Runs ``git add --intent-to-add`` on the file when the destination
+        is a git repository and the file is not yet tracked, regardless
+        of the executable bit or ``core.fileMode``. This makes the file
+        appear in ``git status`` as ``A`` (added with intent) rather
+        than ``??`` (untracked), accurately reflecting that the file is
+        deliberate template output rather than random user-created
+        content. It also gives :meth:`_sync_git_index_executable_bit`
+        an existing index entry whose mode it can rewrite via
+        ``update-index --cacheinfo`` on filesystems that don't preserve
+        executable bits.
+
+        No-op when the destination is not a git repository, when the
+        file is already tracked, or when git is unavailable. All git
+        failures are swallowed so copying or updating cannot be broken
+        by an unrelated git problem — most notably, ``git add
+        --intent-to-add`` fails on gitignored files, and that's the
+        user's explicit signal not to track them.
+        """
+        subproject_root = self.subproject.local_abspath
+        git = get_git(context_dir=subproject_root)
+        try:
+            # TODO: simplify with ``--format %(objectmode)`` once the
+            # minimum git version is raised to 2.38+ (--format cannot be
+            # combined with --stage; see git-ls-files(1)).
+            result = git("ls-files", "--stage", "--", str(dst_relpath)).strip()
+        except ProcessExecutionError:
+            # Not a git repo, or git can't read the index.
+            return
+        if result:
+            # Already tracked; nothing to do.
+            return
+        try:
+            git("add", "--intent-to-add", "--", str(dst_relpath))
+        except (OSError, ProcessExecutionError):
+            # Most likely the file is gitignored (or git is unavailable);
+            # silently fall back so we never break the render path.
+            pass
 
     def _sync_git_index_executable_bit(self, dst_relpath: Path, src_mode: int) -> None:
         """Propagate executable-bit changes to the destination's git index.
@@ -914,9 +956,10 @@ class Worker:
         behavior of leaving rendered changes unstaged for user review.
 
         Also a no-op when the destination is not in a git repository, when
-        the file is not yet tracked (the user's eventual ``git add`` will
-        record the on-disk mode where the platform allows it), or when git
-        is unavailable. All git failures are swallowed so that copying or
+        the file is not in the index (a previous call to
+        :meth:`_register_in_git_index` would normally have intent-to-add'd
+        it, but a gitignored file may not have an entry), or when git is
+        unavailable. All git failures are swallowed so that copying or
         updating cannot be broken by an unrelated git problem.
 
         .. note::
@@ -958,7 +1001,7 @@ class Worker:
             # git can't read the index — fall back to a silent no-op.
             return
         if not result:
-            # File is not tracked yet; nothing to update.
+            # File isn't in the index (e.g. gitignored). Nothing to update.
             return
         # Format: "<mode> <sha> <stage>\t<path>"
         meta = result.split("\t", 1)[0].split()

--- a/docs/updating.md
+++ b/docs/updating.md
@@ -97,6 +97,28 @@ repos:
     you can add both hooks to your `pre-commit-config.yaml` file, making sure that no
     unresolved merge conflicts are committed.
 
+## How Copier registers new files in your Git index
+
+When `copier update` adds files that didn't exist in your project before — say, the
+template gained a new helper script in its latest version — Copier marks them in your
+Git index with
+[`git add --intent-to-add`](https://git-scm.com/docs/git-add#Documentation/git-add.txt---intent-to-add).
+They show up in `git status` as `A` (added with intent) instead of `??` (untracked),
+signalling that they're deliberate template output and not something you happened to
+drop in the directory yourself.
+
+You still need to run `git add <file>` to actually stage the file's content
+for committing.
+
+There's a second reason: on filesystems that don't preserve the executable bit
+on disk, most notably Windows (where `core.fileMode` is `false` by default),
+having an existing index entry lets Copier record the file's mode as `100755`
+directly, so the executable bit isn't silently dropped on your next `git add`.
+
+If you change your mind, [aborting an update](#aborting-an-update) still works
+the same way: `git reset` removes the intent-to-add markers, then `git clean`
+picks up the new files like any other untracked content.
+
 ## Never change the answers file manually
 
 !!! important

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -2571,3 +2571,246 @@ index f163f4b,d20125d..0000000
 ++>>>>>>> after updating
 """)
         # editorconfig-checker-enable
+
+
+@pytest.mark.skipif(
+    condition=platform.system() == "Windows",
+    reason="Windows does not have UNIX-like permissions",
+)
+@pytest.mark.parametrize("file_mode", [True, False])
+def test_update_introduces_new_executable_file(
+    tmp_path_factory: pytest.TempPathFactory,
+    file_mode: bool,
+) -> None:
+    """A template that introduces a NEW executable file between versions
+    must end up registered in the destination's git index after
+    ``copier update``. With ``core.fileMode=false`` the index entry
+    must record ``100755``, since git ignores on-disk mode bits in that
+    config and the user's eventual ``git add`` would otherwise silently
+    drop the executable bit.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    # Template v1: only an answers file. No launcher.sh.
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+            }
+        )
+        git_save(tag="v1")
+
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+    with local.cwd(dst):
+        git("init")
+        git("config", "core.fileMode", str(file_mode).lower())
+        git("add", "-A")
+        git("commit", "-m", "init")
+
+    # Template v2: introduces launcher.sh as a NEW executable file.
+    with local.cwd(src):
+        Path("launcher.sh").write_text("#!/bin/sh\necho hi\n")
+        Path("launcher.sh").chmod(
+            Path("launcher.sh").stat().st_mode
+            | stat.S_IXUSR
+            | stat.S_IXGRP
+            | stat.S_IXOTH
+        )
+        git("add", "-A")
+        git("commit", "-m", "introduce launcher.sh")
+        git("tag", "v2")
+
+    run_update(str(dst), defaults=True, overwrite=True)
+
+    assert (dst / "launcher.sh").exists()
+    with local.cwd(dst):
+        # TODO: simplify with ``--format %(objectmode)`` once the minimum
+        # git version is raised to 2.38+ (--format cannot be combined with
+        # --stage; see git-ls-files(1)).
+        ls = git("ls-files", "--stage", "--", "launcher.sh").strip()
+        porcelain = git("status", "--porcelain", "--", "launcher.sh").rstrip("\n")
+    # The file should be registered in the index as deliberate new
+    # template output, not random untracked content (``??`` in
+    # porcelain).
+    assert ls, "expected launcher.sh to be registered in the index"
+    assert not porcelain.startswith("??"), (
+        f"expected launcher.sh to be tracked, got {porcelain!r}"
+    )
+    # The index entry must record ``100755`` regardless of
+    # ``core.fileMode`` — otherwise the user's eventual ``git add``
+    # would silently drop the executable bit when ``core.fileMode=false``
+    # (Windows default). The two parametrizations exercise different
+    # code paths to arrive at this state: with ``fileMode=true`` the
+    # intent-to-add call reads the on-disk chmod directly, while with
+    # ``fileMode=false`` Copier additionally rewrites the entry's mode
+    # since the on-disk chmod is invisible to git.
+    meta = ls.split("\t", 1)[0].split()
+    assert meta[0] == "100755"
+
+
+@pytest.mark.skipif(
+    condition=platform.system() == "Windows",
+    reason="Windows does not have UNIX-like permissions",
+)
+@pytest.mark.parametrize("file_mode", [True, False])
+def test_update_introduces_new_non_executable_file(
+    tmp_path_factory: pytest.TempPathFactory,
+    file_mode: bool,
+) -> None:
+    """A template that introduces a NEW non-executable file must also
+    be registered in the destination's git index after ``copier
+    update`` — distinguishing it from random untracked content the
+    user might have laying around — but with the default ``100644``
+    mode (no exec-bit override needed).
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+            }
+        )
+        git_save(tag="v1")
+
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+    with local.cwd(dst):
+        git("init")
+        git("config", "core.fileMode", str(file_mode).lower())
+        git("add", "-A")
+        git("commit", "-m", "init")
+
+    # Template v2: introduces a plain README.
+    with local.cwd(src):
+        Path("README.md").write_text("# Hello\n")
+        git("add", "-A")
+        git("commit", "-m", "introduce README")
+        git("tag", "v2")
+
+    run_update(str(dst), defaults=True, overwrite=True)
+
+    assert (dst / "README.md").exists()
+    with local.cwd(dst):
+        ls = git("ls-files", "--stage", "--", "README.md").strip()
+        porcelain = git("status", "--porcelain", "--", "README.md").rstrip("\n")
+    assert ls, "expected README.md to be registered in the index"
+    assert not porcelain.startswith("??"), (
+        f"expected README.md to be tracked, got {porcelain!r}"
+    )
+    meta = ls.split("\t", 1)[0].split()
+    assert meta[0] == "100644"
+
+
+def test_update_introduces_new_executable_file_then_user_commits(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """End-to-end chain with ``core.fileMode=false``: after ``copier
+    update`` introduces a new executable file, the user must be able
+    to ``git add`` and ``git commit`` it and have the resulting commit
+    tree record ``100755`` — so a colleague checking out the repo on a
+    platform that respects exec bits sees the file as executable.
+
+    The template is set up via ``git update-index --chmod`` (rather
+    than an on-disk ``Path.chmod``) so the test exercises the same
+    code path on every platform — including Windows, where
+    ``Path.chmod`` is a no-op for exec bits.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    # Template v1: only an answers file, no launcher.sh.
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+            }
+        )
+        git_save(tag="v1")
+
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+    with local.cwd(dst):
+        git("init")
+        git("config", "core.fileMode", "false")
+        git("add", "-A")
+        git("commit", "-m", "init")
+
+    # Template v2: introduces launcher.sh as a NEW executable file. Use
+    # ``git update-index --chmod=+x`` so the template commits ``100755``
+    # regardless of the platform the test runs on.
+    with local.cwd(src):
+        Path("launcher.sh").write_text("#!/bin/sh\necho hi\n")
+        git("add", "-A")
+        git("update-index", "--chmod=+x", "launcher.sh")
+        git("commit", "-m", "introduce launcher.sh")
+        git("tag", "v2")
+
+    run_update(str(dst), defaults=True, overwrite=True)
+
+    # The user stages the rendered file and commits — the natural
+    # finish to a copier-update cycle.
+    with local.cwd(dst):
+        git("add", "--", "launcher.sh")
+        git("commit", "-m", "introduce launcher.sh")
+        # The committed tree must record ``100755`` so that a colleague
+        # cloning this repo on a platform that respects exec bits sees
+        # an executable file.
+        tree_entry = git("ls-tree", "HEAD", "--", "launcher.sh").strip()
+        meta = tree_entry.split()
+        committed_content = git("cat-file", "blob", meta[2])
+    assert meta[0] == "100755"
+    # And the file's actual content survived the round trip.
+    assert committed_content == "#!/bin/sh\necho hi\n"
+
+
+def test_update_introduces_new_file_can_be_aborted(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """The "Aborting an update" flow documented in ``docs/updating.md``
+    must continue to work after Copier marks new files as
+    intent-to-add: ``git reset`` should drop the intent-to-add markers
+    so the files become untracked again, after which ``git clean``
+    will pick them up like any other untracked content.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+            }
+        )
+        git_save(tag="v1")
+
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+    with local.cwd(dst):
+        git("init")
+        git("add", "-A")
+        git("commit", "-m", "init")
+
+    with local.cwd(src):
+        Path("README.md").write_text("# Hello\n")
+        git("add", "-A")
+        git("commit", "-m", "introduce README")
+        git("tag", "v2")
+
+    run_update(str(dst), defaults=True, overwrite=True)
+
+    # After update, README.md is intent-to-add'd in the index.
+    with local.cwd(dst):
+        ls_before = git("ls-files", "--stage", "--", "README.md").strip()
+    assert ls_before, "expected README.md to be in the index before reset"
+
+    # Run the documented abort flow.
+    with local.cwd(dst):
+        git("reset")
+        # After reset, the intent-to-add marker is gone; the file is
+        # untracked, just like any other unwanted leftover.
+        ls_after = git("ls-files", "--stage", "--", "README.md").strip()
+        porcelain = git("status", "--porcelain", "--", "README.md").rstrip("\n")
+        # ``git clean`` (non-interactive equivalent of ``git clean -d -i``)
+        # then removes it.
+        git("clean", "-fd", "--", "README.md")
+    assert ls_after == "", f"expected README.md untracked post-reset, got {ls_after!r}"
+    assert porcelain.startswith("??"), (
+        f"expected README.md untracked post-reset, got {porcelain!r}"
+    )
+    assert not (dst / "README.md").exists()


### PR DESCRIPTION
## Summary

Closes #2630. Follow-up to #2605.

#2605 fixed executable-bit propagation for files that *already exist* in the destination. Files *introduced* by the template for the first time on `copier update` were still affected when `core.fileMode=false`:

1. Template v2 adds a new `script.sh` with `100755` in the index.
2. Destination has `core.fileMode=false` (Windows default).
3. copier writes the file, `chmod`s it on disk (invisible to git with `fileMode=false`), then calls `_sync_git_index_executable_bit` — which short-circuited because the file is untracked.
4. The user's next `git add script.sh` records `100644` because git ignores on-disk mode with `fileMode=false`. Exec bit lost.

### Changes

**`copier/_main.py` — `_sync_git_index_executable_bit`**:

For untracked files that should be executable, run `git add --intent-to-add <path>` to register an empty index entry, then fall through to the existing `--cacheinfo` path to set the mode to `100755`. The user's eventual `git add` replaces the empty blob with the file's actual content while preserving the mode bit. The intent-to-add marker (`A` in `git status`) is also a more accurate signal than `??` for files that are deliberate template output.

- Skipped when the file does not need an executable bit (the user's `git add` would record `100644` either way).
- Skipped when `core.fileMode=true` (git picks up the on-disk chmod naturally — pre-staging would be inconsistent with copier's "leave changes unstaged for user review" behavior).

**`tests/test_updatediff.py`** — 3 new tests:

| Test | What it covers |
| --- | --- |
| `test_update_introduces_new_executable_file[True\|False]` | New +x file in template v2: index records `100755` on `fileMode=false`; file stays untracked on `fileMode=true` |
| `test_update_introduces_new_non_executable_file[True\|False]` | New non-exec file is NOT pre-staged in either fileMode case |
| `test_update_introduces_new_executable_file_then_user_commits` | End-to-end on `core.fileMode=false`: copier update → `git add` → `git commit` → committed tree records `100755` and the file's actual content. The template setup uses `git update-index --chmod=+x` (rather than `Path.chmod`) so the test runs identically on every platform — Linux, macOS, *and* Windows. |

## Test plan

- [x] All new tests pass on macOS and windows
- [x] Full test suite still green on macOS (1073 passed)
- [x] ruff check, ruff format, mypy, editorconfig-checker all clean