### PR TITLE
fix: treat blank boolean strings as false

### DIFF
--- a/copier/_tools.py
+++ b/copier/_tools.py
@@ -129,7 +129,9 @@ def cast_to_bool(value: Any) -> bool:
         return bool(float(value))
     # Assume it's a string
     with suppress(AttributeError):
-        lower = value.lower()
+        lower = value.strip().lower()
+        if not lower:
+            return False
         if lower in {"y", "yes", "t", "true", "on"}:
             return True
         elif lower in {"n", "no", "f", "false", "off", "~", "null", "none"}:

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -68,6 +68,30 @@ def test_copy_tasks(template_path: str, tmp_path: Path) -> None:
     assert not (tmp_path / "false").exists()
 
 
+def test_task_with_blank_rendered_when_is_skipped(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": """\
+            _tasks:
+                -   command: touch should-not-exist
+                    when: |
+                        {% if false %}
+                        true
+                        {% endif %}
+            """
+        }
+    )
+
+    copier.run_copy(
+        str(src), dst, quiet=True, defaults=True, overwrite=True, unsafe=True
+    )
+
+    assert not (dst / "should-not-exist").exists()
+
+
 def test_copy_skip_tasks(template_path: str, tmp_path: Path) -> None:
     copier.run_copy(
         template_path,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -5,7 +5,7 @@ from tempfile import TemporaryDirectory
 import pytest
 from poethepoet.app import PoeThePoet
 
-from copier._tools import normalize_git_path
+from copier._tools import cast_to_bool, normalize_git_path
 
 from .helpers import git
 
@@ -14,6 +14,33 @@ def test_types() -> None:
     """Ensure source code static typing."""
     result = PoeThePoet(Path())(["types"])
     assert result == 0
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        " ",
+        "\t",
+        "\n",
+        "  \n\t  ",
+    ],
+)
+def test_cast_to_bool_treats_blank_strings_as_false(value: str) -> None:
+    assert cast_to_bool(value) is False
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (" true ", True),
+        ("\nfalse\n", False),
+    ],
+)
+def test_cast_to_bool_ignores_surrounding_whitespace(
+    value: str, expected: bool
+) -> None:
+    assert cast_to_bool(value) is expected
 
 
 def test_temporary_directory_with_readonly_files_deletion() -> None:


### PR DESCRIPTION
## Summary
- treat whitespace-only strings as false in `cast_to_bool`
- ignore surrounding whitespace when parsing existing boolean string literals
- add regression tests for blank strings and multiline task `when` rendering

## Testing
- `uv run ruff format copier/_tools.py tests/test_tools.py tests/test_tasks.py`
- `uv run ruff check copier/_tools.py tests/test_tools.py tests/test_tasks.py`
- `uv run pytest -q tests/test_tools.py tests/test_tasks.py`