### PR TITLE
fix: allow overwriting destination symlinks when `preserve_symlinks: false`

### DIFF
--- a/copier/_main.py
+++ b/copier/_main.py
@@ -815,7 +815,7 @@ class Worker:
             )
             for dst_relpath, ctx in dst_relpaths_ctxs:
                 dst_abspath = dst_root / dst_relpath
-                if dst_abspath.is_symlink() and self.template.preserve_symlinks:
+                if dst_abspath.is_symlink():
                     # If destination path is a symlink, it can safely point outside the
                     # subproject dir, while still itself existing within the subproject.
                     # (So long as nothing is templated into it (if it is a directory),

--- a/tests/test_symlinks.py
+++ b/tests/test_symlinks.py
@@ -646,3 +646,23 @@ def test_resolve_absolute_symlink_outside_template_root_raises_error(
         run_copy(str(src), dst, defaults=True, overwrite=True)
 
     assert not (dst / "symlink.txt").exists()
+
+
+@pytest.mark.parametrize("preserve_symlinks", [True, False])
+def test_destination_symlink_outside_destination_root(
+    tmp_path_factory: pytest.TempPathFactory, preserve_symlinks: bool
+) -> None:
+    src, dst = map(tmp_path_factory.mktemp, ("src", "dst"))
+    build_file_tree(
+        {
+            src / "copier.yaml": f"_preserve_symlinks: {preserve_symlinks}",
+            src / "file.txt": "from template",
+            dst / "other" / "target.txt": "external",
+            dst / "project" / "file.txt": Path("..") / "other" / "target.txt",
+        }
+    )
+
+    run_copy(str(src), dst / "project", overwrite=True)
+
+    assert not (dst / "project" / "file.txt").is_symlink()
+    assert (dst / "project" / "file.txt").read_text() == "from template"


### PR DESCRIPTION
A destination symlink's target is irrelevant for enforcing destination sandbox confinement, since it cannot be exploited for data exfiltration, regardless of `_preserve_symlinks`. Yet the check only avoided resolving a pre-existing destination symlink when `_preserve_symlinks: true`, so a symlink pointing outside the destination root raised `ForbiddenPathError` and blocked its overwrite when `preserve_symlinks: false`.

Apply symlink-safe resolution whenever the destination path is already a symlink, regardless of `_preserve_symlinks`, which only affects how symlinks from the template are rendered.

Fixes #2838.