### PR TITLE
fix(copy): honor configured skip_tasks in unsafe check

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -296,7 +296,7 @@ class Worker:
         features: set[str] = set()
         if self.template.jinja_extensions:
             features.add("jinja_extensions")
-        if self.template.tasks and not self.skip_tasks:
+        if self.template.tasks and not self.effective_skip_tasks:
             features.add("tasks")
         if mode == "update" and self.subproject.template:
             if self.subproject.template.jinja_extensions:
@@ -449,7 +449,7 @@ class Worker:
                 "context_lines": lambda: self.context_lines,
                 "unsafe": lambda: self.unsafe,
                 "skip_answered": lambda: self.skip_answered,
-                "skip_tasks": lambda: self.skip_tasks,
+                "skip_tasks": lambda: self.effective_skip_tasks,
                 "sep": lambda: os.sep,
                 "os": lambda: OS,
             }
@@ -687,6 +687,13 @@ class Worker:
     def all_skip_if_exists(self) -> Sequence[str]:
         """Combine default and template skip-if-exists patterns."""
         return tuple(chain(self.skip_if_exists, self.template.skip_if_exists))
+
+    @cached_property
+    def effective_skip_tasks(self) -> bool:
+        """Check whether template tasks should be skipped."""
+        return self.skip_tasks or cast_to_bool(
+            self.template.config_data.get("skip_tasks", False)
+        )
 
     @cached_property
     def jinja_env(self) -> SandboxedEnvironment:
@@ -1246,7 +1253,7 @@ class Worker:
             if not self.quiet:
                 # TODO Unify printing tools
                 print("")  # padding space
-            if not self.skip_tasks:
+            if not self.effective_skip_tasks:
                 with Phase.use(Phase.TASKS):
                     self._execute_tasks(self.template.tasks)
         except Exception:

--- a/tests/test_unsafe.py
+++ b/tests/test_unsafe.py
@@ -95,6 +95,48 @@ def test_copy(
         run_copy(str(src), dst, unsafe=unsafe)
 
 
+def test_copy_with_configured_skip_tasks_is_not_unsafe(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    build_file_tree(
+        {
+            (src / "copier.yaml"): yaml.safe_dump(
+                {
+                    "_skip_tasks": True,
+                    "_tasks": ["touch task.txt"],
+                }
+            )
+        }
+    )
+
+    run_copy(str(src), dst)
+
+    assert not (dst / "task.txt").exists()
+
+
+def test_copy_with_configured_skip_tasks_false_is_unsafe(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ["src", "dst"])
+    build_file_tree(
+        {
+            (src / "copier.yaml"): yaml.safe_dump(
+                {
+                    "_skip_tasks": "false",
+                    "_tasks": ["touch task.txt"],
+                }
+            )
+        }
+    )
+
+    with pytest.raises(
+        UnsafeTemplateError,
+        match="Template uses potentially unsafe feature: tasks.",
+    ):
+        run_copy(str(src), dst)
+
+
 @pytest.mark.parametrize("unsafe", [False, True])
 @pytest.mark.parametrize("trusted_from_settings", [False, True])
 def test_copy_cli(


### PR DESCRIPTION
Fixes #2690.

When a template defines `_skip_tasks: true` together with `_tasks`, Copier currently refuses to run without `--unsafe`, even though those tasks are configured not to run.

The unsafe check already skips task-related unsafe warnings when `skip_tasks=True` is passed through the CLI/API. However, it did not take the template-configured `_skip_tasks` value into account, so these two equivalent ways of disabling tasks behaved differently:

- `copier copy --skip-tasks ...`
- `_skip_tasks: true` in `copier.yml`

This change introduces a single effective skip-tasks value that combines both sources:

- the CLI/API `skip_tasks` option;
- the template configuration value from `_skip_tasks`.

That effective value is then used consistently for:

- the unsafe-feature check;
- `_copier_conf.skip_tasks` in the render context;
- deciding whether template tasks should actually be executed.

This does not make task execution trusted. It only avoids requiring `--unsafe` when tasks are configured not to run. Other unsafe features, such as Jinja extensions and migrations, are still checked as before.

The configured value is parsed with Copier's existing boolean coercion helper, so values such as `_skip_tasks: "false"` do not accidentally bypass the unsafe check.

Added regression coverage for:

- `_skip_tasks: true` with `_tasks`, which should not require `--unsafe` and should not execute tasks;
- `_skip_tasks: "false"` with `_tasks`, which should still require `--unsafe`.

Tests run:

- `pytest -q tests/test_unsafe.py -k "configured_skip_tasks" -rs`
- `pytest -q tests/test_unsafe.py tests/test_tasks.py -rs`
- `pytest -q tests/test_config.py tests/test_context.py tests/test_unsafe.py tests/test_tasks.py -rs`
- `ruff format --check copier/_main.py tests/test_unsafe.py`
- `ruff check copier/_main.py tests/test_unsafe.py`