### PR TITLE
fix(vcs): ignore empty nested git repos in dirty templates

### DIFF
--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -190,6 +190,20 @@ def get_latest_tag(url: str, use_prereleases: OptBool = False) -> str:
         return "HEAD"
 
 
+def _nested_empty_git_repo_excludes(root: Path) -> list[str]:
+    """Build Git pathspec excludes for nested repositories without checked-out HEAD."""
+    excludes = []
+    for git_dir in root.glob("**/.git"):
+        repo = git_dir.parent
+        if repo == root:
+            continue
+        try:
+            get_git()("-C", repo, "rev-parse", "--verify", "HEAD")
+        except ProcessExecutionError:
+            excludes.append(f":(exclude){repo.relative_to(root).as_posix()}")
+    return excludes
+
+
 def clone(url: str, ref: str = "HEAD", location: str | None = None) -> str:
     """Clone repo into some temporary destination.
 
@@ -234,20 +248,39 @@ def clone(url: str, ref: str = "HEAD", location: str | None = None) -> str:
             is_dirty = bool(git("status", "--porcelain").strip())
         if is_dirty:
             with local.cwd(location):
-                git("--git-dir=.git", f"--work-tree={url_abspath}", "add", "-A")
                 git(
                     "--git-dir=.git",
                     f"--work-tree={url_abspath}",
-                    "commit",
-                    "-m",
-                    "Copier automated commit for draft changes",
-                    "--no-verify",
-                    "--no-gpg-sign",
+                    "add",
+                    "-A",
+                    "--",
+                    ".",
+                    *_nested_empty_git_repo_excludes(url_abspath),
                 )
-                warn(
-                    "Dirty template changes included automatically.",
-                    DirtyLocalWarning,
+                has_staged_changes = (
+                    git[
+                        "--git-dir=.git",
+                        f"--work-tree={url_abspath}",
+                        "diff",
+                        "--cached",
+                        "--quiet",
+                    ].run(retcode=(0, 1))[0]
+                    == 1
                 )
+                if has_staged_changes:
+                    git(
+                        "--git-dir=.git",
+                        f"--work-tree={url_abspath}",
+                        "commit",
+                        "-m",
+                        "Copier automated commit for draft changes",
+                        "--no-verify",
+                        "--no-gpg-sign",
+                    )
+                    warn(
+                        "Dirty template changes included automatically.",
+                        DirtyLocalWarning,
+                    )
 
     with local.cwd(location):
         ## The `git checkout -f <ref>` command doesn't works when repo is local, dirty

--- a/tests/test_dirty_local.py
+++ b/tests/test_dirty_local.py
@@ -93,6 +93,51 @@ def test_copy_dirty_head(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert (dst / "untracked").exists()
 
 
+def test_copy_dirty_head_with_empty_nested_git_repo(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": "",
+            src / "tracked": "",
+        }
+    )
+    with local.cwd(src):
+        git("init")
+        git("add", "copier.yml", "tracked")
+        git("commit", "-m1")
+        git("init", "empty_repo")
+
+    copier.run_copy(str(src), dst, vcs_ref="HEAD", defaults=True)
+
+    assert (dst / "tracked").exists()
+
+
+def test_copy_dirty_head_with_empty_nested_git_repo_and_dirty_file(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": "",
+            src / "tracked": "",
+        }
+    )
+    with local.cwd(src):
+        git("init")
+        git("add", "copier.yml", "tracked")
+        git("commit", "-m1")
+        git("init", "empty_repo")
+    (src / "dirty.txt").write_text("dirty")
+
+    with pytest.warns(DirtyLocalWarning):
+        copier.run_copy(str(src), dst, vcs_ref="HEAD", defaults=True)
+
+    assert (dst / "tracked").exists()
+    assert (dst / "dirty.txt").read_text() == "dirty"
+
+
 def test_copy_dirty_head_with_gpg(
     tmp_path_factory: pytest.TempPathFactory, gitconfig: GitConfig
 ) -> None:


### PR DESCRIPTION
Fixes #2692.

When copying from a dirty local template at `HEAD`, Copier clones the template into a temporary repository and creates an automatic WIP commit with the local dirty changes.

If the source tree contains a nested Git repository without a checked-out `HEAD`, `git add -A` fails with:

```console
error: 'empty_repo/' does not have a commit checked out
fatal: adding files failed
```

This change detects nested Git repositories whose `HEAD` cannot be resolved and excludes them from the temporary WIP staging pathspec.

It also avoids creating the automatic dirty commit when no staged changes remain after those exclusions. This prevents a second Git failure when the only dirty item is an empty nested repository.

Regression coverage added for:

- a dirty local template containing only an empty nested Git repository, which should no longer crash;
- a dirty local template containing both an empty nested Git repository and a real dirty file, which should still include the dirty file and emit `DirtyLocalWarning`.

Checks run:

- `pytest -q tests/test_dirty_local.py -k "empty_nested_git_repo or dirty_head" -rs`
- `pytest -q tests/test_dirty_local.py tests/test_vcs.py -rs`
- `ruff format --check copier/_vcs.py tests/test_dirty_local.py`
- `ruff check copier/_vcs.py tests/test_dirty_local.py`
- `git diff --check`
