### PR TITLE
chore(config): recommend Ruff's VS Code extension and install in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
     "vscode": {
       "extensions": [
         "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+        "charliermarsh.ruff",
         "editorconfig.editorconfig",
         "elagil.pre-commit-helper",
         "jetpack-io.devbox",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
+    "charliermarsh.ruff",
     "editorconfig.editorconfig",
     "elagil.pre-commit-helper",
     "ms-python.python"


### PR DESCRIPTION
I've added [Ruff's VS Code extension](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) to the recommended VS Code extensions as well as to the extensions to be installed in a VS Code devcontainer. This makes format-on-save and inline linter feedback work out of the box in a VS Code devcontainer and points non-devcontainer developers to the recommended extension.