### PR TITLE
feat: Adds support for multiline exclusion under a single flag

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -769,18 +769,12 @@ class Worker:
         # Note: This method is a cached property, it needs to be regenerated
         # when reusing an instance in different contexts.
         extra_context = {"_copier_operation": _operation.get()}
-
-        # A single exclusion entry may render to multiple newline-separated patterns.
-        # Blank lines are dropped, so an empty conditional renders to nothing.
-        def _rendered_patterns() -> Iterable[str]:
-            for exclusion in self.all_exclusions:
-                rendered = self._render_string(exclusion, extra_context=extra_context)
-                for line in rendered.splitlines():
-                    stripped = line.strip()
-                    if stripped:
-                        yield stripped
-
-        return self._path_matcher(_rendered_patterns())
+        return self._path_matcher(
+            chain.from_iterable(
+                self._render_string(exclusion, extra_context=extra_context).splitlines()
+                for exclusion in self.all_exclusions
+            )
+        )
 
     @cached_property
     def match_skip(self) -> Callable[[Path], bool]:

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -769,10 +769,20 @@ class Worker:
         # Note: This method is a cached property, it needs to be regenerated
         # when reusing an instance in different contexts.
         extra_context = {"_copier_operation": _operation.get()}
-        return self._path_matcher(
-            self._render_string(exclusion, extra_context=extra_context)
-            for exclusion in self.all_exclusions
-        )
+
+        # A single exclusion entry may render to multiple newline-separated
+        # patterns. This lets one Jinja block conditionally emit a whole list of
+        # patterns (e.g. `{% if flag %}a\nb\nc{% endif %}`) instead of repeating
+        # the condition on every entry. Blank lines (including the empty render of
+        # a false conditional) are dropped, so a no-op renders to nothing.
+        def _rendered_patterns() -> Iterable[str]:
+            for exclusion in self.all_exclusions:
+                rendered = self._render_string(exclusion, extra_context=extra_context)
+                for line in rendered.splitlines():
+                    if line.strip():
+                        yield line
+
+        return self._path_matcher(_rendered_patterns())
 
     @cached_property
     def match_skip(self) -> Callable[[Path], bool]:

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import platform
+import re
 import stat
 import subprocess
 import sys
@@ -769,9 +770,12 @@ class Worker:
         # Note: This method is a cached property, it needs to be regenerated
         # when reusing an instance in different contexts.
         extra_context = {"_copier_operation": _operation.get()}
+        regex_linebreak = re.compile(r"\r\n|\r|\n")
         return self._path_matcher(
             chain.from_iterable(
-                self._render_string(exclusion, extra_context=extra_context).splitlines()
+                regex_linebreak.split(
+                    self._render_string(exclusion, extra_context=extra_context),
+                )
                 for exclusion in self.all_exclusions
             )
         )

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -770,11 +770,15 @@ class Worker:
         # when reusing an instance in different contexts.
         extra_context = {"_copier_operation": _operation.get()}
 
-        # A single exclusion entry may render to multiple newline-separated
-        # patterns. This lets one Jinja block conditionally emit a whole list of
-        # patterns (e.g. `{% if flag %}a\nb\nc{% endif %}`) instead of repeating
-        # the condition on every entry. Blank lines (including the empty render of
-        # a false conditional) are dropped, so a no-op renders to nothing.
+        # A single exclusion entry can render multiple newline-separated patterns.
+        # This lets one Jinja block conditionally emit a whole list of patterns e.g.:
+        # {% if flag %}
+        #   - a
+        #   - b
+        #   - c
+        # {% endif %}`) instead of repeating {% if flag %} on every line
+        # Blank lines (including the empty render of a false conditional) are dropped
+        # so a no-op renders to nothing.
         def _rendered_patterns() -> Iterable[str]:
             for exclusion in self.all_exclusions:
                 rendered = self._render_string(exclusion, extra_context=extra_context)

--- a/copier/_main.py
+++ b/copier/_main.py
@@ -770,21 +770,15 @@ class Worker:
         # when reusing an instance in different contexts.
         extra_context = {"_copier_operation": _operation.get()}
 
-        # A single exclusion entry can render multiple newline-separated patterns.
-        # This lets one Jinja block conditionally emit a whole list of patterns e.g.:
-        # {% if flag %}
-        #   - a
-        #   - b
-        #   - c
-        # {% endif %}`) instead of repeating {% if flag %} on every line
-        # Blank lines (including the empty render of a false conditional) are dropped
-        # so a no-op renders to nothing.
+        # A single exclusion entry may render to multiple newline-separated patterns.
+        # Blank lines are dropped, so an empty conditional renders to nothing.
         def _rendered_patterns() -> Iterable[str]:
             for exclusion in self.all_exclusions:
                 rendered = self._render_string(exclusion, extra_context=extra_context)
                 for line in rendered.splitlines():
