### PR TITLE
fix(update): preserve executable bit for new files

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -915,11 +915,12 @@ class Worker:
         as an *unstaged* modification, which matches copier's normal
         behavior of leaving rendered changes unstaged for user review.
 
-        Also a no-op when the destination is not in a git repository, when
-        the file is not yet tracked (the user's eventual ``git add`` will
-        record the on-disk mode where the platform allows it), or when git
-        is unavailable. All git failures are swallowed so that copying or
-        updating cannot be broken by an unrelated git problem.
+        Also a no-op when the destination is not in a git repository, or
+        when git is unavailable. New executable files are first registered
+        with ``git add --intent-to-add`` so an empty index entry exists; then
+        only that entry's executable mode is prepared, without staging the
+        rendered file contents. All git failures are swallowed so that copying
+        or updating cannot be broken by an unrelated git problem.
 
         .. note::
 
@@ -951,6 +952,7 @@ class Worker:
             # git will pick up the plain on-disk ``chmod`` from
             # :meth:`_render_file`; no index manipulation needed.
             return
+        desired_executable = bool(src_mode & 0o111)
         try:
             # TODO: simplify with ``--format %(objectmode)`` once the
             # minimum git version is raised to 2.38+ (--format cannot be
@@ -960,13 +962,19 @@ class Worker:
             # git can't read the index — fall back to a silent no-op.
             return
         if not result:
-            # File is not tracked yet; nothing to update.
-            return
+            if desired_executable:
+                # For a new executable file, create an empty intent-to-add index
+                # entry first. The later ``--cacheinfo`` call can then set the
+                # entry mode to 100755 without staging the rendered file contents.
+                with suppress(OSError, ProcessExecutionError):
+                    git("add", "--intent-to-add", "--", str(dst_relpath))
+                    result = git("ls-files", "--stage", "--", str(dst_relpath)).strip()
+            if not result:
+                return
         # Format: "<mode> <sha> <stage>\t<path>"
         meta = result.split("\t", 1)[0].split()
         current_index_mode = int(meta[0], 8)
         current_index_sha = meta[1]
-        desired_executable = bool(src_mode & 0o111)
         current_executable = bool(current_index_mode & 0o111)
         if desired_executable == current_executable:
             return

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -2329,6 +2329,111 @@ def test_update_propagates_executable_bit_addition(
     condition=platform.system() == "Windows",
     reason="Windows does not have UNIX-like permissions",
 )
+def test_update_leaves_new_non_executable_files_unstaged_with_filemode_false(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """New non-executable files should not get an intent-to-add index entry."""
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    filename = "notes.txt"
+
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+                "README.md": "hello\n",
+            }
+        )
+        git_save(tag="v1")
+
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+
+    with local.cwd(dst):
+        git("init")
+        git("config", "core.fileMode", "false")
+        git("add", "-A")
+        git("commit", "-m", "init")
+
+    with local.cwd(src):
+        Path(filename).write_text("plain text\n")
+        git("add", "-A")
+        git("commit", "-m", "add non-executable file")
+        git("tag", "v2")
+
+    run_update(str(dst), defaults=True, overwrite=True)
+
+    with local.cwd(dst):
+        status = git("status", "--porcelain=v1", "--", filename).rstrip("\n")
+        staged = git("ls-files", "--stage", "--", filename).strip()
+
+    assert status == f"?? {filename}"
+    assert staged == ""
+
+
+@pytest.mark.skipif(
+    condition=platform.system() == "Windows",
+    reason="Windows does not have UNIX-like permissions",
+)
+def test_update_preserves_executable_bit_for_new_files_with_filemode_false(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    """New executable files introduced during update must keep ``+x`` when
+    later added by the user in repositories with ``core.fileMode=false``.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    filename = "script.sh"
+
+    # Template v1: no script.sh yet.
+    with local.cwd(src):
+        build_file_tree(
+            {
+                "{{ _copier_conf.answers_file }}.jinja": "{{ _copier_answers|to_nice_yaml }}",
+                "README.md": "hello\n",
+            }
+        )
+        git_save(tag="v1")
+
+    run_copy(str(src), dst, defaults=True, overwrite=True)
+    assert not (dst / filename).exists()
+
+    with local.cwd(dst):
+        git("init")
+        git("config", "core.fileMode", "false")
+        git("add", "-A")
+        git("commit", "-m", "init")
+
+    # Template v2: add a new executable file.
+    with local.cwd(src):
+        Path(filename).write_text("#!/bin/sh\necho hi\n")
+        Path(filename).chmod(
+            Path(filename).stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+        )
+        git("add", "-A")
+        git("commit", "-m", "add executable script")
+        git("tag", "v2")
+
+    run_update(str(dst), defaults=True, overwrite=True)
+
+    assert (dst / filename).stat().st_mode & 0o111 != 0
+    with local.cwd(dst):
+        status = git("status", "--porcelain=v1", "--", filename).rstrip("\n")
+        staged = git("ls-files", "--stage", "--", filename).strip().split()
+        cached_diff = git("diff", "--cached", "--", filename)
+
+    assert status == f"AM {filename}"
+    assert staged[0] == "100755"
+    assert "#!/bin/sh" not in cached_diff
+
+    with local.cwd(dst):
+        git("add", "--", filename)
+        mode = git("ls-files", "--stage", "--", filename).strip().split()[0]
+
+    assert mode == "100755"
+
+
+@pytest.mark.skipif(
+    condition=platform.system() == "Windows",
+    reason="Windows does not have UNIX-like permissions",
+)
 @pytest.mark.parametrize("file_mode", [True, False])
 def test_update_propagates_executable_bit_removal(
     tmp_path_factory: pytest.TempPathFactory,


### PR DESCRIPTION
Fixes #2630.

When a template update introduces a new executable file in a destination repository with `core.fileMode=false`, Git ignores the on-disk executable bit. As a result, the user's later `git add` records the new file as `100644` instead of `100755`.

This change handles new executable files in the same executable-bit sync path used for existing files:

- if the destination has `core.fileMode=false`;
- and the rendered file is executable;
- and the file is not tracked yet;

Copier first creates an empty intent-to-add index entry, then updates only that entry's mode via `git update-index --cacheinfo`. This prepares the executable bit without staging the rendered file contents.

Added regression coverage for a template update that introduces a new executable file, verifying that:

- the file is executable on disk after update;
- the intermediate index entry has mode `100755`;
- the rendered file contents are not staged;
- a later user `git add` records the file as `100755`.

Also added coverage for new non-executable files with `core.fileMode=false`, ensuring Copier leaves them untracked and does not create an unnecessary intent-to-add index entry.

Tests run:

- `pytest -q tests/test_updatediff.py -k "new_files_with_filemode_false or new_non_executable_files" -rs`
- `LC_ALL=C pytest -q tests/test_updatediff.py -k "executable_bit or exec_bit or new_non_executable_files" -rs`
- `LC_ALL=C pytest -q tests/test_updatediff.py -rs`
- `LC_ALL=C pytest -q tests/test_updatediff.py tests/test_copy.py -rs`
- `ruff format --check copier/_main.py tests/test_updatediff.py`
- `ruff check copier/_main.py tests/test_updatediff.py`
