### PR TITLE
feat: cache remote git templates as local mirrors with worktrees

### DIFF
--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -2,18 +2,23 @@
 
 from __future__ import annotations
 
+import os
 import re
 import sys
 from contextlib import suppress
+from hashlib import sha256
 from pathlib import Path
+from shutil import rmtree
 from tempfile import TemporaryDirectory, mkdtemp
 from warnings import warn
 
 from packaging import version
 from packaging.version import InvalidVersion, Version
+from platformdirs import user_cache_dir
 from plumbum import TF, CommandNotFound, ProcessExecutionError, colors, local
 from plumbum.commands.base import BaseCommand
 
+from ._tools import handle_remove_readonly
 from ._types import OptBool, OptStrOrPath, StrOrPath
 from .errors import DirtyLocalWarning, ShallowCloneWarning
 
@@ -21,6 +26,9 @@ GIT_USER_NAME = "Copier"
 GIT_USER_EMAIL = "copier@copier"
 
 CLONE_PREFIX = f"{__name__}.clone."
+
+# Environment variable to override the on-disk location of the git mirror cache.
+CACHE_DIR_ENV_VAR = "COPIER_CACHE_DIR"
 
 
 class _PathStr(str):
@@ -190,8 +198,135 @@ def get_latest_tag(url: str, use_prereleases: OptBool = False) -> str:
         return "HEAD"
 
 
