### PR TITLE
fix(update): don't skip gitignored .rej files for inline-conflict resolution

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1529,12 +1529,16 @@ class Worker:
                     conflicted = []
                     old_path = Path(old_copy)
                     new_path = Path(new_copy)
-                    status = git("status", "--porcelain").strip().splitlines()
+                    # `--ignored` so we still find .rej files when the
+                    # destination has a `*.rej` ignore rule.
+                    status = (
+                        git("status", "--porcelain", "--ignored").strip().splitlines()
+                    )
                     for line in status:
                         # Filter merge rejections (part 1/2)
-                        if not line.startswith("?? "):
+                        if not line.startswith(("?? ", "!! ")):
                             continue
-                        # Remove "?? " prefix
+                        # Remove prefix
                         fname = line[3:]
                         # Normalize name
                         fname = normalize_git_path(fname)

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1284,6 +1284,7 @@ def test_update_needs_more_context(
     )
 
 
+@pytest.mark.parametrize("gitignore_rej", [False, True])
 @pytest.mark.parametrize(
     "filename",
     [
@@ -1297,6 +1298,7 @@ def test_update_needs_more_context(
 def test_conflicted_files_are_marked_unmerged(
     tmp_path_factory: pytest.TempPathFactory,
     filename: str,
+    gitignore_rej: bool,
 ) -> None:
     # Template in v1 has a file with a single line;
     # in v2 it changes that line.
@@ -1324,6 +1326,17 @@ def test_conflicted_files_are_marked_unmerged(
     # Start versioning the generated project
     with local.cwd(dst):
         git_init("hello project")
+
+        # Optionally gitignore .rej files. Inline-conflict resolution
+        # must still produce inline markers — the .rej is just an
+        # internal artifact of the resolution, never something the
+        # downstream user wants to see, so it's reasonable for them to
+        # ignore it. Regression for the case where copier's `git status
+        # --porcelain` invocation silently dropped ignored .rej files.
+        if gitignore_rej:
+            Path(".gitignore").write_text("*.rej\n")
+            git("add", ".gitignore")
+            git("commit", "-m", "ignore .rej files")
 
         # After first commit, change the file, commit again
         Path(filename).write_text("upstream version 1 + downstream")


### PR DESCRIPTION
When a downstream project gitignores `*.rej`, `copier update --conflict=inline` silently skips the inline-merge step for affected files. The `.rej` files survive in the working tree, the original target files don't get the inline conflict markers, and nothing is reported as conflicted.

## Fix

`Worker._apply_update` ([_main.py:1532](https://github.com/copier-org/copier/blob/master/copier/_main.py#L1532)) discovers `.rej` files via `git status --porcelain`, which respects `.gitignore` and omits ignored paths.

The same function at the line above already uses `git status --ignored --porcelain` to enumerate ignored files for `--exclude` patterns to `git apply`. The fix brings the two invocations into alignment:

- Add `--ignored` to the `git status --porcelain` call.
- Accept both `?? ` (untracked) and `!! ` (ignored) prefixes.

The existing `endswith(".rej")` filter scopes processing to rejection witnesses regardless of tracked/untracked/ignored status, so behaviour for non-rej ignored files is unchanged.

## Tests

Added a `gitignore_rej` parameter to `test_conflicted_files_are_marked_unmerged` which adds a destination `.gitignore` containing `*.rej`. Asserts the same post-conditions: inline markers in the file, no `.rej` left over, file reported as unmerged in the index.

Without the fix, the new `gitignore_rej=True` parametrizations fail (no markers, `.rej` survives). With the fix, all parametrizations pass.