### PR TITLE
fix: clean up temporary clone directory when internal `git clone` is interrupted

### DIFF
--- a/copier/_template.py
+++ b/copier/_template.py
@@ -11,6 +11,7 @@ from dataclasses import field
 from functools import cached_property
 from pathlib import Path, PurePosixPath
 from shutil import rmtree
+from tempfile import mkdtemp
 from typing import Any, Literal
 from warnings import warn
 
@@ -25,7 +26,7 @@ from pydantic.dataclasses import dataclass
 
 from ._tools import copier_version, handle_remove_readonly
 from ._types import AnyByStrDict, VCSTypes
-from ._vcs import clone, get_git, get_latest_tag, get_repo
+from ._vcs import CLONE_PREFIX, clone, get_git, get_latest_tag, get_repo
 from .errors import (
     InvalidConfigFileError,
     MultipleConfigFilesError,
@@ -220,36 +221,26 @@ class Template:
     url: str
     ref: str | None = None
     use_prereleases: bool = False
+    _temp_clone_path: Path | None = field(
+        default=None, init=False, repr=False, compare=False
+    )
 
     def _cleanup(self) -> None:
-        if temp_clone := self._temp_clone():
-            if sys.version_info >= (3, 12):
-                rmtree(
-                    temp_clone,
-                    ignore_errors=False,
-                    onexc=handle_remove_readonly,
-                )
-            else:
-                rmtree(
-                    temp_clone,
-                    ignore_errors=False,
-                    onerror=handle_remove_readonly,
-                )
-
-    def _temp_clone(self) -> Path | None:
-        """Get the path to the temporary clone of the template.
-
-        If the template hasn't yet been cloned, or if it was a local template,
-        then there's no temporary clone and this will return `None`.
-        """
-        if "local_abspath" not in self.__dict__:
-            return None
-        original_path = Path(self.url).expanduser()
-        with suppress(OSError):  # triggered for URLs on Windows
-            original_path = original_path.resolve()
-        if (clone_path := self.local_abspath) != original_path:
-            return clone_path
-        return None
+        temp_clone = self._temp_clone_path
+        if temp_clone is None or not temp_clone.exists():
+            return
+        if sys.version_info >= (3, 12):
+            rmtree(
+                temp_clone,
+                ignore_errors=False,
+                onexc=handle_remove_readonly,
+            )
+        else:
+            rmtree(
+                temp_clone,
+                ignore_errors=False,
+                onerror=handle_remove_readonly,
+            )
 
     @cached_property
     def _raw_config(self) -> AnyByStrDict:
@@ -568,10 +559,12 @@ class Template:
         """
         result = Path(self.url)
         if self.vcs == "git":
+            self._temp_clone_path = Path(mkdtemp(prefix=CLONE_PREFIX))
             result = Path(
                 clone(
                     self.url_expanded,
                     self.ref or get_latest_tag(self.url_expanded, self.use_prereleases),
+                    location=str(self._temp_clone_path),
                 )
             )
         if not result.is_dir():

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -20,6 +20,8 @@ from .errors import DirtyLocalWarning, ShallowCloneWarning
 GIT_USER_NAME = "Copier"
 GIT_USER_EMAIL = "copier@copier"
 
+CLONE_PREFIX = f"{__name__}.clone."
+
 
 class _PathStr(str):
     """A string that represents a path."""
@@ -175,7 +177,7 @@ def get_latest_tag(url: str, use_prereleases: OptBool = False) -> str:
         return "HEAD"
 
 
-def clone(url: str, ref: str = "HEAD") -> str:
+def clone(url: str, ref: str = "HEAD", location: str | None = None) -> str:
     """Clone repo into some temporary destination.
 
     Includes dirty changes for local templates by copying into a temp
@@ -187,10 +189,14 @@ def clone(url: str, ref: str = "HEAD") -> str:
             [get_repo][copier.vcs.get_repo].
         ref:
             Reference to checkout. For Git repos, defaults to `HEAD`.
+        location:
+            Pre-allocated empty directory to clone into. When `None`, a new
+            temporary directory is created.
     """
     git = get_git()
     git_version = get_git_version()
-    location = mkdtemp(prefix=f"{__name__}.clone.")
+    if location is None:
+        location = mkdtemp(prefix=CLONE_PREFIX)
     _clone = git["clone", "--no-checkout", url, location]
     # Faster clones if possible
     if git_version >= Version("2.27"):

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -1,9 +1,16 @@
+import os
+import signal
+import subprocess
+import sys
+import tempfile
 from pathlib import Path
 
 import pytest
 from plumbum import local
 
 import copier
+
+from .helpers import build_file_tree, git_save
 
 
 def test_cleanup(tmp_path: Path) -> None:
@@ -51,3 +58,136 @@ def test_no_cleanup_when_template_in_parent_folder(tmp_path: Path) -> None:
     with local.cwd(cwd):
         copier.run_copy(str(Path("..", "src")), dst, quiet=True)
     assert src.exists()
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "`os.kill(pid, SIGINT)` is not supported on Windows; "
+        "there is no clean way to deliver SIGINT to the parent process from a child."
+    ),
+)
+def test_cleanup_on_interrupt_during_copy_task(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test cleaning up when copy is interrupted during task."""
+    src, dst, tmp = map(tmp_path_factory.mktemp, ("src", "dst", "tmp"))
+
+    # Isolate the temp root so we only see clone dirs created by this test.
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp))
+    monkeypatch.setenv("TMPDIR", str(tmp))
+
+    build_file_tree(
+        {
+            src / "copier.yml": (
+                f"""\
+                _tasks:
+                    - "{{{{ _copier_python }}}} -c 'import os, signal; os.kill({os.getpid()}, signal.SIGINT)'"
+                """
+            ),
+        }
+    )
+    git_save(src, tag="v1")
+
+    with pytest.raises(KeyboardInterrupt):
+        copier.run_copy(str(src), dst, unsafe=True)
+
+    assert list(tmp.glob("**/*")) == []
+
+
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason=(
+        "`os.kill(pid, SIGINT)` is not supported on Windows; "
+        "there is no clean way to deliver SIGINT to the parent process from a child."
+    ),
+)
+def test_cleanup_on_interrupt_during_update_task(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test cleaning up when update is interrupted during task."""
+    src, dst, tmp = map(tmp_path_factory.mktemp, ("src", "dst", "tmp"))
+
+    # Isolate the temp root so we only see clone dirs created by this test.
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp))
+    monkeypatch.setenv("TMPDIR", str(tmp))
+
+    build_file_tree(
+        {
+            src / "{{ _copier_conf.answers_file }}.jinja": (
+                "{{ _copier_answers|to_yaml }}"
+            ),
+        }
+    )
+    git_save(src, tag="v1")
+
+    build_file_tree(
+        {
+            src / "copier.yml": (
+                f"""\
+                _tasks:
+                    - "{{{{ _copier_python }}}} -c 'import os, signal; os.kill({os.getpid()}, signal.SIGINT)'"
+                """
+            ),
+        }
+    )
+    git_save(src, tag="v2")
+
+    copier.run_copy(str(src), dst, vcs_ref="v1")
+    git_save(dst)
+
+    with pytest.raises(KeyboardInterrupt):
+        copier.run_update(dst, overwrite=True, unsafe=True)
+
+    assert list(tmp.glob("**/*")) == []
+
+
+def test_cleanup_on_interrupt_during_git_clone(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Test cleaning up when copy is interrupted during git clone."""
+    src, dst, tmp = map(tmp_path_factory.mktemp, ("src", "dst", "tmp"))
+
+    # Isolate the temp root so we only see clone dirs created by this test.
+    monkeypatch.setattr(tempfile, "tempdir", str(tmp))
+    monkeypatch.setenv("TMPDIR", str(tmp))
+
+    build_file_tree(
+        {
+            src / "{{ _copier_conf.answers_file }}.jinja": (
+                "{{ _copier_answers|to_yaml }}"
+            ),
+        }
+    )
+    git_save(src, tag="v1")
+
+    original_popen = subprocess.Popen
+
+    def interrupting_popen(args, *a, **kw):  # type: ignore[no-untyped-def]
+        cmd_list = list(args) if isinstance(args, (list, tuple)) else [args]
+        is_git_clone = (
+            len(cmd_list) >= 2
+            and Path(str(cmd_list[0])).stem == "git"
+            and "clone" in cmd_list
+        )
+        if is_git_clone:
+            # `signal.raise_signal` works on both POSIX and Windows, whereas
+            # `os.kill(os.getpid(), SIGINT)` would terminate the process on Windows
+            # instead of raising `KeyboardInterrupt`.
+            signal.raise_signal(signal.SIGINT)
+        return original_popen(args, *a, **kw)
+
+    # `plumbum.machines.local` executes `from subprocess import Popen` at import
+    # time, this is what we need to patch, but this module actually returns a
+    # `LocalMachine` instance via plumbum's module-replacement magic. The real module
+    # is accessible via `sys.modules`.
+    import plumbum.machines.local  # noqa: F401  (ensure module is loaded into sys.modules)
+
+    monkeypatch.setattr(
+        sys.modules["plumbum.machines.local"], "Popen", interrupting_popen
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        copier.run_copy(str(src), dst)
+
+    assert list(tmp.glob("**/*")) == []


### PR DESCRIPTION
Previously, if an operation was interrupted (e.g. by `Ctrl-C`) while the template repository was being fetched, the temporary directory holding the partial clone would be silently leaked. The fix lifts ownership of the temporary clone directory to a higher level, so cleanup is ensured regardless of when an interruption occurs.

Fixes #2644.