### PR TITLE
fix(copy): preserve answers file subdirectories

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1040,19 +1040,22 @@ class Worker:
             dst_abspath = self.subproject.local_abspath / dst_relpath
             dst_abspath.mkdir(parents=True, exist_ok=True)
 
-    def _adjust_rendered_part(self, rendered_part: str) -> str:
-        """Adjust the rendered part if necessary.
+    def _adjust_rendered_part(
+        self, rendered_parts: tuple[str, ...], rendered_part: str
+    ) -> str:
+        """Avoid duplicating already rendered path prefixes.
 
-        If `{{ _copier_conf.answers_file }}` becomes the full path,
-        restore part to be just the end leaf.
-
-        Args:
-            rendered_part:
-                The rendered part of the path to adjust.
-
+        If a path part renders to the full answers file path while the current
+        rendered path already contains its parent directory, keep only the leaf
+        name. Otherwise, preserve the rendered part as-is.
         """
-        if str(self.answers_relpath) == rendered_part:
-            return Path(rendered_part).name
+        rendered_path = Path(rendered_part)
+        current_path = Path(*rendered_parts) if rendered_parts else Path()
+        if (
+            rendered_path == self.answers_relpath
+            and rendered_path.parent == current_path
+        ):
+            return rendered_path.name
         return rendered_part
 
     def _render_parts(
@@ -1094,12 +1097,18 @@ class Worker:
 
         ctx = get_yield_context(self.jinja_env)
         yield_name = ctx.yield_name
+        yield_iterable = ctx.yield_iterable
         if yield_name:
-            for value in ctx.yield_iterable or ():
+            ctx.yield_name = None
+            ctx.yield_iterable = None
+            for value in yield_iterable or ():
                 new_context = {**extra_context, yield_name: value}
                 rendered_part = self._render_string(part, extra_context=new_context)
-                rendered_part = self._adjust_rendered_part(rendered_part)
-
+                ctx.yield_name = None
+                ctx.yield_iterable = None
+                rendered_part = self._adjust_rendered_part(
+                    rendered_parts, rendered_part
+                )
                 # Skip if any part is rendered as an empty string
                 if not rendered_part:
                     continue
@@ -1110,11 +1119,11 @@ class Worker:
 
             return
 
+        rendered_part = self._adjust_rendered_part(rendered_parts, rendered_part)
+
         # Skip if any part is rendered as an empty string
         if not rendered_part:
             return
-
-        rendered_part = self._adjust_rendered_part(rendered_part)
 
         yield from self._render_parts(
             parts, rendered_parts + (rendered_part,), extra_context, is_template

--- a/tests/test_answersfile.py
+++ b/tests/test_answersfile.py
@@ -56,6 +56,24 @@ def template_path(tmp_path_factory: pytest.TempPathFactory) -> str:
     return str(root)
 
 
+def test_answers_file_keeps_configured_subdirectory(tmp_path: Path) -> None:
+    """The configured answers file path should keep its relative directory."""
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    build_file_tree(
+        {
+            src / "copier.yml": "_answers_file: subdir/.custom-answers.yml",
+            src
+            / "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_yaml }}",
+        }
+    )
+
+    copier.run_copy(str(src), dst, defaults=True, overwrite=True)
+
+    assert (dst / "subdir" / ".custom-answers.yml").exists()
+    assert not (dst / ".custom-answers.yml").exists()
+
+
 @pytest.mark.parametrize("answers_file", [None, ".changed-by-user.yaml"])
 def test_answersfile(
     template_path: str, tmp_path: Path, answers_file: str | None


### PR DESCRIPTION
Fixes #1257.

When `_answers_file` was configured with a relative subdirectory, for example:

    _answers_file: subdir/.custom-answers.yml

Copier flattened the rendered answers file path and created:

    .custom-answers.yml

instead of:

    subdir/.custom-answers.yml

This change preserves the configured relative path while still avoiding duplicated path prefixes when the answers file template is already located inside that same directory.

It also keeps dynamic file path rendering working by clearing the yield context after path-part expansion.

Added regression coverage to ensure the answers file is created in the configured subdirectory.

Tests run:

- `pytest -q tests/test_answersfile.py -k "answers_file_keeps_configured_subdirectory" -rs`
- `pytest -q tests/test_cli.py -k "good_cli_run_dot_config" -rs`
- `pytest -q tests/test_dynamic_file_structures.py -k "file_loop" -rs`
- `LC_ALL=C pytest -q tests/test_answersfile.py tests/test_answersfile_templating.py tests/test_subdirectory.py tests/test_copy.py tests/test_updatediff.py tests/test_cli.py tests/test_dynamic_file_structures.py -rs`
