### PR TITLE
chore(config): recommend rumdl's VS Code extension and install in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,8 @@
         "editorconfig.editorconfig",
         "elagil.pre-commit-helper",
         "jetpack-io.devbox",
-        "ms-python.python"
+        "ms-python.python",
+        "rvben.rumdl"
       ],
       "settings": {
         "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,7 @@
     "bpruitt-goddard.mermaid-markdown-syntax-highlighting",
     "editorconfig.editorconfig",
     "elagil.pre-commit-helper",
-    "ms-python.python"
+    "ms-python.python",
+    "rvben.rumdl"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,6 @@
   "[markdown]": {
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file",
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "rvben.rumdl"
   }
 }


### PR DESCRIPTION
I've added [rumdl's VS Code extension](https://marketplace.visualstudio.com/items?itemName=rvben.rumdl) to the recommended VS Code extensions as well as to the extensions to be installed in a VS Code devcontainer. This makes format-on-save and inline linter feedback work out of the box in a VS Code devcontainer and points non-devcontainer developers to the recommended extension.