### PR TITLE
chore(config): migrate pytest configuration to `[tool.pytest]` section in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,8 +167,8 @@ disable_error_code = ["no-untyped-def"]
 module = "mkdocs_hooks"
 disable_error_code = ["import-not-found"]
 
-[tool.pytest.ini_options]
-addopts = "-n auto -ra"
+[tool.pytest]
+addopts = ["-n", "auto", "-ra"]
 markers = ["impure: needs network or is not 100% reproducible"]
 
 [tool.coverage.run]


### PR DESCRIPTION
Starting with pytest [v9.0.0](https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05), native TOML configuration is supported including an idiomatic [`[tool.pytest]` section in `pyproject.toml`](https://docs.pytest.org/en/stable/reference/customize.html#pyproject-toml). Since [we're already using pytest v9+](https://github.com/copier-org/copier/blob/fa9ce15ad39e1eb3085eeed4adb7b16a25e643e6/pyproject.toml#L54), I've migrated our pytest configuration accordingly. 