+def get_cache_dir() -> Path:
+    """Get the directory where cached git mirrors are stored.
+
+    Defaults to a per-user cache directory (via `platformdirs`), but can be
+    overridden with the `COPIER_CACHE_DIR` environment variable.
+    """
+    override = os.environ.get(CACHE_DIR_ENV_VAR)
+    if override:
+        return Path(override)
+    return Path(user_cache_dir("copier")) / "git"
+
+
+def _mirror_path(url: str) -> Path:
+    """Compute the deterministic on-disk location of the mirror for `url`."""
+    digest = sha256(url.encode("utf-8")).hexdigest()
+    return get_cache_dir() / f"{digest}.git"
+
+
+def _is_remote(url: str) -> bool:
+    """Tell whether `url` points to a remote repository worth caching.
+
+    Local repositories (existing directories or bundle files, as well as
+    paths marked with [_PathStr][]) keep their original clone behavior, which
+    preserves features like including dirty changes.
+    """
+    if isinstance(url, _PathStr):
+        return False
+    try:
+        if Path(url).exists():
+            return False
+    except OSError:
+        pass
+    return True
+
+
+def _force_rmtree(path: Path) -> None:
+    """Remove `path`, coping with git's read-only files (e.g. on Windows)."""
+    if sys.version_info >= (3, 12):
+        rmtree(path, onexc=handle_remove_readonly)
+    else:
+        rmtree(path, onerror=handle_remove_readonly)
+
+
+def _is_valid_mirror(mirror: Path) -> bool:
+    """Tell whether `mirror` is a usable bare git repository.
+
+    Guards against partial or corrupt cache entries (e.g. left behind by an
+    interrupted clone or a failed deletion) that would otherwise be mistaken
+    for a healthy mirror.
+    """
+    if not (mirror / "objects").is_dir():
+        return False
+    try:
+        out = get_git()(
+            "--git-dir", str(mirror), "rev-parse", "--is-bare-repository"
+        ).strip()
+    except (OSError, ProcessExecutionError):
+        return False
+    return out == "true"
+
+
+def get_or_create_mirror(url: str) -> Path:
+    """Get a cached `--mirror` clone of `url`, creating or refreshing it.
+
+    On first use the remote is mirror-cloned into the cache. On subsequent
+    uses the existing mirror is refreshed via `git remote update` and stale
+    worktree registrations are pruned, so no full re-download is needed. A
+    corrupt or partial cache entry is discarded and re-created.
+    """
+    git = get_git()
+    mirror = _mirror_path(url)
+    if _is_valid_mirror(mirror):
+        # Refreshing the existing mirror. Use `--git-dir` explicitly when
+        # operating on the bare repository so this works even when Git is
+        # configured with `safe.bareRepository=explicit`.
+        git("--git-dir", str(mirror), "remote", "update", "--prune")
+        # Dropping registrations for worktrees whose directories were already
+        # removed by the cleanup step (from `Template._cleanup`).
+        git("--git-dir", str(mirror), "worktree", "prune")
+    else:
+        # Discarding any corrupt/partial remnant before recreating.
+        if mirror.exists():
+            _force_rmtree(mirror)
+
+        '''Creating the mirror atomically: clone into a staging directory, then
+        move it into place. If a concurrent Copier process created the
+        mirror first, discard ours and reuse theirs. This avoids colliding
+        on a half-written mirror without requiring full inter-process locks.
+        A fresh `--mirror` clone already has every ref, so no fetch is needed.'''
+
+        mirror.parent.mkdir(parents=True, exist_ok=True)
+        staging = Path(mkdtemp(prefix=CLONE_PREFIX, dir=mirror.parent))
+        try:
+            staging_repo = staging / "repo.git"
+            git("clone", "--mirror", url, str(staging_repo))
+            try:
+                staging_repo.rename(mirror)
+            except OSError:
+                if not _is_valid_mirror(mirror):
+                    raise
+        finally:
+            rmtree(staging, ignore_errors=True)
+    return mirror
+
+
+def _clone_via_cache(ref: str, location: str, mirror: Path) -> str:
+    """Create a temporary worktree of `mirror` at `ref` in `location`.
+    
+    `git worktree add` refuses a path that already exists, so remove the
+    pre-allocated (empty) placeholder directory and let git recreate it."""
+    git = get_git()
+    placeholder = Path(location)
+    if placeholder.exists():
+        placeholder.rmdir()
+    git(
+        "--git-dir", str(mirror),
+        "worktree", "add", "--detach", "--force", location, ref,
+    )
+    with local.cwd(location):
+        git("submodule", "update", "--checkout", "--init", "--recursive", "--force")
+    return location
+
+
 def clone(url: str, ref: str = "HEAD", location: str | None = None) -> str:
     """Clone repo into some temporary destination.
+
+    Remote repositories are cached as a local git mirror and checked out into
+    a temporary worktree, so repeated use of the same template avoids a full
+    re-download.
 
     Includes dirty changes for local templates by copying into a temp
     directory and applying a wip commit there.
@@ -210,6 +345,11 @@ def clone(url: str, ref: str = "HEAD", location: str | None = None) -> str:
     git_version = get_git_version()
     if location is None:
         location = mkdtemp(prefix=CLONE_PREFIX)
+    # Remote templates: use a cached mirror + temporary worktree.
+    if _is_remote(url):
+        mirror = get_or_create_mirror(url)
+        return _clone_via_cache(ref, location, mirror)
+    # Local templates: keep the original clone behavior.
     _clone = git["clone", "--no-checkout", url, location]
     # Faster clones if possible
     if git_version >= Version("2.27"):

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -10,6 +10,7 @@ from hashlib import sha256
 from pathlib import Path
 from shutil import rmtree
 from tempfile import TemporaryDirectory, mkdtemp
+from urllib.parse import urlsplit, urlunsplit
 from warnings import warn
 
 from packaging import version
@@ -198,7 +199,7 @@ def get_latest_tag(url: str, use_prereleases: OptBool = False) -> str:
         return "HEAD"
 
 
-def get_cache_dir() -> Path:
+def _get_cache_dir() -> Path:
     """Get the directory where cached git mirrors are stored.
 
     Defaults to a per-user cache directory (via `platformdirs`), but can be
@@ -207,13 +208,29 @@ def get_cache_dir() -> Path:
     override = os.environ.get(CACHE_DIR_ENV_VAR)
     if override:
         return Path(override)
-    return Path(user_cache_dir("copier")) / "git"
+    # `appauthor=False` avoids a redundant "copier" path segment on Windows,
+    # e.g. `.../copier/Cache` instead of `.../copier/copier/Cache`.
+    return Path(user_cache_dir("copier", appauthor=False)) / "git"
 
 
-def _mirror_path(url: str) -> Path:
+def _strip_credentials(url: str) -> str:
+    """Remove any embedded `user:password@` credentials from `url`.
+
+    Used to build the cache key so that the same repository accessed with
+    different credentials maps to a single mirror, and so secrets never
+    influence the cache layout.
+    """
+    parts = urlsplit(url)
+    if parts.netloc and "@" in parts.netloc:
+        netloc = parts.netloc.rsplit("@", 1)[1]
+        return urlunsplit(parts._replace(netloc=netloc))
+    return url
+
+
+def _get_mirror_path(url: str) -> Path:
     """Compute the deterministic on-disk location of the mirror for `url`."""
