### PR TITLE
fix: disambiguate Windows paths from SCP URLs in trust check

### DIFF
--- a/copier/_settings.py
+++ b/copier/_settings.py
@@ -9,7 +9,7 @@ import warnings
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from os.path import expanduser
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 from urllib.parse import unquote, urlsplit, urlunsplit
 
@@ -163,7 +163,7 @@ def _normalize(url: str) -> str:
             (parts.scheme, parts.netloc, path, parts.query, parts.fragment)
         )
 
-    if _SCP_URL.fullmatch(url):
+    if not PureWindowsPath(url).is_absolute() and _SCP_URL.fullmatch(url):
         host, path = url.split(":", 1)
         path = _normalize_url_path(path)
         return f"{host}:{path}"


### PR DESCRIPTION
This is a follow-up of dcae6635f3fa126bc616f88409d28b898fb6b23f which added detection of Git's SCP-style URL syntax, but it also matched absolute Windows paths (e.g. `C:\Users\...`), since a drive letter followed by `:` looks identical to a shorthand SCP host. As a result, trusted local template paths on Windows were no longer recognized as trusted, causing an unexpected trust prompt.

Absolute Windows paths are now correctly treated as local paths again.