### PR TITLE
fix(update): render new exclude patterns with new answers

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -251,6 +251,7 @@ class Worker:
     unsafe: bool = False
     skip_answered: bool = False
     skip_tasks: bool = False
+    _exclude_context: AnyByStrDict = field(default_factory=dict, init=False)
 
     answers: AnswersMap = field(default_factory=AnswersMap, init=False)
     _cleanup_hooks: list[Callable[[], None]] = field(default_factory=list, init=False)
@@ -753,10 +754,22 @@ class Worker:
         # Include the current operation in the rendering context.
         # Note: This method is a cached property, it needs to be regenerated
         # when reusing an instance in different contexts.
-        extra_context = {"_copier_operation": _operation.get()}
+        operation_context = {"_copier_operation": _operation.get()}
+        extra_context = {
+            **self._exclude_context,
+            **operation_context,
+        }
         return self._path_matcher(
-            self._render_string(exclusion, extra_context=extra_context)
-            for exclusion in self.all_exclusions
+            chain(
+                (
+                    self._render_string(exclusion, extra_context=operation_context)
+                    for exclusion in self.template.exclude
+                ),
+                (
+                    self._render_string(exclusion, extra_context=extra_context)
+                    for exclusion in self.exclude
+                ),
+            )
         )
 
     @cached_property
@@ -1152,7 +1165,7 @@ class Worker:
                 Additional variables to use for rendering the template.
         """
         tpl = self.jinja_env.from_string(string)
-        return tpl.render(**self._render_context(), **(extra_context or {}))
+        return tpl.render({**self._render_context(), **(extra_context or {})})
 
     def _render_value(
         self, value: _T, extra_context: AnyByStrDict | None = None
@@ -1193,6 +1206,44 @@ class Worker:
         )
         self._cleanup_hooks.append(result._cleanup)
         return result
+
+    def _question_defaults_data(self) -> AnyByStrDict:
+        """Return available answers for defaulted template questions.
+
+        This is used during update while rendering new-template exclusion
+        patterns against an old-template copy. New exclusion patterns may refer
+        to questions that did not exist in the old template yet.
+        """
+        previous_answers = self.answers
+        self.answers = AnswersMap(
+            user_defaults=self.user_defaults,
+            init=self.data,
+            last=self.subproject.last_answers,
+            metadata=self.template.metadata,
+            external=self._external_data(),
+        )
+        try:
+            defaults: AnyByStrDict = {}
+            for var_name, details in self.template.questions_data.items():
+                question = Question(
+                    answers=self.answers,
+                    context=self._render_context(),
+                    jinja_env=self.jinja_env,
+                    settings=self.settings,
+                    var_name=var_name,
+                    **details,
+                )
+                if var_name in self.answers.init:
+                    answer = question.parse_answer(self.answers.init[var_name])
+                else:
+                    answer = question.get_default()
+                    if answer is MISSING:
+                        continue
+                self.answers.user[var_name] = answer
+                defaults[var_name] = answer
+            return defaults
+        finally:
+            self.answers = previous_answers
 
     @cached_property
     def template(self) -> Template:
@@ -1357,6 +1408,7 @@ class Worker:
             ) as new_copy,
         ):
             # Copy old template into a temporary destination
+            new_template_defaults = self._question_defaults_data()
             with replace(
                 self,
                 dst_path=old_copy / subproject_subdir,
@@ -1370,6 +1422,7 @@ class Worker:
                 # https://github.com/orgs/copier-org/discussions/2345
                 exclude=[*self.template.exclude, *self.exclude],
             ) as old_worker:
+                old_worker._exclude_context = new_template_defaults
                 old_worker.run_copy()
             # Run pre-migration tasks
             with Phase.use(Phase.MIGRATE):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -153,6 +153,79 @@ def test_exclude_templating_with_operation_added_in_new_version(
     assert copy_and_update.read_text() == "bar"
 
 
+@pytest.mark.parametrize(
+    ("data", "expected_copy_only"),
+    [
+        ({}, "foo"),
+        ({"manage_copy_only": True}, "bar"),
+    ],
+)
+def test_update_exclude_added_in_new_version_can_use_new_answer(
+    tmp_path_factory: pytest.TempPathFactory,
+    data: dict[str, bool],
+    expected_copy_only: str,
+) -> None:
+    """
+    Ensure a templated `_exclude` item added by a new template version can
+    reference an answer introduced by that same new version during update.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "copier.yml": (
+                    """\
+                    _envops:
+                        undefined: jinja2.StrictUndefined
+                    """
+                ),
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+                "copy-only": "foo",
+                "copy-and-update": "foo",
+            }
+        )
+        git_save(tag="1.0.0")
+        build_file_tree(
+            {
+                "copier.yml": (
+                    """\
+                    _envops:
+                        undefined: jinja2.StrictUndefined
+
+                    _exclude:
+                        - "{% if not manage_copy_only %}copy-only{% endif %}"
+
+                    manage_copy_only:
+                        type: bool
+                        default: false
+
+                    unused_hidden:
+                        type: str
+                        when: false
+                    """
+                ),
+                "copy-only": "bar",
+                "copy-and-update": "bar",
+            }
+        )
+        git_save(tag="2.0.0")
+
+    copy_only = dst / "copy-only"
+    copy_and_update = dst / "copy-and-update"
+
+    copier.run_copy(str(src), dst, defaults=True, overwrite=True, vcs_ref="1.0.0")
+    assert copy_only.read_text() == "foo"
+    assert copy_and_update.read_text() == "foo"
+
+    with local.cwd(dst):
+        git_save()
+
+    copier.run_update(str(dst), data=data, defaults=True, overwrite=True)
+    assert copy_only.read_text() == expected_copy_only
+    assert copy_and_update.read_text() == "bar"
+
+
 def test_task_templating_with_operation(
     tmp_path_factory: pytest.TempPathFactory, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
Fixes #2482.

During update, Copier renders a temporary copy from the old template while also applying exclusion patterns from the new template, so paths newly excluded by the template are not treated as deleted.

When those new `_exclude` patterns reference answers introduced by the new template version, rendering them against the old answers can fail under strict undefined handling.

This change computes available new-template answers/defaults and uses them only while rendering the new exclusion patterns for the old-copy step. It does not use those values to render the old template itself, avoiding false diffs/conflicts.

Added regression coverage for:
- a new templated `_exclude` referencing a new answer with its default value;
- the same `_exclude` honoring explicit `data` passed during update.

Tests run:

- `pytest -q tests/test_context.py -k "update_exclude_added_in_new_version" -rs`
- `pytest -q tests/test_updatediff.py -k "conditional_computed_value or dont_validate_computed_value" -rs`
- `LC_ALL=C pytest -q tests/test_context.py tests/test_updatediff.py tests/test_exclude.py tests/test_config.py -rs`