-    digest = sha256(url.encode("utf-8")).hexdigest()
-    return get_cache_dir() / f"{digest}.git"
+    digest = sha256(_strip_credentials(url).encode("utf-8")).hexdigest()
+    return _get_cache_dir() / f"{digest}.git"
 
 
 def _is_remote(url: str) -> bool:
@@ -259,7 +276,7 @@ def _is_valid_mirror(mirror: Path) -> bool:
     return out == "true"
 
 
-def get_or_create_mirror(url: str) -> Path:
+def _get_or_create_mirror(url: str) -> Path:
     """Get a cached `--mirror` clone of `url`, creating or refreshing it.
 
     On first use the remote is mirror-cloned into the cache. On subsequent
@@ -268,7 +285,7 @@ def get_or_create_mirror(url: str) -> Path:
     corrupt or partial cache entry is discarded and re-created.
     """
     git = get_git()
-    mirror = _mirror_path(url)
+    mirror = _get_mirror_path(url)
     if _is_valid_mirror(mirror):
         # Refreshing the existing mirror. Use `--git-dir` explicitly when
         # operating on the bare repository so this works even when Git is
@@ -282,32 +299,31 @@ def get_or_create_mirror(url: str) -> Path:
         if mirror.exists():
             _force_rmtree(mirror)
 
-        '''Creating the mirror atomically: clone into a staging directory, then
-        move it into place. If a concurrent Copier process created the
-        mirror first, discard ours and reuse theirs. This avoids colliding
-        on a half-written mirror without requiring full inter-process locks.
-        A fresh `--mirror` clone already has every ref, so no fetch is needed.'''
-
+        # Creating the mirror atomically: clone into a staging directory, then
+        # move it into place. If a concurrent Copier process created the
+        # mirror first, discard ours and reuse theirs. This avoids colliding
+        # on a half-written mirror without requiring full inter-process locks.
+        # A fresh `--mirror` clone already has every ref, so no fetch is needed.
         mirror.parent.mkdir(parents=True, exist_ok=True)
-        staging = Path(mkdtemp(prefix=CLONE_PREFIX, dir=mirror.parent))
-        try:
-            staging_repo = staging / "repo.git"
+        with TemporaryDirectory(
+            prefix=CLONE_PREFIX, dir=mirror.parent, ignore_cleanup_errors=True
+        ) as staging:
+            staging_repo = Path(staging) / "repo.git"
             git("clone", "--mirror", url, str(staging_repo))
             try:
                 staging_repo.rename(mirror)
             except OSError:
                 if not _is_valid_mirror(mirror):
                     raise
