### PR TITLE
docs: clarify validator helper filters

### DIFF
--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -281,6 +281,18 @@ Supported keys:
     will be rendered with the combined answers as variables; it should render _nothing_
     if the value is valid, and an error message to show to the user otherwise.
 
+    !!! example "Validate a slug with `regex_search`"
+
+        ```yaml title="copier.yml"
+        project_slug:
+            type: str
+            help: Project slug
+            validator: >-
+                {% if not (project_slug | regex_search('^[a-z][a-z0-9-]+$')) %}
+                Use lowercase letters, digits, and dashes; start with a letter.
+                {% endif %}
+        ```
+
 - **when**: Condition that, if `false`, skips the question.
 
     If it is a boolean, it is used directly. Setting it to `false` is useful for


### PR DESCRIPTION
Fixes #1529.

Clarifies that question validators are rendered as Jinja templates and can use:

- built-in Jinja filters, tests, and functions;
- Copier helpers such as `pathjoin`;
- filters from `jinja2-ansible-filters`, including `regex_search`.

Also clarifies that `regex_search` is a Jinja filter, not a dedicated validation method, and points users to `_jinja_extensions` for project-specific validation helpers.

Checks run:

- `uv run rumdl check docs/configuring.md`