### PR TITLE
fix: don't let cleanup replace the exception being handled

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -77,6 +77,7 @@ from ._types import (
 from ._user_data import AnswersMap, Question, load_answersfile_data
 from ._vcs import get_git, is_git_available
 from .errors import (
+    CleanupWarning,
     ConfigFileError,
     CopierAnswersInterrupt,
     ExtensionNotFoundError,
@@ -1295,7 +1296,17 @@ class Worker:
                     self._execute_tasks(self.template.tasks)
         except Exception:
             if not was_existing and self.cleanup_on_error:
-                rmtree(self.subproject.local_abspath)
+                try:
+                    rmtree(self.subproject.local_abspath)
+                except FileNotFoundError:
+                    pass  # Nothing was created yet, so nothing to clean up.
+                except OSError as cleanup_error:
+                    # Never raise: another exception is already being handled.
+                    warnings.warn(
+                        f"Failed to clean up {self.subproject.local_abspath}: "
+                        f"{cleanup_error}",
+                        CleanupWarning,
+                    )
             raise
         self._print_message(self.template.message_after_copy)
         if not self.quiet:

--- a/copier/errors.py
+++ b/copier/errors.py
@@ -23,6 +23,7 @@ else:
 
 
 __all__ = [
+    "CleanupWarning",
     "ConfigFileError",
     "CopierAnswersInterrupt",
     "CopierError",

--- a/copier/errors.py
+++ b/copier/errors.py
@@ -231,6 +231,10 @@ class MissingFileWarning(UserWarning, CopierWarning):
     """I still couldn't find what I'm looking for."""
 
 
+class CleanupWarning(UserWarning, CopierWarning):
+    """Failed to clean up the destination after an error."""
+
+
 class InteractiveSessionError(UserMessageError):
     """An interactive session is required to run this program."""
 

--- a/tests/test_cleanup.py
+++ b/tests/test_cleanup.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
+from jinja2.exceptions import UndefinedError
 from plumbum import local
 
 import copier
@@ -191,3 +192,17 @@ def test_cleanup_on_interrupt_during_git_clone(
         copier.run_copy(str(src), dst)
 
     assert list(tmp.glob("**/*")) == []
+
+
+def test_cleanup_does_not_mask_render_error(tmp_path: Path) -> None:
+    """Copier reports the render error, not a failure from its own cleanup."""
+    src = tmp_path / "src"
+    dst = tmp_path / "new_folder"
+    build_file_tree({src / "template.txt.jinja": "{{ not_a_question.value }}"})
+
+    # The template's only file fails, so `dst` is never created and cleanup has
+    # nothing to remove.
+    with pytest.raises(UndefinedError, match="'not_a_question' is undefined"):
+        copier.run_copy(str(src), dst, quiet=True)
+
+    assert not dst.exists()


### PR DESCRIPTION
Symptom: ran copier against a template that contained an error (a template where the only file contained {{ not_a_question.value }}) and got a FileNotFoundError that named the destination directory.
Cause: rmtree in the run_copy exception handler raises inside the except block and replaces the exception being handled. The original exception survives in __context__. This only happens when the render fails before the first file is written, as if any file is written then the destination exists and cleanup succeeds.

Fix: 2 branches, 1st handles the destination is missing - passes. 2nd warns on any other OSError so that it isn't lost. Original exception then raised outside of the if.
Additional warning type CleanupWarning added to errors.py, subclassing UserWarning and CopierWarning as the other warnings in that file do

Test: New test in tests/test_cleanup.py, fails against master with FileNotFoundError, passes after the fix, full suite green.

Notes: This is the only unguarded cleanup that I could find in the codebase. _vcs.py and _template.py already have guards. This is bringing _main.py into line with these.
There is a simpler 1-line alternative I considered, using ignore_errors=True, but it silences genuine failures so was discarded.
A case could be made to take the handle_remove_readonly helper approach and build/extend the helper to handle this case as well, however _main.py does not import that helper today, using a bare shutil.rmtree, however I went with the simpler fix. Let me know if you would like me to run a separate PR to fold that in (1 helper used everywhere and the helper updated to resolve this error as well)