-        finally:
-            rmtree(staging, ignore_errors=True)
     return mirror
 
 
 def _clone_via_cache(ref: str, location: str, mirror: Path) -> str:
     """Create a temporary worktree of `mirror` at `ref` in `location`.
-    
+
     `git worktree add` refuses a path that already exists, so remove the
-    pre-allocated (empty) placeholder directory and let git recreate it."""
+    pre-allocated (empty) placeholder directory and let git recreate it.
+    """
     git = get_git()
     placeholder = Path(location)
     if placeholder.exists():
@@ -347,7 +363,7 @@ def clone(url: str, ref: str = "HEAD", location: str | None = None) -> str:
         location = mkdtemp(prefix=CLONE_PREFIX)
     # Remote templates: use a cached mirror + temporary worktree.
     if _is_remote(url):
-        mirror = get_or_create_mirror(url)
+        mirror = _get_or_create_mirror(url)
         return _clone_via_cache(ref, location, mirror)
     # Local templates: keep the original clone behavior.
     _clone = git["clone", "--no-checkout", url, location]

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -208,8 +208,6 @@ def _get_cache_dir() -> Path:
     override = os.environ.get(CACHE_DIR_ENV_VAR)
     if override:
         return Path(override)
-    # `appauthor=False` avoids a redundant "copier" path segment on Windows,
-    # e.g. `.../copier/Cache` instead of `.../copier/copier/Cache`.
     return Path(user_cache_dir("copier", appauthor=False)) / "git"
 
 

--- a/copier/_vcs.py
+++ b/copier/_vcs.py
@@ -329,8 +329,14 @@ def _clone_via_cache(ref: str, location: str, mirror: Path) -> str:
     if placeholder.exists():
         placeholder.rmdir()
     git(
-        "--git-dir", str(mirror),
-        "worktree", "add", "--detach", "--force", location, ref,
+        "--git-dir",
+        str(mirror),
+        "worktree",
+        "add",
+        "--detach",
+        "--force",
+        location,
+        ref,
     )
     with local.cwd(location):
         git("submodule", "update", "--checkout", "--init", "--recursive", "--force")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,6 +95,19 @@ def default_gitconfig(default_gitconfig: GitConfig) -> GitConfig:
     return default_gitconfig
 
 
+@pytest.fixture(scope="session", autouse=True)
+def copier_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """Redirect the git template mirror cache to a temporary directory.
+
+    Avoids polluting the user's real Copier cache with the templates cloned
+    during the test suite.
+    """
+    cache_dir = tmp_path_factory.mktemp("copier_cache")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("COPIER_CACHE_DIR", str(cache_dir))
+        yield
+
+
 @pytest.fixture
 def gitconfig(gitconfig: GitConfig) -> Iterator[GitConfig]:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,19 +95,6 @@ def default_gitconfig(default_gitconfig: GitConfig) -> GitConfig:
     return default_gitconfig
 
 
-@pytest.fixture(scope="session", autouse=True)
-def copier_cache_dir(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
-    """Redirect the git template mirror cache to a temporary directory.
-
-    Avoids polluting the user's real Copier cache with the templates cloned
-    during the test suite.
-    """
-    cache_dir = tmp_path_factory.mktemp("copier_cache")
-    with pytest.MonkeyPatch.context() as monkeypatch:
-        monkeypatch.setenv("COPIER_CACHE_DIR", str(cache_dir))
-        yield
-
-
 @pytest.fixture
 def gitconfig(gitconfig: GitConfig) -> Iterator[GitConfig]:
     """