-                    if line.strip():
-                        yield line
+                    stripped = line.strip()
+                    if stripped:
+                        yield stripped
 
         return self._path_matcher(_rendered_patterns())
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1121,7 +1121,9 @@ Each pattern can be templated using Jinja.
     entry individually:
 
     ```yaml
-    skip_ci: bool
+    skip_ci:
+        type: bool
+
     _exclude:
         - |
           {% if skip_ci %}

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1112,10 +1112,15 @@ Each pattern can be templated using Jinja.
     The difference with [skip_if_exists](#skip_if_exists) is that it will never be
     rendered during an update, no matter if it exists or not.
 
-A single pattern may render to **multiple newline-separated patterns**. Each rendered
-line is treated as its own pattern (blank lines, including the empty render of a false
-conditional, are ignored). This lets one Jinja block conditionally emit a whole list of
-patterns instead of repeating the same condition on every entry.
+ A single exclusion entry can render multiple newline-separated patterns.
+ This lets one Jinja block conditionally emit a whole list of patterns e.g.:
+{% if flag %}
+    - a
+    - b
+    - c
+{% endif %}`) instead of repeating {% if flag %} on every line
+Blank lines (including the empty render of a false conditional) are dropped
+so a no-op renders to nothing.
 
 !!! example
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1113,9 +1113,7 @@ Each pattern can be templated using Jinja.
     rendered during an update, no matter if it exists or not.
 
     A single exclusion entry may render to multiple newline-separated patterns,
