### PR TITLE
feat: allow an exclude entry to render to multiple newline-separated patterns

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -769,10 +769,20 @@ class Worker:
         # Note: This method is a cached property, it needs to be regenerated
         # when reusing an instance in different contexts.
         extra_context = {"_copier_operation": _operation.get()}
-        return self._path_matcher(
-            self._render_string(exclusion, extra_context=extra_context)
-            for exclusion in self.all_exclusions
-        )
+
+        # A single exclusion entry may render to multiple newline-separated
+        # patterns. This lets one Jinja block conditionally emit a whole list of
+        # patterns (e.g. `{% if flag %}a\nb\nc{% endif %}`) instead of repeating
+        # the condition on every entry. Blank lines (including the empty render of
+        # a false conditional) are dropped, so a no-op renders to nothing.
+        def _rendered_patterns() -> Iterable[str]:
+            for exclusion in self.all_exclusions:
+                rendered = self._render_string(exclusion, extra_context=extra_context)
+                for line in rendered.splitlines():
+                    if line.strip():
+                        yield line
+
+        return self._path_matcher(_rendered_patterns())
 
     @cached_property
     def match_skip(self) -> Callable[[Path], bool]:

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1112,6 +1112,29 @@ Each pattern can be templated using Jinja.
     The difference with [skip_if_exists](#skip_if_exists) is that it will never be
     rendered during an update, no matter if it exists or not.
 
+A single pattern may render to **multiple newline-separated patterns**. Each rendered
+line is treated as its own pattern (blank lines, including the empty render of a false
+conditional, are ignored). This lets one Jinja block conditionally emit a whole list of
+patterns instead of repeating the same condition on every entry.
+
+!!! example
+
+    Exclude a group of files with a single conditional block instead of guarding each
+    entry individually:
+
+    ```yaml
+    skip_ci: bool
+    _exclude:
+        - |
+          {% if skip_ci %}
+          .github/workflows/ci.yml
+          .github/workflows/deploy.yml
+          docs/ci/
+          {% endif %}
+    ```
+
+    When `skip_ci` is false the block renders empty and nothing extra is excluded.
+
 !!! info
 
     When you define this parameter in `copier.yml`, it will **replace** the default

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -54,6 +54,45 @@ def test_config_include(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert (dst / "copier.yml").exists()
 
 
+@pytest.mark.parametrize("skip", [True, False])
+def test_config_exclude_multiline_conditional(
+    tmp_path_factory: pytest.TempPathFactory, skip: bool
+) -> None:
+    """A single exclusion entry may render to multiple newline-separated patterns.
+
+    This lets one Jinja block conditionally emit a whole list of patterns instead of
+    repeating the condition on every entry. When the guard is false the block renders
+    empty and excludes nothing.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": (
+                "skip: {type: bool}\n"
+                "_exclude:\n"
+                '  - "copier.yml"\n'
+                "  - |\n"
+                "    {% if skip %}\n"
+                "    a.txt\n"
+                "    b.txt\n"
+                "    sub/c.txt\n"
+                "    {% endif %}\n"
+            ),
+            src / "a.txt": "",
+            src / "b.txt": "",
+            src / "sub" / "c.txt": "",
+            src / "keep.txt": "",
+        }
+    )
+    run_copy(str(src), dst, quiet=True, data={"skip": skip})
+    # keep.txt is never in the block, so it is always copied.
+    assert (dst / "keep.txt").exists()
+    # The whole list is emitted from one guarded block: excluded iff skip is true.
+    assert (dst / "a.txt").exists() is not skip
+    assert (dst / "b.txt").exists() is not skip
+    assert (dst / "sub" / "c.txt").exists() is not skip
+
+
 @pytest.mark.xfail(
     condition=platform.system() == "Darwin",
     reason="OS without proper UTF-8 filesystem.",


### PR DESCRIPTION
## What

Split each rendered `_exclude` entry on newlines, so a **single Jinja block can conditionally emit a whole list of patterns** instead of repeating the condition on every entry.

```yaml
skip_ci: bool
_exclude:
  - |
    {% if skip_ci %}
    .github/workflows/ci.yml
    .github/workflows/deploy.yml
    docs/ci/
    {% endif %}
```

When `skip_ci` is false the block renders empty and nothing extra is excluded.

## Why

`_exclude` patterns are templated per-item, so conditionally excluding a *group* of files today requires repeating the guard on every line:

```yaml
_exclude:
  - "{% if skip_ci %}.github/workflows/ci.yml{% endif %}"
  - "{% if skip_ci %}.github/workflows/deploy.yml{% endif %}"
  - "{% if skip_ci %}docs/ci/{% endif %}"
```

Authoring a multi-line block instead **silently does nothing**: the rendered value reaches `PathSpec.from_lines` as a single string containing newlines, i.e. one malformed pattern that matches no path. This change makes the intuitive form work.

## How

In `Worker.match_exclude`, each rendered exclusion is split on newlines and blank lines are dropped before building the `PathSpec`. This mirrors gitignore-style semantics (one pattern per line, blanks ignored).

- **Backward-compatible:** a single-line entry splits to itself; existing templates are unaffected (all 13 pre-existing exclude tests still pass).
- **No-op safety:** a false conditional renders to whitespace → dropped → excludes nothing.

## Tests

Added a parametrized `test_config_exclude_multiline_conditional` (true/false) asserting a one-block conditional excludes the whole list when the guard is true and nothing when false. Full `tests/test_exclude.py` passes (15 passed, 1 pre-existing xfail); `ruff check` + `ruff format` clean.

## Docs

Documented the multi-line behavior with an example under the `exclude` setting in `docs/configuring.md`.