@@ -132,3 +119,16 @@ def settings_path(config_path: Path) -> Path:
     config_path.mkdir()
     settings_path = config_path / "settings.yml"
     return settings_path
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _cache_dir(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """Redirect the git template mirror cache to a temporary directory.
+
+    Avoids polluting the user's real Copier cache with the templates cloned
+    during the test suite.
+    """
+    cache_dir = tmp_path_factory.mktemp("copier_cache")
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setenv("COPIER_CACHE_DIR", str(cache_dir))
+        yield

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from collections.abc import Callable, Iterator, Sequence
+from contextlib import ExitStack
 from pathlib import Path
 from unittest import mock
 
@@ -13,8 +14,8 @@ from copier import run_copy, run_update
 from copier._main import Worker
 from copier._user_data import load_answersfile_data
 from copier._vcs import (
+    _get_mirror_path,
     _is_remote,
-    _mirror_path,
     clone,
     get_git,
     get_git_version,
@@ -98,12 +99,16 @@ def test_local_clone() -> None:
     shutil.rmtree(local_tmp, ignore_errors=True)
 
 
-def _make_remote_repo(path: Path) -> str:
-    """Create a small local git repo and return a ``file://`` URL to it.
+@pytest.fixture
+def remote_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+    """A small local git repo exposed via a ``file://`` URL (treated as remote).
 
     A ``file://`` URL is treated as remote by ``clone()``, so this exercises
-    the mirror-cache code path without requiring network access.
+    the mirror-cache code path without requiring network access. The mirror
+    cache is redirected to a temp dir to keep the test isolated.
     """
+    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
+    path = tmp_path / "remote"
     path.mkdir(parents=True, exist_ok=True)
     with local.cwd(path):
         git("init")
@@ -112,6 +117,22 @@ def _make_remote_repo(path: Path) -> str:
         git("commit", "-m", "init")
         git("tag", "v1.0.0")
     return path.as_uri()
+
+
+@pytest.fixture
+def clone_cleanup() -> Iterator[Callable[[str], str]]:
+    """Register clone destinations to remove on teardown, even on failure.
+
+    Returns a function that records and returns its argument, so test
+    assertions can't leak temporary worktrees when they fail.
+    """
+    with ExitStack() as stack:
+
+        def register(dst: str) -> str:
+            stack.callback(shutil.rmtree, dst, ignore_errors=True)
+            return dst
+
+        yield register
 
 
 def test_is_remote() -> None:
@@ -124,15 +145,20 @@ def test_is_remote() -> None:
     assert not _is_remote(get_repo(str(Path.cwd())) or "")
 
 
-def test_remote_clone_creates_and_reuses_mirror(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
-    url = _make_remote_repo(tmp_path / "remote")
+def test_mirror_path_ignores_credentials() -> None:
+    # Embedded credentials must not affect the cache key, so the same repo
+    # accessed with or without a token maps to a single mirror.
+    base = "https://github.com/org/repo.git"
+    with_token = "https://x-access-token:github_pat_secret@github.com/org/repo.git"
+    assert _get_mirror_path(with_token) == _get_mirror_path(base)
 
+
+def test_remote_clone_creates_and_reuses_mirror(
+    remote_repo: str, clone_cleanup: Callable[[str], str]
+) -> None:
     # First use creates the mirror and checks out a worktree.
-    dst1 = clone(url)
-    mirror = _mirror_path(url)
+    dst1 = clone_cleanup(clone(remote_repo))
+    mirror = _get_mirror_path(remote_repo)
     assert (mirror / "objects").is_dir()
     assert Path(dst1, "README.md").read_text() == "hello world"
 
@@ -141,56 +167,43 @@ def test_remote_clone_creates_and_reuses_mirror(
     sentinel = mirror / "copier-cache-sentinel"
     sentinel.write_text("kept")
 
-    dst2 = clone(url)
+    dst2 = clone_cleanup(clone(remote_repo))
     assert sentinel.exists(), "mirror was re-created instead of reused"
     assert Path(dst2, "README.md").exists()
     assert dst2 != dst1  # a fresh worktree per use
 
-    shutil.rmtree(dst1, ignore_errors=True)
-    shutil.rmtree(dst2, ignore_errors=True)
-
 
 def test_remote_clone_checks_out_ref(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    remote_repo: str, clone_cleanup: Callable[[str], str]
 ) -> None:
-    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
-    url = _make_remote_repo(tmp_path / "remote")
-
-    dst = clone(url, "v1.0.0")
+    dst = clone_cleanup(clone(remote_repo, "v1.0.0"))
     assert Path(dst, "README.md").read_text() == "hello world"
-    shutil.rmtree(dst, ignore_errors=True)
 
 
 def test_remote_clone_prunes_stale_worktree(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    remote_repo: str, clone_cleanup: Callable[[str], str]
 ) -> None:
-    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
-    url = _make_remote_repo(tmp_path / "remote")
-    mirror = _mirror_path(url)
+    mirror = _get_mirror_path(remote_repo)
 
     # Simulate Copier's cleanup: the worktree directory is removed, leaving a
     # stale registration behind in the mirror.
-    dst1 = clone(url)
+    dst1 = clone(remote_repo)
     shutil.rmtree(dst1, ignore_errors=True)
     assert not Path(dst1).exists()
 
     # The next use must prune the stale registration and succeed.
-    dst2 = clone(url)
+    dst2 = clone_cleanup(clone(remote_repo))
     assert Path(dst2, "README.md").exists()
     worktrees = get_git()("-C", str(mirror), "worktree", "list", "--porcelain")
     assert Path(dst1).as_posix() not in worktrees.replace("\\", "/")
-    shutil.rmtree(dst2, ignore_errors=True)
 
 
 def test_remote_clone_recovers_from_corrupt_mirror(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    remote_repo: str, clone_cleanup: Callable[[str], str]
 ) -> None:
-    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
-    url = _make_remote_repo(tmp_path / "remote")
-
-    dst1 = clone(url)
+    dst1 = clone(remote_repo)
     shutil.rmtree(dst1, ignore_errors=True)
-    mirror = _mirror_path(url)
+    mirror = _get_mirror_path(remote_repo)
 
     # Simulate a partial/corrupt cache entry: the `objects` directory survives
     # but the rest of the repository is gone (e.g. an interrupted deletion).
@@ -203,9 +216,8 @@ def test_remote_clone_recovers_from_corrupt_mirror(
     assert (mirror / "objects").is_dir()
 
     # The next use must discard the corrupt mirror and rebuild it.
-    dst2 = clone(url)
+    dst2 = clone_cleanup(clone(remote_repo))
     assert Path(dst2, "README.md").read_text() == "hello world"
-    shutil.rmtree(dst2, ignore_errors=True)
 
 
 def test_local_dirty_clone(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,7 +1,6 @@
 import os
 import shutil
 from collections.abc import Callable, Iterator, Sequence
-from contextlib import ExitStack
 from pathlib import Path
 from unittest import mock
 
@@ -100,16 +99,20 @@ def test_local_clone() -> None:
 
 
 @pytest.fixture
-def remote_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
+def remote_repo(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> str:
     """A small local git repo exposed via a ``file://`` URL (treated as remote).
 
     A ``file://`` URL is treated as remote by ``clone()``, so this exercises
     the mirror-cache code path without requiring network access. The mirror
     cache is redirected to a temp dir to keep the test isolated.
+
+    Uses ``tmp_path_factory`` rather than ``tmp_path`` so the repo and cache
+    don't share a path with a test's own ``tmp_path``.
     """
-    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
-    path = tmp_path / "remote"
-    path.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path_factory.mktemp("cache")))
+    path = tmp_path_factory.mktemp("remote_repo")
     with local.cwd(path):
         git("init")
         Path("README.md").write_text("hello world")
@@ -117,22 +120,6 @@ def remote_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
         git("commit", "-m", "init")
         git("tag", "v1.0.0")
     return path.as_uri()
-
-
-@pytest.fixture
-def clone_cleanup() -> Iterator[Callable[[str], str]]:
-    """Register clone destinations to remove on teardown, even on failure.
-
-    Returns a function that records and returns its argument, so test
-    assertions can't leak temporary worktrees when they fail.
-    """
-    with ExitStack() as stack:
-
-        def register(dst: str) -> str:
-            stack.callback(shutil.rmtree, dst, ignore_errors=True)
-            return dst
-
-        yield register
 
 
 def test_is_remote() -> None:
@@ -154,10 +141,13 @@ def test_mirror_path_ignores_credentials() -> None:
 
 
 def test_remote_clone_creates_and_reuses_mirror(
-    remote_repo: str, clone_cleanup: Callable[[str], str]
+    remote_repo: str, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
-    # First use creates the mirror and checks out a worktree.
-    dst1 = clone_cleanup(clone(remote_repo))
+    # First use creates the mirror and checks out a worktree. Passing an
+    # explicit, test-managed location keeps the worktree from leaking. Distinct
+    # subpaths under one base dir avoids `mktemp` reusing a deleted name.
+    clones = tmp_path_factory.mktemp("clones")
+    dst1 = clone(remote_repo, location=str(clones / "first"))
     mirror = _get_mirror_path(remote_repo)
     assert (mirror / "objects").is_dir()
     assert Path(dst1, "README.md").read_text() == "hello world"
@@ -167,41 +157,43 @@ def test_remote_clone_creates_and_reuses_mirror(
     sentinel = mirror / "copier-cache-sentinel"
     sentinel.write_text("kept")
 
-    dst2 = clone_cleanup(clone(remote_repo))
+    dst2 = clone(remote_repo, location=str(clones / "second"))
     assert sentinel.exists(), "mirror was re-created instead of reused"
     assert Path(dst2, "README.md").exists()
     assert dst2 != dst1  # a fresh worktree per use
 
 
 def test_remote_clone_checks_out_ref(
-    remote_repo: str, clone_cleanup: Callable[[str], str]
+    remote_repo: str, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
-    dst = clone_cleanup(clone(remote_repo, "v1.0.0"))
+    dst = clone(remote_repo, "v1.0.0", location=str(tmp_path_factory.mktemp("clone")))
     assert Path(dst, "README.md").read_text() == "hello world"
 
 
 def test_remote_clone_prunes_stale_worktree(
-    remote_repo: str, clone_cleanup: Callable[[str], str]
+    remote_repo: str, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
     mirror = _get_mirror_path(remote_repo)
+    clones = tmp_path_factory.mktemp("clones")
 
     # Simulate Copier's cleanup: the worktree directory is removed, leaving a
     # stale registration behind in the mirror.
-    dst1 = clone(remote_repo)
+    dst1 = clone(remote_repo, location=str(clones / "stale"))
     shutil.rmtree(dst1, ignore_errors=True)
     assert not Path(dst1).exists()
 
     # The next use must prune the stale registration and succeed.
-    dst2 = clone_cleanup(clone(remote_repo))
+    dst2 = clone(remote_repo, location=str(clones / "fresh"))
     assert Path(dst2, "README.md").exists()
     worktrees = get_git()("-C", str(mirror), "worktree", "list", "--porcelain")
     assert Path(dst1).as_posix() not in worktrees.replace("\\", "/")
 
 
 def test_remote_clone_recovers_from_corrupt_mirror(
-    remote_repo: str, clone_cleanup: Callable[[str], str]
+    remote_repo: str, tmp_path_factory: pytest.TempPathFactory
 ) -> None:
-    dst1 = clone(remote_repo)
+    clones = tmp_path_factory.mktemp("clones")
+    dst1 = clone(remote_repo, location=str(clones / "orig"))
     shutil.rmtree(dst1, ignore_errors=True)
     mirror = _get_mirror_path(remote_repo)
 
@@ -216,7 +208,7 @@ def test_remote_clone_recovers_from_corrupt_mirror(
     assert (mirror / "objects").is_dir()
 
     # The next use must discard the corrupt mirror and rebuild it.
-    dst2 = clone_cleanup(clone(remote_repo))
+    dst2 = clone(remote_repo, location=str(clones / "rebuilt"))
     assert Path(dst2, "README.md").read_text() == "hello world"
 
 

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -13,7 +13,10 @@ from copier import run_copy, run_update
 from copier._main import Worker
 from copier._user_data import load_answersfile_data
 from copier._vcs import (
+    _is_remote,
+    _mirror_path,
     clone,
+    get_git,
     get_git_version,
     get_latest_tag,
     get_repo,
@@ -93,6 +96,116 @@ def test_local_clone() -> None:
     assert local_tmp
     assert Path(local_tmp, "README.md").exists()
     shutil.rmtree(local_tmp, ignore_errors=True)
+
+
+def _make_remote_repo(path: Path) -> str:
+    """Create a small local git repo and return a ``file://`` URL to it.
+
+    A ``file://`` URL is treated as remote by ``clone()``, so this exercises
+    the mirror-cache code path without requiring network access.
+    """
+    path.mkdir(parents=True, exist_ok=True)
+    with local.cwd(path):
+        git("init")
+        Path("README.md").write_text("hello world")
+        git("add", "-A")
+        git("commit", "-m", "init")
+        git("tag", "v1.0.0")
+    return path.as_uri()
+
+
+def test_is_remote() -> None:
+    assert _is_remote("https://github.com/copier-org/copier.git")
+    assert _is_remote("git@github.com:copier-org/copier.git")
+    assert _is_remote("file:///some/where/repo.git")
+    # Local, on-disk paths are not remote.
+    assert not _is_remote(str(Path.cwd()))
+    # `get_repo` marks resolved local repos so they keep the old behavior.
+    assert not _is_remote(get_repo(str(Path.cwd())) or "")
+
+
+def test_remote_clone_creates_and_reuses_mirror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
+    url = _make_remote_repo(tmp_path / "remote")
+
+    # First use creates the mirror and checks out a worktree.
+    dst1 = clone(url)
+    mirror = _mirror_path(url)
+    assert (mirror / "objects").is_dir()
+    assert Path(dst1, "README.md").read_text() == "hello world"
+
+    # Drop a sentinel inside the mirror; if the second use re-clones from
+    # scratch the mirror directory (and the sentinel) would be recreated.
+    sentinel = mirror / "copier-cache-sentinel"
+    sentinel.write_text("kept")
+
+    dst2 = clone(url)
+    assert sentinel.exists(), "mirror was re-created instead of reused"
+    assert Path(dst2, "README.md").exists()
+    assert dst2 != dst1  # a fresh worktree per use
+
+    shutil.rmtree(dst1, ignore_errors=True)
+    shutil.rmtree(dst2, ignore_errors=True)
+
+
+def test_remote_clone_checks_out_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
+    url = _make_remote_repo(tmp_path / "remote")
+
+    dst = clone(url, "v1.0.0")
+    assert Path(dst, "README.md").read_text() == "hello world"
+    shutil.rmtree(dst, ignore_errors=True)
+
+
+def test_remote_clone_prunes_stale_worktree(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
+    url = _make_remote_repo(tmp_path / "remote")
+    mirror = _mirror_path(url)
+
+    # Simulate Copier's cleanup: the worktree directory is removed, leaving a
+    # stale registration behind in the mirror.
+    dst1 = clone(url)
+    shutil.rmtree(dst1, ignore_errors=True)
+    assert not Path(dst1).exists()
+
+    # The next use must prune the stale registration and succeed.
+    dst2 = clone(url)
+    assert Path(dst2, "README.md").exists()
+    worktrees = get_git()("-C", str(mirror), "worktree", "list", "--porcelain")
+    assert Path(dst1).as_posix() not in worktrees.replace("\\", "/")
+    shutil.rmtree(dst2, ignore_errors=True)
+
+
+def test_remote_clone_recovers_from_corrupt_mirror(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path / "cache"))
+    url = _make_remote_repo(tmp_path / "remote")
+
+    dst1 = clone(url)
+    shutil.rmtree(dst1, ignore_errors=True)
+    mirror = _mirror_path(url)
+
+    # Simulate a partial/corrupt cache entry: the `objects` directory survives
+    # but the rest of the repository is gone (e.g. an interrupted deletion).
+    for child in mirror.iterdir():
+        if child.name != "objects":
+            if child.is_dir():
+                shutil.rmtree(child, ignore_errors=True)
+            else:
+                child.unlink()
+    assert (mirror / "objects").is_dir()
+
+    # The next use must discard the corrupt mirror and rebuild it.
+    dst2 = clone(url)
+    assert Path(dst2, "README.md").read_text() == "hello world"
+    shutil.rmtree(dst2, ignore_errors=True)
 
 
 def test_local_dirty_clone(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -99,19 +99,17 @@ def test_local_clone() -> None:
 
 
 @pytest.fixture
-def remote_repo(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
-) -> str:
+def remote_repo(tmp_path_factory: pytest.TempPathFactory) -> str:
     """A small local git repo exposed via a ``file://`` URL (treated as remote).
 
     A ``file://`` URL is treated as remote by ``clone()``, so this exercises
     the mirror-cache code path without requiring network access. The mirror
-    cache is redirected to a temp dir to keep the test isolated.
+    cache itself is redirected to a temp dir by the session-wide ``_cache_dir``
+    fixture in ``conftest.py``.
 
-    Uses ``tmp_path_factory`` rather than ``tmp_path`` so the repo and cache
-    don't share a path with a test's own ``tmp_path``.
+    Uses ``tmp_path_factory`` rather than ``tmp_path`` so the repo doesn't share
+    a path with a test's own ``tmp_path``.
     """
-    monkeypatch.setenv("COPIER_CACHE_DIR", str(tmp_path_factory.mktemp("cache")))
     path = tmp_path_factory.mktemp("remote_repo")
     with local.cwd(path):
         git("init")

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -103,12 +103,7 @@ def remote_repo(tmp_path_factory: pytest.TempPathFactory) -> str:
     """A small local git repo exposed via a ``file://`` URL (treated as remote).
 
     A ``file://`` URL is treated as remote by ``clone()``, so this exercises
-    the mirror-cache code path without requiring network access. The mirror
-    cache itself is redirected to a temp dir by the session-wide ``_cache_dir``
-    fixture in ``conftest.py``.
-
-    Uses ``tmp_path_factory`` rather than ``tmp_path`` so the repo doesn't share
-    a path with a test's own ``tmp_path``.
+    the mirror-cache code path without requiring network access.
     """
     path = tmp_path_factory.mktemp("remote_repo")
     with local.cwd(path):


### PR DESCRIPTION
Remote templates were re-cloned into a throwaway temp directory on every run.
Following @yajo's suggestion, this caches a persistent `git --mirror` clone per template under the user cache dir and checks out temporary worktrees from it.

- First use: `git clone --mirror` into the cache (created atomically via staging + rename), then `git worktree add` a temporary checkout.
- Later uses: `git remote update --prune` (no full re-download) + a fresh worktree.
- Local templates keep the original behavior (including dirty-change handling).
- Cache dir via `platformdirs`, overridable with `COPIER_CACHE_DIR`. No new dependency.
- Robustness: explicit `--git-dir` (works with `safe.bareRepository=explicit`), stale-worktree pruning, read-only-safe cleanup, corrupt-mirror recovery.
- Existing VCS tests unchanged; 5 new network free tests added (20 passing under pytest-xdist).

Closes #450