### PR TITLE
test: fix expected exception message regex on Windows

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -376,7 +376,7 @@ def test_include_path_outside_template_root_raises_error(
     )
     with pytest.raises(
         ForbiddenPathError,
-        match=re.escape(rf'"{src}/outside/include.yml" is forbidden'),
+        match=re.escape(f'"{src / "outside" / "include.yml"}" is forbidden'),
     ):
         copier.run_copy(str(src / "template"), dst, defaults=True)
 


### PR DESCRIPTION
Just a minor fix of the expected exception message regex in `tests/test_config.py::test_include_path_outside_template_root_raises_error` on Windows.

Follow-up of 10607b4900d1f6ae74746b8470261cc28e8c1a71.