### PR TITLE
fix: restore support for `copier copy` when `git` is not available

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -68,7 +68,7 @@ from ._types import (
     VcsRef,
 )
 from ._user_data import AnswersMap, Question, load_answersfile_data
-from ._vcs import get_git
+from ._vcs import get_git, is_git_available
 from .errors import (
     ConfigFileError,
     CopierAnswersInterrupt,
@@ -895,7 +895,8 @@ class Worker:
                         f"{stat.filemode(dst_mode)} to {stat.filemode(src_mode)}",
                         stacklevel=2,
                     )
-            self._sync_git_index_executable_bit(dst_relpath, src_mode)
+            if is_git_available():
+                self._sync_git_index_executable_bit(dst_relpath, src_mode)
 
     def _sync_git_index_executable_bit(self, dst_relpath: Path, src_mode: int) -> None:
         """Propagate executable-bit changes to the destination's git index.

--- a/copier/_template.py
+++ b/copier/_template.py
@@ -26,7 +26,14 @@ from pydantic.dataclasses import dataclass
 
 from ._tools import copier_version, handle_remove_readonly
 from ._types import AnyByStrDict, VCSTypes
-from ._vcs import CLONE_PREFIX, clone, get_git, get_latest_tag, get_repo
+from ._vcs import (
+    CLONE_PREFIX,
+    clone,
+    get_git,
+    get_latest_tag,
+    get_repo,
+    is_git_available,
+)
 from .errors import (
     InvalidConfigFileError,
     MultipleConfigFilesError,
@@ -654,6 +661,6 @@ class Template:
     @cached_property
     def vcs(self) -> VCSTypes | None:
         """Get VCS system used by the template, if any."""
-        if get_repo(self.url):
+        if is_git_available() and get_repo(self.url):
             return "git"
         return None

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -11,7 +11,7 @@ from warnings import warn
 
 from packaging import version
 from packaging.version import InvalidVersion, Version
-from plumbum import TF, ProcessExecutionError, colors, local
+from plumbum import TF, CommandNotFound, ProcessExecutionError, colors, local
 from plumbum.machines import LocalCommand
 
 from ._types import OptBool, OptStrOrPath, StrOrPath
@@ -45,6 +45,19 @@ def get_git_version() -> Version:
     git = get_git()
 
     return Version(re.findall(r"\d+\.\d+(?:\.\d+)?", git("version"))[0])
+
+
+def is_git_available() -> bool:
+    """Indicate if `git` is available in the system."""
+    git_path: str | None = None
+    for exe in ("git", "git.exe"):
+        try:
+            git_path = local.which(exe)
+        except CommandNotFound:  # noqa: PERF203
+            continue
+        else:
+            break
+    return git_path is not None
 
 
 GIT_PREFIX = ("git@", "git://", "git+", "https://github.com/", "https://gitlab.com/")

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -17,7 +17,7 @@ from unittest import mock
 
 import pytest
 import yaml
-from plumbum import local
+from plumbum import CommandNotFound, local
 
 import copier
 from copier import run_copy
@@ -42,6 +42,35 @@ def test_project_not_found(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError):
         copier.run_copy(__file__, tmp_path)
+
+
+def test_copy_without_git(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Generating a minimal project must work even if `git` is not installed."""
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "hello" / "world.txt.jinja": "Hello, {{ name }}!",
+            src / "copier.yml": "name: world",
+        }
+    )
+
+    original_which = local.which
+
+    def fake_which(progname: Any) -> Any:
+        if Path(progname).name in {"git", "git.exe"}:
+            raise CommandNotFound(progname, [])
+        return original_which(progname)
+
+    monkeypatch.setattr(local, "which", fake_which)
+
+    # Sanity-check: the patch makes plumbum behave as if `git` is missing.
+    with pytest.raises(CommandNotFound):
+        local["git"]
+
+    copier.run_copy(str(src), dst, defaults=True)
+    assert (dst / "hello" / "world.txt").read_text() == "Hello, world!"
 
 
 def test_copy_with_non_version_tags(tmp_path_factory: pytest.TempPathFactory) -> None:


### PR DESCRIPTION
I've fixed a regression that broke `copier copy` when `git` is not available, which is a working mode we aim to support. To guard against future regression, I've added a test case that patches Plumbum to raise a `CommandNotFound` exception when calling `git`.