-    letting one Jinja block conditionally emit a whole list instead of repeating
-    the condition on every entry. Blank lines are dropped, so an empty conditional
-    renders to nothing.
+    equivalent to a complete gitignore file including comments and blank lines.
 
 !!! example
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1112,15 +1112,10 @@ Each pattern can be templated using Jinja.
     The difference with [skip_if_exists](#skip_if_exists) is that it will never be
     rendered during an update, no matter if it exists or not.
 
- A single exclusion entry can render multiple newline-separated patterns.
- This lets one Jinja block conditionally emit a whole list of patterns e.g.:
-{% if flag %}
-    - a
-    - b
-    - c
-{% endif %}`) instead of repeating {% if flag %} on every line
-Blank lines (including the empty render of a false conditional) are dropped
-so a no-op renders to nothing.
+    A single exclusion entry may render to multiple newline-separated patterns,
+    letting one Jinja block conditionally emit a whole list instead of repeating
+    the condition on every entry. Blank lines are dropped, so an empty conditional
+    renders to nothing.
 
 !!! example
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1112,6 +1112,29 @@ Each pattern can be templated using Jinja.
     The difference with [skip_if_exists](#skip_if_exists) is that it will never be
     rendered during an update, no matter if it exists or not.
 
+A single pattern may render to **multiple newline-separated patterns**. Each rendered
+line is treated as its own pattern (blank lines, including the empty render of a false
+conditional, are ignored). This lets one Jinja block conditionally emit a whole list of
+patterns instead of repeating the same condition on every entry.
+
+!!! example
+
+    Exclude a group of files with a single conditional block instead of guarding each
+    entry individually:
+
+    ```yaml
+    skip_ci: bool
+    _exclude:
+        - |
+          {% if skip_ci %}
+          .github/workflows/ci.yml
+          .github/workflows/deploy.yml
+          docs/ci/
+          {% endif %}
+    ```
+
+    When `skip_ci` is false the block renders empty and nothing extra is excluded.
+
 !!! info
 
     When you define this parameter in `copier.yml`, it will **replace** the default

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1133,7 +1133,7 @@ Each pattern can be templated using Jinja.
           {% endif %}
     ```
 
-    When `skip_ci` is false the block renders empty and nothing extra is excluded.
+    When `skip_ci` is `false` the block renders empty and nothing extra is excluded.
 
 !!! info
 

--- a/docs/configuring.md
+++ b/docs/configuring.md
@@ -1126,11 +1126,11 @@ Each pattern can be templated using Jinja.
 
     _exclude:
         - |
-          {% if skip_ci %}
-          .github/workflows/ci.yml
-          .github/workflows/deploy.yml
-          docs/ci/
-          {% endif %}
+            {% if skip_ci %}
+            /.github/workflows/ci.yml
+            /.github/workflows/deploy.yml
+            /docs/ci/
+            {% endif %}
     ```
 
     When `skip_ci` is `false` the block renders empty and nothing extra is excluded.

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -87,10 +87,17 @@ def test_config_exclude_multiline_conditional(
     run_copy(str(src), dst, quiet=True, data={"skip": skip})
     # keep.txt is never in the block, so it is always copied.
     assert (dst / "keep.txt").exists()
-    # The whole list is emitted from one guarded block: excluded iff skip is true.
-    assert (dst / "a.txt").exists() is not skip
-    assert (dst / "b.txt").exists() is not skip
-    assert (dst / "sub" / "c.txt").exists() is not skip
+
+    if skip:
+        # When skip=True, the conditional block renders patterns, so files are excluded
+        assert not (dst / "a.txt").exists()
+        assert not (dst / "b.txt").exists()
+        assert not (dst / "sub" / "c.txt").exists()
+    else:
+        # When skip=False, the conditional block renders empty, so files are copied
+        assert (dst / "a.txt").exists()
+        assert (dst / "b.txt").exists()
+        assert (dst / "sub" / "c.txt").exists()
 
 
 @pytest.mark.xfail(

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -54,6 +54,45 @@ def test_config_include(tmp_path_factory: pytest.TempPathFactory) -> None:
     assert (dst / "copier.yml").exists()
 
 
+@pytest.mark.parametrize("skip", [True, False])
+def test_config_exclude_multiline_conditional(
+    tmp_path_factory: pytest.TempPathFactory, skip: bool
+) -> None:
+    """A single exclusion entry may render to multiple newline-separated patterns.
+
+    This lets one Jinja block conditionally emit a whole list of patterns instead of
+    repeating the condition on every entry. When the guard is false the block renders
+    empty and excludes nothing.
+    """
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yml": (
+                "skip: {type: bool}\n"
+                "_exclude:\n"
+                '  - "copier.yml"\n'
+                "  - |\n"
+                "    {% if skip %}\n"
+                "    a.txt\n"
+                "    b.txt\n"
+                "    sub/c.txt\n"
+                "    {% endif %}\n"
+            ),
+            src / "a.txt": "",
+            src / "b.txt": "",
+            src / "sub" / "c.txt": "",
+            src / "keep.txt": "",
+        }
+    )
+    run_copy(str(src), dst, quiet=True, data={"skip": skip})
+    # keep.txt is never in the block, so it is always copied.
+    assert (dst / "keep.txt").exists()
+    # The whole list is emitted from one guarded block: excluded iff skip is true.
+    assert (dst / "a.txt").exists() is not skip
+    assert (dst / "b.txt").exists() is not skip
+    assert (dst / "sub" / "c.txt").exists() is not skip
+
+
 @pytest.mark.xfail(
     condition=platform.system() == "Darwin",
     reason="OS without proper UTF-8 filesystem.",

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -68,15 +68,19 @@ def test_config_exclude_multiline_conditional(
     build_file_tree(
         {
             src / "copier.yml": (
-                "skip: {type: bool}\n"
-                "_exclude:\n"
-                '  - "copier.yml"\n'
-                "  - |\n"
-                "    {% if skip %}\n"
-                "    a.txt\n"
-                "    b.txt\n"
-                "    sub/c.txt\n"
-                "    {% endif %}\n"
+                """\
+                skip:
+                    type: bool
+
+                _exclude:
+                    - copier.yml
+                    - |
+                        {% if skip %}
+                        /a.txt
+                        /b.txt
+                        /sub/c.txt
+                        {% endif %}
+                """
             ),
             src / "a.txt": "",
             src / "b.txt": "",

--- a/tests/test_exclude.py
+++ b/tests/test_exclude.py
@@ -91,17 +91,10 @@ def test_config_exclude_multiline_conditional(
     run_copy(str(src), dst, quiet=True, data={"skip": skip})
     # keep.txt is never in the block, so it is always copied.
     assert (dst / "keep.txt").exists()
-
-    if skip:
-        # When skip=True, the conditional block renders patterns, so files are excluded
-        assert not (dst / "a.txt").exists()
-        assert not (dst / "b.txt").exists()
-        assert not (dst / "sub" / "c.txt").exists()
-    else:
-        # When skip=False, the conditional block renders empty, so files are copied
-        assert (dst / "a.txt").exists()
-        assert (dst / "b.txt").exists()
-        assert (dst / "sub" / "c.txt").exists()
+    # Files are excluded when skip=True
+    assert (dst / "a.txt").exists() is not skip
+    assert (dst / "b.txt").exists() is not skip
+    assert (dst / "sub" / "c.txt").exists() is not skip
 
 
 @pytest.mark.xfail(


### PR DESCRIPTION
# description
This pr introduces the capability to do multiline exclusion under the same flag, removing the need to do a condition per line, thus resulting in cleaner config files

# approach
This one was a quick solution, after the logic is rendered it causes the result to be a pattern that doesn't match anything as 
`.github/workflows/ci.yml \n.github/workflows/deploy.yml\n docs/ci/` this will never match, so I then split by line jump

fixes #2803 