### PR TITLE
fix(copy): report template path for Jinja errors

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -30,6 +30,7 @@ from typing import (
 )
 from unicodedata import normalize
 
+from jinja2.exceptions import TemplateError
 from jinja2.loaders import FileSystemLoader
 from jinja2.sandbox import SandboxedEnvironment
 from jinja2.utils import import_string
@@ -1047,6 +1048,7 @@ class Worker:
         rendered_parts: tuple[str, ...] | None = None,
         extra_context: AnyByStrDict | None = None,
         is_template: bool = False,
+        source_parts: tuple[str, ...] = (),
     ) -> Iterable[tuple[Path, AnyByStrDict | None]]:
         """Render a set of parts into path and context pairs.
 
@@ -1070,20 +1072,32 @@ class Worker:
 
         part = parts[0]
         parts = parts[1:]
+        source_parts = source_parts + (part,)
+        source_path = Path(*source_parts)
 
         if not extra_context:
             extra_context = {}
 
         # If the `part` has a yield tag, `self.jinja_env` will be set with the yield
         # name and iterable
-        rendered_part = self._render_string(part, extra_context=extra_context)
+        try:
+            rendered_part = self._render_string(part, extra_context=extra_context)
+        except TemplateError as error:
+            raise UserMessageError(
+                f"Error rendering template path {source_path}: {error}"
+            ) from error
 
         ctx = get_yield_context(self.jinja_env)
         yield_name = ctx.yield_name
         if yield_name:
             for value in ctx.yield_iterable or ():
                 new_context = {**extra_context, yield_name: value}
-                rendered_part = self._render_string(part, extra_context=new_context)
+                try:
+                    rendered_part = self._render_string(part, extra_context=new_context)
+                except TemplateError as error:
+                    raise UserMessageError(
+                        f"Error rendering template path {source_path}: {error}"
+                    ) from error
                 if str(self.answers_relpath) == rendered_part:
                     if rendered_parts:
                         deprecate_answers_file_template_path()
@@ -1095,7 +1109,11 @@ class Worker:
                     continue
 
                 yield from self._render_parts(
-                    parts, rendered_parts + (rendered_part,), new_context, is_template
+                    parts,
+                    rendered_parts + (rendered_part,),
+                    new_context,
+                    is_template,
+                    source_parts,
                 )
 
             return
@@ -1111,7 +1129,11 @@ class Worker:
             return
 
         yield from self._render_parts(
-            parts, rendered_parts + (rendered_part,), extra_context, is_template
+            parts,
+            rendered_parts + (rendered_part,),
+            extra_context,
+            is_template,
+            source_parts,
         )
 
     def _render_path(self, relpath: Path) -> Iterable[tuple[Path, AnyByStrDict | None]]:

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -22,7 +22,7 @@ from plumbum import CommandNotFound, local
 import copier
 from copier import run_copy
 from copier._types import AnyByStrDict
-from copier.errors import ForbiddenPathError
+from copier.errors import ForbiddenPathError, UserMessageError
 
 from .helpers import (
     BRACKET_ENVOPS,
@@ -1335,6 +1335,31 @@ def test_copier_phase_variable(tmp_path_factory: pytest.TempPathFactory) -> None
     copier.run_copy(str(src), dst)
     assert (dst / "render").exists()
     assert (dst / "render").read_text() == "render"
+
+
+def test_invalid_jinja_in_rendered_path_reports_template_path(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    broken_path = "some-{{{{ jinja_error }}}}"
+    build_file_tree({src / broken_path: "content"})
+
+    with pytest.raises(UserMessageError, match=re.escape(broken_path)):
+        copier.run_copy(str(src), dst, overwrite=True)
+
+
+def test_invalid_jinja_in_nested_rendered_path_reports_failing_path_part(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    broken_part = "some-{{{{ jinja_error }}}}"
+    build_file_tree({src / "parent" / broken_part / "child.txt": "content"})
+
+    with pytest.raises(UserMessageError) as error:
+        copier.run_copy(str(src), dst, overwrite=True)
+
+    assert str(Path("parent", broken_part)) in str(error.value)
+    assert str(Path("parent", broken_part, "child.txt")) not in str(error.value)
 
 
 def test_relative_render_path_outside_destination_raises_error(

--- a/tests/test_dynamic_file_structures.py
+++ b/tests/test_dynamic_file_structures.py
@@ -1,9 +1,10 @@
 import warnings
+from pathlib import Path
 
 import pytest
 
 import copier
-from copier.errors import MultipleYieldTagsError, YieldTagInFileError
+from copier.errors import MultipleYieldTagsError, UserMessageError, YieldTagInFileError
 from tests.helpers import build_file_tree
 
 
@@ -40,6 +41,35 @@ def test_folder_loop(tmp_path_factory: pytest.TempPathFactory) -> None:
         unexpected_files = set(all_files) - set(expected_files)
 
         assert not unexpected_files, f"Unexpected files found: {unexpected_files}"
+
+
+def test_folder_loop_reports_path_when_yielded_part_rendering_fails(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    broken_part = (
+        "{% yield item from items %}"
+        "{% if item is defined %}{% include 'missing-template.jinja' %}{% endif %}"
+        "{% endyield %}"
+    )
+    build_file_tree(
+        {
+            src / "copier.yml": "",
+            src / "folder_loop" / broken_part / "child.txt": "Hello",
+        }
+    )
+
+    with pytest.raises(UserMessageError) as error:
+        copier.run_copy(
+            str(src),
+            dst,
+            data={"items": [{}]},
+            defaults=True,
+            overwrite=True,
+        )
+
+    assert str(Path("folder_loop", broken_part)) in str(error.value)
+    assert str(Path("folder_loop", broken_part, "child.txt")) not in str(error.value)
 
 
 def test_nested_folder_loop(tmp_path_factory: pytest.TempPathFactory) -> None:


### PR DESCRIPTION
Fixes #2267.

When a template path contains invalid Jinja syntax, Jinja raises a `TemplateSyntaxError` with `<unknown>` as the filename. This makes it difficult to identify which template path failed, especially in larger templates.

This change wraps Jinja errors raised while rendering template path parts and re-raises them as `UserMessageError` with the original template path included in the message.

Added regression coverage for an invalid Jinja expression in a rendered path.

Tests run:

- `pytest -q tests/test_copy.py -k "invalid_jinja_in_rendered_path" -rs`
- `pytest -q tests/test_copy.py -k "render_path or invalid_jinja_in_rendered_path" -rs`
- `LC_ALL=C pytest -q tests/test_copy.py -rs`
- `pytest -q tests/test_dynamic_file_structures.py -rs`
- `pytest -q tests/test_jinja2_undefined.py -rs`
- `pytest -q tests/test_context.py -k "copier_operation or exclude or skip" -rs`
- `ruff format --check copier/_main.py tests/test_copy.py`
- `ruff check copier/_main.py tests/test_copy.py`