### PR TITLE
fix(updating): don't exclude template-generated gitignored files from apply

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1412,13 +1412,13 @@ class Worker:
                     "HEAD",
                     subproject_head,
                 ).splitlines()
-                exclude_plus_removed = list(
-                    set(self.exclude).union(
-                        f"/{escape_git_path(path)}"
-                        for path in map(normalize_git_path, files_removed)
-                        if not self.match_skip(Path(path))
-                    )
-                )
+                removed_paths = []
+                for path in map(normalize_git_path, files_removed):
+                    if (subproject_top / path).exists():
+                        continue
+                    if not self.match_skip(Path(path)):
+                        removed_paths.append(f"/{escape_git_path(path)}")
+                exclude_plus_removed = list(set(self.exclude).union(removed_paths))
             # Clear last answers cache to load possible answers migration, if
             # skip_answered flag is not set
             if self.skip_answered is False:
@@ -1543,9 +1543,7 @@ class Worker:
                         # Don't exclude template-generated files that happen to
                         # be gitignored — they should still be updated.
                         # Fixes #2729, regression of #1162.
-                        if (
-                            Path(new_copy) / normalize_git_path(filepath)
-                        ).exists():
+                        if (Path(new_copy) / normalize_git_path(filepath)).exists():
                             continue
                         apply_cmd = apply_cmd["--exclude", filepath]
                 (apply_cmd << diff)(retcode=None)

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1539,7 +1539,15 @@ class Worker:
                 # adds `--exclude file1 --exclude file2` to `git apply` command
                 for filename in ignored_files.splitlines():
                     if filename.startswith("!! "):
-                        apply_cmd = apply_cmd["--exclude", filename[3:]]
+                        filepath = filename[3:]
+                        # Don't exclude template-generated files that happen to
+                        # be gitignored — they should still be updated.
+                        # Fixes #2729, regression of #1162.
+                        if (
+                            Path(new_copy) / normalize_git_path(filepath)
+                        ).exists():
+                            continue
+                        apply_cmd = apply_cmd["--exclude", filepath]
                 (apply_cmd << diff)(retcode=None)
                 if self.conflict == "inline":
                     conflicted = []

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -1412,13 +1412,14 @@ class Worker:
                     "HEAD",
                     subproject_head,
                 ).splitlines()
-                removed_paths = []
-                for path in map(normalize_git_path, files_removed):
-                    if (subproject_top / path).exists():
-                        continue
-                    if not self.match_skip(Path(path)):
-                        removed_paths.append(f"/{escape_git_path(path)}")
-                exclude_plus_removed = list(set(self.exclude).union(removed_paths))
+                exclude_plus_removed = list(
+                    set(self.exclude).union(
+                        f"/{escape_git_path(path)}"
+                        for path in map(normalize_git_path, files_removed)
+                        if not (subproject_top / path).exists()
+                        and not self.match_skip(Path(path))
+                    )
+                )
             # Clear last answers cache to load possible answers migration, if
             # skip_answered flag is not set
             if self.skip_answered is False:

--- a/tests/test_updatediff.py
+++ b/tests/test_updatediff.py
@@ -1943,6 +1943,41 @@ def test_gitignore_file_unignored(
     assert load_answersfile_data(dst).get("_commit") == "v3"
 
 
+def test_update_keeps_template_generated_gitignored_file(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+
+    build_file_tree(
+        {
+            src / "{{ _copier_conf.answers_file }}.jinja": (
+                "{{ _copier_answers|to_yaml }}"
+            ),
+            src / ".env.jinja": "VERSION=v1",
+        }
+    )
+    with local.cwd(src):
+        git_init("v1")
+        git("tag", "v1")
+
+    build_file_tree({src / ".env.jinja": "VERSION=v2"})
+    with local.cwd(src):
+        git("commit", "-am2")
+        git("tag", "v2")
+
+    run_copy(str(src), dst, vcs_ref="v1")
+    assert (dst / ".env").read_text() == "VERSION=v1"
+    with local.cwd(dst):
+        Path(".gitignore").write_text(".env\n")
+        git("init")
+        git("add", ".")
+        assert ".env" not in git("ls-files", "--", ".env").splitlines()
+        git("commit", "-m1")
+
+    run_update(dst, overwrite=True)
+    assert (dst / ".env").read_text() == "VERSION=v2"
+
+
 def test_update_with_answers_with_umlaut(
     tmp_path_factory: pytest.TempPathFactory,
 ) -> None:


### PR DESCRIPTION
Template-generated files matching .gitignore patterns were silently dropped during `copier update` because `git status --ignored` returned them and `--exclude` was unconditionally added for each to `git apply`.

Check if an ignored file exists in the fresh template copy before excluding it — if it does, it's template-managed and should be updated.

Fixes #2729, regression of #1162.